### PR TITLE
Add UniqueHandle non-const accessors, ensure all by reference.

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -381,8 +381,8 @@ const std::string structureChainHeader = R"(
 
     StructureChain& operator=(StructureChain const &rhs)
     {
-      linkAndCopy(rhs);
-      return this;
+      linkAndCopy<StructureElements...>(rhs);
+      return *this;
     }
 
     template<typename ClassType> ClassType& get() { return static_cast<ClassType&>(*this);}

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -607,13 +607,28 @@ const std::string uniqueHandleHeader = R"(
     {
       return &m_value;
     }
-
+    
+    Type * operator->()
+    {
+      return &m_value;
+    }
+    
     Type const& operator*() const
     {
       return m_value;
     }
 
-    Type get() const
+    Type & operator*()
+    {
+      return m_value;
+    }
+
+    const Type & get() const
+    {
+      return m_value;
+    }
+    
+    Type & get()
     {
       return m_value;
     }

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -361,13 +361,28 @@ namespace vk
     {
       return &m_value;
     }
-
+    
+    Type * operator->()
+    {
+      return &m_value;
+    }
+    
     Type const& operator*() const
     {
       return m_value;
     }
 
-    Type get() const
+    Type & operator*()
+    {
+      return m_value;
+    }
+
+    const Type & get() const
+    {
+      return m_value;
+    }
+    
+    Type & get()
     {
       return m_value;
     }


### PR DESCRIPTION
- Add `Type * operator->()`
- Fix `Type get() const` to `const Type & get() const`
- Add `Type & get()`

Fixes https://github.com/KhronosGroup/Vulkan-Hpp/issues/122#issuecomment-327198391