### PR TITLE
Changes necessary to build 1.0.60 header

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -1676,7 +1676,7 @@ void readExtensionsExtension(tinyxml2::XMLElement * element, VkData & vkData)
   assert(vkData.tags.find(tag) != vkData.tags.end());
 
   tinyxml2::XMLElement * child = element->FirstChildElement();
-  assert(child && (strcmp(child->Value(), "require") == 0) && !child->NextSiblingElement());
+  assert(child && (strcmp(child->Value(), "require") == 0));
 
   if (strcmp(element->Attribute("supported"), "disabled") == 0)
   {
@@ -1690,8 +1690,11 @@ void readExtensionsExtension(tinyxml2::XMLElement * element, VkData & vkData)
     {
       protect = element->Attribute("protect");
     }
-
-    readExtensionRequire(child, vkData, protect, tag);
+    while (child) {
+      assert(strcmp(child->Value(), "require") == 0);
+      readExtensionRequire(child, vkData, protect, tag);
+      child = child->NextSiblingElement();
+    }
   }
 }
 

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -1649,6 +1649,10 @@ void readExtensionRequire(tinyxml2::XMLElement * element, VkData & vkData, std::
     {
       readExtensionEnum(child, vkData.enums, tag);
     }
+    else if (value == "comment")
+    {
+      // do nothing for comment
+    }
     else
     {
       assert(value=="usage");


### PR DESCRIPTION
I ran into some asserts doing the 1.0.60 header update in https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers.  These are the workarounds I used to generate a header.