### PR TITLE
Added parameters to SurfaceFormatKHR constructor

### DIFF
--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -20715,7 +20715,9 @@ namespace VULKAN_HPP_NAMESPACE
 
   struct SurfaceFormatKHR
   {
-    SurfaceFormatKHR(  )
+    SurfaceFormatKHR(Format format_ = Format(), ColorSpaceKHR colorSpace_ = ColorSpaceKHR())
+      : format(format_)
+      , colorSpace(colorSpace_)
     {
     }
 


### PR DESCRIPTION
1a32a6c072c9a5ac63fa5e6baf7d570a3d05ea64 added an empty constructor SurfaceFormatKHR.

SurfaceFormatKHR is however not always used as read-only struct. Instead the Vulkan API may signal to the application that no specific format is preferred (cf. [](https://vulkan.lunarg.com/doc/view/1.0.26.0/linux/vkspec.chunked/ch29s05.html) ). For this case, the application has to construct an instance of this struct itself rather than passing it on.

The empty constructor blocks the single-line construction and initialization of SurfaceFormatKHR, which I count as an explicit feature for most of the structures defined in Vulkan-Hpp.