### PR TITLE
Cast to MaskType rather than uint32_t

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -72,7 +72,7 @@ const std::string flagsHeader(
 "    }\n"
 "\n"
 "    Flags(BitType bit)\n"
-"      : m_mask(static_cast<uint32_t>(bit))\n"
+"      : m_mask(static_cast<MaskType>(bit))\n"
 "    {\n"
 "    }\n"
 "\n"

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -77,7 +77,7 @@ namespace vk
     }
 
     Flags(BitType bit)
-      : m_mask(static_cast<uint32_t>(bit))
+      : m_mask(static_cast<MaskType>(bit))
     {
     }
 


### PR DESCRIPTION
The constructor that initializes from the `BitType` should probably cast its `bit` argument to `MaskType` (which may or may not be synonymous with `uint32_t`), which is the type of the `m_mask` member that's being initialized.