### PR TITLE
Add support for std::tie on ResultValues. 

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -319,6 +319,8 @@ std::string const resultValueHeader = (
   "\n"
   "    Result  result;\n"
   "    T       value;\n"
+  "\n"
+  "    operator std::tuple<Result&, T&>() { return std::tuple<Result&, T&>(result, value); }\n"
   "  };\n"
   "\n"
   "  template <typename T>\n"
@@ -3106,6 +3108,7 @@ int main( int argc, char **argv )
       << "#include <initializer_list>" << std::endl
       << "#include <string>" << std::endl
       << "#include <system_error>" << std::endl
+      << "#include <tuple>" << std::endl
       << "#include <type_traits>" << std::endl
       << "#include <vulkan/vulkan.h>" << std::endl
       << "#ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE" << std::endl

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -33,6 +33,7 @@
 #include <initializer_list>
 #include <string>
 #include <system_error>
+#include <tuple>
 #include <type_traits>
 #include <vulkan/vulkan.h>
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
@@ -399,6 +400,8 @@ namespace vk
 
     Result  result;
     T       value;
+
+    operator std::tuple<Result&, T&>() { return std::tuple<Result&, T&>(result, value); }
   };
 
   template <typename T>


### PR DESCRIPTION
This allows developers to write

vk::Result result;
vk::Image image;
std::tie(result, image) = device.createImage(...);

when using the non-exception mode.