### PR TITLE
Fix issue #147. Do not assert on negative result codes when throwing an exception

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -3899,7 +3899,6 @@ void writeThrowExceptions( std::ostream & os, EnumData const& enumData)
   os << 
 R"(  VULKAN_HPP_INLINE void throwResultException( Result result, char const * message )
   {
-    assert ( static_cast<long long int>(result) < 0 );
     switch ( result )
     {
 )";

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -819,7 +819,6 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE void throwResultException( Result result, char const * message )
   {
-    assert ( static_cast<long long int>(result) < 0 );
     switch ( result )
     {
     case Result::eErrorOutOfHostMemory: throw OutOfHostMemoryError ( message );


### PR DESCRIPTION
There're cases where vendors are non-standard conform and return positive return codes and it's also possible that new success codes could be introduced which require special handling. For the latter case it's legit to throw an exception which a positive result code.