### PR TITLE
Use std::move when calling createResultValue with NO_EXCEPTIONS

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -600,7 +600,7 @@ const std::string createResultValueHeader = R"(
   {
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
     VULKAN_HPP_ASSERT( result == Result::eSuccess );
-    return ResultValue<T>( result, data );
+    return ResultValue<T>( result, std::move(data) );
 #else
     if ( result != Result::eSuccess )
     {
@@ -643,7 +643,7 @@ const std::string createResultValueHeader = R"(
   {
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
     VULKAN_HPP_ASSERT( result == Result::eSuccess );
-    return ResultValue<UniqueHandle<T,D>>( result, UniqueHandle<T,D>(data, deleter) );
+    return ResultValue<UniqueHandle<T,D>>( result, UniqueHandle<T,D>(std::move(data), deleter) );
 #else
     if ( result != Result::eSuccess )
     {

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -1037,7 +1037,7 @@ namespace VULKAN_HPP_NAMESPACE
   {
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
     VULKAN_HPP_ASSERT( result == Result::eSuccess );
-    return ResultValue<T>( result, data );
+    return ResultValue<T>( result, std::move(data) );
 #else
     if ( result != Result::eSuccess )
     {
@@ -1080,7 +1080,7 @@ namespace VULKAN_HPP_NAMESPACE
   {
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
     VULKAN_HPP_ASSERT( result == Result::eSuccess );
-    return ResultValue<UniqueHandle<T,D>>( result, UniqueHandle<T,D>(data, deleter) );
+    return ResultValue<UniqueHandle<T,D>>( result, UniqueHandle<T,D>(std::move(data), deleter) );
 #else
     if ( result != Result::eSuccess )
     {


### PR DESCRIPTION
### Use `std::move` when calling `createResultValue` with `NO_EXCEPTIONS`
> Fix for issue https://github.com/KhronosGroup/Vulkan-Hpp/issues/272

Use move semantics when calling `createResultValue` to allow compiling when `T` is a `std::vector<UniqueHandle<>>`.