### PR TITLE
Add structure chain constructor which accepts a list of its elements

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -398,6 +398,11 @@ const std::string structureChainHeader = R"(
       linkAndCopy<StructureElements...>(rhs);
     }
 
+    StructureChain(StructureElements const &... elems)
+    {
+      linkAndCopyElements<StructureElements...>(elems...);
+    }
+
     StructureChain& operator=(StructureChain const &rhs)
     {
       linkAndCopy<StructureElements...>(rhs);
@@ -439,6 +444,22 @@ const std::string structureChainHeader = R"(
       linkAndCopy<Y, Z...>(rhs);
     }
 
+    template<typename X>
+    void linkAndCopyElements(X const &rhs)
+    {
+      static_cast<X&>(*this) = rhs;
+    }
+
+    template<typename X, typename Y, typename ...Z>
+    void linkAndCopyElements(X const &xelem, Y const &yelem, Z const &... zelem)
+    {
+      static_assert(isStructureChainValid<X,Y>::value, "The structure chain is not valid!");
+      X& x = static_cast<X&>(*this);
+      Y& y = static_cast<Y&>(*this);
+      x = xelem;
+      x.pNext = &y;
+      linkAndCopyElements<Y, Z...>(yelem, zelem...);
+    }
 };
 )";
 


### PR DESCRIPTION
Previously in order to initialize a structure chain, lots of boilerplate code had to be written (since direct assignment to the `get()` results would break the `pNext` linkage:
```c++
vk::StructureChain<vk::MemoryAllocateInfo, vk::MemoryDedicatedAllocateInfo> chain;

vk::MemoryAllocateInfo &elem0 = chain.get<vk::MemoryAllocateInfo>();
elem0.allocationSize = size;
elem0.memoryTypeIndex = type;

vk::MemoryDedicatedAllocateInfo &elem1 = chain.get<vk::MemoryDedicatedAllocateInfo>();
elem1.image = image;
```

This pull requests extends the structure chain helper to allow simpler construction with much less code like the following:
```c++
vk::StructureChain<vk::MemoryAllocateInfo> chain =
  vk::MemoryAllocateInfo(size, type);
```
```c++
vk::StructureChain<vk::MemoryAllocateInfo, vk::MemoryDedicatedAllocateInfo> chain = {
  vk::MemoryAllocateInfo(size, type),
  vk::MemoryDedicatedAllocateInfo(image)
};
```
