### PR TITLE
Add allocator argument to enhanced functions that return a vector

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -2078,8 +2078,14 @@ void writeFunctionBody(std::ofstream & ofs, std::string const& indentation, std:
             }
           }
           assert(!size.empty());
-          ofs << "( " << size << " )";
-        } else if (commandData.twoStep)
+          ofs << "( " << size;
+          if (returnType.find("Allocator") != std::string::npos)
+          {
+            ofs << ", " << commandData.arguments[returnIndex].pureType << "(), alloc";
+          }
+          ofs << " )";
+        }
+        else if (commandData.twoStep)
         {
             ofs << "( alloc )";
         }
@@ -3257,7 +3263,7 @@ int main( int argc, char **argv )
         << arrayProxyHeader;
 
     // first of all, write out vk::Result and the exception handling stuff
-    std::list<DependencyData>::const_iterator it = std::find_if(vkData.dependencies.begin(), vkData.dependencies.end(), [](DependencyData const& dp) { return dp.name == "Result"; });
+    std::list<DependencyData>::iterator it = std::find_if(vkData.dependencies.begin(), vkData.dependencies.end(), [](DependencyData const& dp) { return dp.name == "Result"; });
     assert(it != vkData.dependencies.end());
     writeTypeEnum(ofs, *it, vkData.enums.find(it->name)->second);
     writeEnumsToString(ofs, *it, vkData.enums.find(it->name)->second);

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -2079,6 +2079,9 @@ void writeFunctionBody(std::ofstream & ofs, std::string const& indentation, std:
           }
           assert(!size.empty());
           ofs << "( " << size << " )";
+        } else if (commandData.twoStep)
+        {
+            ofs << "( alloc )";
         }
       }
       ofs << ";" << std::endl;
@@ -2361,6 +2364,14 @@ void writeFunctionHeader(std::ofstream & ofs, VkData const& vkData, std::string 
       }
     }
     ofs << " ";
+  }
+  if (!singular && (returnType.find("Allocator") != std::string::npos))
+  {
+    if (skippedArguments.size() + (commandData.handleCommand ? 1 : 0) < commandData.arguments.size())
+    {
+      ofs << ", ";
+    }
+    ofs << " Allocator const& alloc = Allocator()";
   }
   ofs << ")";
   if (commandData.handleCommand)

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -16695,9 +16695,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   template <typename Allocator = std::allocator<LayerProperties>>
-  typename ResultValueType<std::vector<LayerProperties,Allocator>>::type enumerateInstanceLayerProperties()
+  typename ResultValueType<std::vector<LayerProperties,Allocator>>::type enumerateInstanceLayerProperties( Allocator const& alloc = Allocator())
   {
-    std::vector<LayerProperties,Allocator> properties;
+    std::vector<LayerProperties,Allocator> properties( alloc );
     uint32_t propertyCount;
     Result result;
     do
@@ -16722,9 +16722,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   template <typename Allocator = std::allocator<ExtensionProperties>>
-  typename ResultValueType<std::vector<ExtensionProperties,Allocator>>::type enumerateInstanceExtensionProperties( Optional<const std::string> layerName = nullptr )
+  typename ResultValueType<std::vector<ExtensionProperties,Allocator>>::type enumerateInstanceExtensionProperties( Optional<const std::string> layerName = nullptr ,  Allocator const& alloc = Allocator())
   {
-    std::vector<ExtensionProperties,Allocator> properties;
+    std::vector<ExtensionProperties,Allocator> properties( alloc );
     uint32_t propertyCount;
     Result result;
     do
@@ -18004,9 +18004,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<SparseImageMemoryRequirements>>
-    std::vector<SparseImageMemoryRequirements,Allocator> getImageSparseMemoryRequirements( Image image ) const
+    std::vector<SparseImageMemoryRequirements,Allocator> getImageSparseMemoryRequirements( Image image ,  Allocator const& alloc = Allocator()) const
     {
-      std::vector<SparseImageMemoryRequirements,Allocator> sparseMemoryRequirements;
+      std::vector<SparseImageMemoryRequirements,Allocator> sparseMemoryRequirements( alloc );
       uint32_t sparseMemoryRequirementCount;
       vkGetImageSparseMemoryRequirements( m_device, static_cast<VkImage>( image ), &sparseMemoryRequirementCount, nullptr );
       sparseMemoryRequirements.resize( sparseMemoryRequirementCount );
@@ -18396,9 +18396,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<uint8_t>>
-    typename ResultValueType<std::vector<uint8_t,Allocator>>::type getPipelineCacheData( PipelineCache pipelineCache ) const
+    typename ResultValueType<std::vector<uint8_t,Allocator>>::type getPipelineCacheData( PipelineCache pipelineCache ,  Allocator const& alloc = Allocator()) const
     {
-      std::vector<uint8_t,Allocator> data;
+      std::vector<uint8_t,Allocator> data( alloc );
       size_t dataSize;
       Result result;
       do
@@ -18436,9 +18436,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<Pipeline>>
-    typename ResultValueType<std::vector<Pipeline,Allocator>>::type createGraphicsPipelines( PipelineCache pipelineCache, ArrayProxy<const GraphicsPipelineCreateInfo> createInfos, Optional<const AllocationCallbacks> allocator = nullptr ) const
+    typename ResultValueType<std::vector<Pipeline,Allocator>>::type createGraphicsPipelines( PipelineCache pipelineCache, ArrayProxy<const GraphicsPipelineCreateInfo> createInfos, Optional<const AllocationCallbacks> allocator = nullptr ,  Allocator const& alloc = Allocator()) const
     {
-      std::vector<Pipeline,Allocator> pipelines( createInfos.size() );
+      std::vector<Pipeline,Allocator> pipelines( createInfos.size(), Pipeline(), alloc );
       Result result = static_cast<Result>( vkCreateGraphicsPipelines( m_device, static_cast<VkPipelineCache>( pipelineCache ), createInfos.size() , reinterpret_cast<const VkGraphicsPipelineCreateInfo*>( createInfos.data() ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkPipeline*>( pipelines.data() ) ) );
       return createResultValue( result, pipelines, "vk::Device::createGraphicsPipelines" );
     }
@@ -18458,9 +18458,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<Pipeline>>
-    typename ResultValueType<std::vector<Pipeline,Allocator>>::type createComputePipelines( PipelineCache pipelineCache, ArrayProxy<const ComputePipelineCreateInfo> createInfos, Optional<const AllocationCallbacks> allocator = nullptr ) const
+    typename ResultValueType<std::vector<Pipeline,Allocator>>::type createComputePipelines( PipelineCache pipelineCache, ArrayProxy<const ComputePipelineCreateInfo> createInfos, Optional<const AllocationCallbacks> allocator = nullptr ,  Allocator const& alloc = Allocator()) const
     {
-      std::vector<Pipeline,Allocator> pipelines( createInfos.size() );
+      std::vector<Pipeline,Allocator> pipelines( createInfos.size(), Pipeline(), alloc );
       Result result = static_cast<Result>( vkCreateComputePipelines( m_device, static_cast<VkPipelineCache>( pipelineCache ), createInfos.size() , reinterpret_cast<const VkComputePipelineCreateInfo*>( createInfos.data() ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkPipeline*>( pipelines.data() ) ) );
       return createResultValue( result, pipelines, "vk::Device::createComputePipelines" );
     }
@@ -18611,9 +18611,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<DescriptorSet>>
-    typename ResultValueType<std::vector<DescriptorSet,Allocator>>::type allocateDescriptorSets( const DescriptorSetAllocateInfo & allocateInfo ) const
+    typename ResultValueType<std::vector<DescriptorSet,Allocator>>::type allocateDescriptorSets( const DescriptorSetAllocateInfo & allocateInfo ,  Allocator const& alloc = Allocator()) const
     {
-      std::vector<DescriptorSet,Allocator> descriptorSets( allocateInfo.descriptorSetCount );
+      std::vector<DescriptorSet,Allocator> descriptorSets( allocateInfo.descriptorSetCount, DescriptorSet(), alloc );
       Result result = static_cast<Result>( vkAllocateDescriptorSets( m_device, reinterpret_cast<const VkDescriptorSetAllocateInfo*>( &allocateInfo ), reinterpret_cast<VkDescriptorSet*>( descriptorSets.data() ) ) );
       return createResultValue( result, descriptorSets, "vk::Device::allocateDescriptorSets" );
     }
@@ -18758,9 +18758,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<CommandBuffer>>
-    typename ResultValueType<std::vector<CommandBuffer,Allocator>>::type allocateCommandBuffers( const CommandBufferAllocateInfo & allocateInfo ) const
+    typename ResultValueType<std::vector<CommandBuffer,Allocator>>::type allocateCommandBuffers( const CommandBufferAllocateInfo & allocateInfo ,  Allocator const& alloc = Allocator()) const
     {
-      std::vector<CommandBuffer,Allocator> commandBuffers( allocateInfo.commandBufferCount );
+      std::vector<CommandBuffer,Allocator> commandBuffers( allocateInfo.commandBufferCount, CommandBuffer(), alloc );
       Result result = static_cast<Result>( vkAllocateCommandBuffers( m_device, reinterpret_cast<const VkCommandBufferAllocateInfo*>( &allocateInfo ), reinterpret_cast<VkCommandBuffer*>( commandBuffers.data() ) ) );
       return createResultValue( result, commandBuffers, "vk::Device::allocateCommandBuffers" );
     }
@@ -18785,9 +18785,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<SwapchainKHR>>
-    typename ResultValueType<std::vector<SwapchainKHR,Allocator>>::type createSharedSwapchainsKHR( ArrayProxy<const SwapchainCreateInfoKHR> createInfos, Optional<const AllocationCallbacks> allocator = nullptr ) const
+    typename ResultValueType<std::vector<SwapchainKHR,Allocator>>::type createSharedSwapchainsKHR( ArrayProxy<const SwapchainCreateInfoKHR> createInfos, Optional<const AllocationCallbacks> allocator = nullptr ,  Allocator const& alloc = Allocator()) const
     {
-      std::vector<SwapchainKHR,Allocator> swapchains( createInfos.size() );
+      std::vector<SwapchainKHR,Allocator> swapchains( createInfos.size(), SwapchainKHR(), alloc );
       Result result = static_cast<Result>( vkCreateSharedSwapchainsKHR( m_device, createInfos.size() , reinterpret_cast<const VkSwapchainCreateInfoKHR*>( createInfos.data() ), reinterpret_cast<const VkAllocationCallbacks*>( static_cast<const AllocationCallbacks*>( allocator)), reinterpret_cast<VkSwapchainKHR*>( swapchains.data() ) ) );
       return createResultValue( result, swapchains, "vk::Device::createSharedSwapchainsKHR" );
     }
@@ -18833,9 +18833,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<Image>>
-    typename ResultValueType<std::vector<Image,Allocator>>::type getSwapchainImagesKHR( SwapchainKHR swapchain ) const
+    typename ResultValueType<std::vector<Image,Allocator>>::type getSwapchainImagesKHR( SwapchainKHR swapchain ,  Allocator const& alloc = Allocator()) const
     {
-      std::vector<Image,Allocator> swapchainImages;
+      std::vector<Image,Allocator> swapchainImages( alloc );
       uint32_t swapchainImageCount;
       Result result;
       do
@@ -19085,9 +19085,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<QueueFamilyProperties>>
-    std::vector<QueueFamilyProperties,Allocator> getQueueFamilyProperties() const
+    std::vector<QueueFamilyProperties,Allocator> getQueueFamilyProperties( Allocator const& alloc = Allocator()) const
     {
-      std::vector<QueueFamilyProperties,Allocator> queueFamilyProperties;
+      std::vector<QueueFamilyProperties,Allocator> queueFamilyProperties( alloc );
       uint32_t queueFamilyPropertyCount;
       vkGetPhysicalDeviceQueueFamilyProperties( m_physicalDevice, &queueFamilyPropertyCount, nullptr );
       queueFamilyProperties.resize( queueFamilyPropertyCount );
@@ -19173,9 +19173,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<LayerProperties>>
-    typename ResultValueType<std::vector<LayerProperties,Allocator>>::type enumerateDeviceLayerProperties() const
+    typename ResultValueType<std::vector<LayerProperties,Allocator>>::type enumerateDeviceLayerProperties( Allocator const& alloc = Allocator()) const
     {
-      std::vector<LayerProperties,Allocator> properties;
+      std::vector<LayerProperties,Allocator> properties( alloc );
       uint32_t propertyCount;
       Result result;
       do
@@ -19200,9 +19200,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<ExtensionProperties>>
-    typename ResultValueType<std::vector<ExtensionProperties,Allocator>>::type enumerateDeviceExtensionProperties( Optional<const std::string> layerName = nullptr ) const
+    typename ResultValueType<std::vector<ExtensionProperties,Allocator>>::type enumerateDeviceExtensionProperties( Optional<const std::string> layerName = nullptr ,  Allocator const& alloc = Allocator()) const
     {
-      std::vector<ExtensionProperties,Allocator> properties;
+      std::vector<ExtensionProperties,Allocator> properties( alloc );
       uint32_t propertyCount;
       Result result;
       do
@@ -19227,9 +19227,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<SparseImageFormatProperties>>
-    std::vector<SparseImageFormatProperties,Allocator> getSparseImageFormatProperties( Format format, ImageType type, SampleCountFlagBits samples, ImageUsageFlags usage, ImageTiling tiling ) const
+    std::vector<SparseImageFormatProperties,Allocator> getSparseImageFormatProperties( Format format, ImageType type, SampleCountFlagBits samples, ImageUsageFlags usage, ImageTiling tiling ,  Allocator const& alloc = Allocator()) const
     {
-      std::vector<SparseImageFormatProperties,Allocator> properties;
+      std::vector<SparseImageFormatProperties,Allocator> properties( alloc );
       uint32_t propertyCount;
       vkGetPhysicalDeviceSparseImageFormatProperties( m_physicalDevice, static_cast<VkFormat>( format ), static_cast<VkImageType>( type ), static_cast<VkSampleCountFlagBits>( samples ), static_cast<VkImageUsageFlags>( usage ), static_cast<VkImageTiling>( tiling ), &propertyCount, nullptr );
       properties.resize( propertyCount );
@@ -19245,9 +19245,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<DisplayPropertiesKHR>>
-    typename ResultValueType<std::vector<DisplayPropertiesKHR,Allocator>>::type getDisplayPropertiesKHR() const
+    typename ResultValueType<std::vector<DisplayPropertiesKHR,Allocator>>::type getDisplayPropertiesKHR( Allocator const& alloc = Allocator()) const
     {
-      std::vector<DisplayPropertiesKHR,Allocator> properties;
+      std::vector<DisplayPropertiesKHR,Allocator> properties( alloc );
       uint32_t propertyCount;
       Result result;
       do
@@ -19272,9 +19272,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<DisplayPlanePropertiesKHR>>
-    typename ResultValueType<std::vector<DisplayPlanePropertiesKHR,Allocator>>::type getDisplayPlanePropertiesKHR() const
+    typename ResultValueType<std::vector<DisplayPlanePropertiesKHR,Allocator>>::type getDisplayPlanePropertiesKHR( Allocator const& alloc = Allocator()) const
     {
-      std::vector<DisplayPlanePropertiesKHR,Allocator> properties;
+      std::vector<DisplayPlanePropertiesKHR,Allocator> properties( alloc );
       uint32_t propertyCount;
       Result result;
       do
@@ -19299,9 +19299,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<DisplayKHR>>
-    typename ResultValueType<std::vector<DisplayKHR,Allocator>>::type getDisplayPlaneSupportedDisplaysKHR( uint32_t planeIndex ) const
+    typename ResultValueType<std::vector<DisplayKHR,Allocator>>::type getDisplayPlaneSupportedDisplaysKHR( uint32_t planeIndex ,  Allocator const& alloc = Allocator()) const
     {
-      std::vector<DisplayKHR,Allocator> displays;
+      std::vector<DisplayKHR,Allocator> displays( alloc );
       uint32_t displayCount;
       Result result;
       do
@@ -19326,9 +19326,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<DisplayModePropertiesKHR>>
-    typename ResultValueType<std::vector<DisplayModePropertiesKHR,Allocator>>::type getDisplayModePropertiesKHR( DisplayKHR display ) const
+    typename ResultValueType<std::vector<DisplayModePropertiesKHR,Allocator>>::type getDisplayModePropertiesKHR( DisplayKHR display ,  Allocator const& alloc = Allocator()) const
     {
-      std::vector<DisplayModePropertiesKHR,Allocator> properties;
+      std::vector<DisplayModePropertiesKHR,Allocator> properties( alloc );
       uint32_t propertyCount;
       Result result;
       do
@@ -19425,9 +19425,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<SurfaceFormatKHR>>
-    typename ResultValueType<std::vector<SurfaceFormatKHR,Allocator>>::type getSurfaceFormatsKHR( SurfaceKHR surface ) const
+    typename ResultValueType<std::vector<SurfaceFormatKHR,Allocator>>::type getSurfaceFormatsKHR( SurfaceKHR surface ,  Allocator const& alloc = Allocator()) const
     {
-      std::vector<SurfaceFormatKHR,Allocator> surfaceFormats;
+      std::vector<SurfaceFormatKHR,Allocator> surfaceFormats( alloc );
       uint32_t surfaceFormatCount;
       Result result;
       do
@@ -19452,9 +19452,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<PresentModeKHR>>
-    typename ResultValueType<std::vector<PresentModeKHR,Allocator>>::type getSurfacePresentModesKHR( SurfaceKHR surface ) const
+    typename ResultValueType<std::vector<PresentModeKHR,Allocator>>::type getSurfacePresentModesKHR( SurfaceKHR surface ,  Allocator const& alloc = Allocator()) const
     {
-      std::vector<PresentModeKHR,Allocator> presentModes;
+      std::vector<PresentModeKHR,Allocator> presentModes( alloc );
       uint32_t presentModeCount;
       Result result;
       do
@@ -19640,9 +19640,9 @@ namespace vk
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Allocator = std::allocator<PhysicalDevice>>
-    typename ResultValueType<std::vector<PhysicalDevice,Allocator>>::type enumeratePhysicalDevices() const
+    typename ResultValueType<std::vector<PhysicalDevice,Allocator>>::type enumeratePhysicalDevices( Allocator const& alloc = Allocator()) const
     {
-      std::vector<PhysicalDevice,Allocator> physicalDevices;
+      std::vector<PhysicalDevice,Allocator> physicalDevices( alloc );
       uint32_t physicalDeviceCount;
       Result result;
       do


### PR DESCRIPTION
C++17 will support polymorphic allocators where std::vector can be handed an allocator on construction. I've modified the function generation code to take a defaulted allocator argument that will be passed along to the std::vector. This enables code like the following using
 [Howard Hinnant's stack allocator](https://howardhinnant.github.io/stack_alloc.html).

```
vk::PhysicalDevice physical;
// ...

using extensions_vector = std::vector<vk::ExtensionProperties, short_alloc<T, 8192, alignof(T)>>;
using allocator = extensions_vector::allocator_type;
allocator::arena_type arena;
extensions_vector extensions{arena};
std::tie(result, extensions) = physical.enumerateDeviceExtensionProperties(nullptr, allocator{arena});
```