### PR TITLE
Change readme example to catch std::exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Here are a few code examples:
     device.allocateMemory(allocateInfo, nullptr);
 
   }
-  catch (std::system_error e)
+  catch (const std::exception &e)
   {
     std::cerr << "Vulkan failure: " << e.what() << std::endl;
   }


### PR DESCRIPTION
There are two reasons for this change.

1. The C++ mantra "throw by value, catch by reference" still applies,
even when you're only specifically throwing std::system_error at this
time
2. Vulkan-Hpp is using C++ stdlib containers, such as std::string and
std::vector, which have their own exception specifications to consider.
The example provided may throw various exceptions, all of which derive
from std::exception, and many will not be std::system_error.

This is a serious issue in the readme simply because that snippet of
code will be the copy/pasted foundation of many projects which adopt
Vulkan-Hpp. We might as well try to avoid some common pitfalls of
exception handling.