### PR TITLE
Fix to_string bracket formatting functions on *Flags.

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -677,7 +677,7 @@ void writeBitmaskToStringFunction(std::ostream & os, std::string const& bitmaskN
     if ( !value ) return "{}";
     std::string result;
 ${cases}
-    return result;)";
+    return "{" + result.substr(0, result.size() - 3) + "}";)";
     functionBody = replaceWithMap(bodyTemplate, { { "cases", casesString } });
   }
 

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -665,13 +665,9 @@ void writeBitmaskToStringFunction(std::ostream & os, std::string const& bitmaskN
     std::string casesString;
     for (auto const& value : enumValues)
     {
-      if (!casesString.empty())
-      {
-        casesString += " | \";";
-      }
       casesString += replaceWithMap(caseTemplate, { { "typeName", enumName },{ "value", value.second },{ "valueString", value.second.substr(1) } });
+      casesString += " | \";";
     }
-    casesString += "\";";
 
     static const std::string bodyTemplate = R"(
     if ( !value ) return "{}";


### PR DESCRIPTION
This just a fix in relation to 9a4f863d6e8bbaa9a029d985781104e0ffc4158d to have bitflag formatting be consistent with previous versions of `vulkan.hpp`
Right now:
Empty bitmask returns: `{}`
Populated bitmask returns: ` Graphics | Compute | Transfer | SparseBinding`

How it used to be:
Empty bitmask returns: `{}`
Populated bitmask returns: ` {Graphics | Compute | Transfer | SparseBinding}`