### PR TITLE
Fix naming conventions for functions in README.md and update to Vulkan 1.0.34

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Vulkan-Hpp requires a C++11 capable compiler to compile. The following compilers
 
 # namespace vk
 To avoid name collisions with the Vulkan C API the C++ bindings reside in the vk namespace. The following rules apply to the new naming
-* All functions, enums and structs have the Vk prefix removed.
-  * ```vkCreateImage``` can be accessed as ```vk::CreateImage```
+* All functions, enums, handles, and structs have the Vk prefix removed. In addition to this the first leter of functions is lower case.
+  * ```vkCreateImage``` can be accessed as ```vk::createImage```
   * ```VkImageTiling``` can be accessed as ```vk::ImageTiling```
   * ```VkImageCreateInfo``` can be accessed as ```vk::ImageCreateInfo```
 * Enums are mapped to scoped enums to provide compile time type safety. The names have been changed to 'e' + CamelCase with the VK_ prefix and type infix removed. In case the enum type is an extension the extension suffix has been removed from the enum values.

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -41,7 +41,7 @@
 # include <vector>
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
-static_assert( VK_HEADER_VERSION ==  32 , "Wrong VK_HEADER_VERSION!" );
+static_assert( VK_HEADER_VERSION ==  34 , "Wrong VK_HEADER_VERSION!" );
 
 // 32-bit vulkan is not typesafe for handles, so don't allow copy constructors on this platform by default.
 // To enable this feature on 32-bit platforms please define VULKAN_HPP_TYPESAFE_CONVERSION


### PR DESCRIPTION
Fixes issue #49