### PR TITLE
Add StructureChain tuple-based accessor

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -4554,6 +4554,15 @@ int main( int argc, char **argv )
 
     template<typename ClassType> ClassType& get() { return static_cast<ClassType&>(*this);}
 
+    template<typename ClassTypeA, typename ClassTypeB, typename ...ClassTypes>
+    std::tuple<ClassTypeA, ClassTypeB, ClassTypes...> get()
+    {
+        return std::tuple_cat(
+            std::make_tuple(get<ClassTypeA>(),get<ClassTypeB>()),
+            std::make_tuple(get<ClassTypes>()...)
+        );
+    }
+
   private:
     template<typename List, typename X>
     void link()


### PR DESCRIPTION
At the moment, pulling out individual components of a structure chain involves multiple calls to `get` and creating references to each individual element in the chain:
```cpp
// Makes a structure-chain type
auto DevicePropertyChain
	= SomePhysicalDevice.getProperties2<
		vk::PhysicalDeviceProperties2,
		vk::PhysicalDeviceIDProperties
	>();

// Now I have to pull out individual references
auto& DeviceProperties = DevicePropertyChain.get<vk::PhysicalDeviceProperties2>();
auto& DeviceIDProperties = DevicePropertyChain.get<vk::PhysicalDeviceIDProperties>();
```

A tuple-based accessor is added that returns a tuple of the requested reference types. Also allows for [structured-binding](https://en.cppreference.com/w/cpp/language/structured_binding) based declarations.
```cpp
// Makes a structure-chain type
auto DevicePropertyChain
	= SomePhysicalDevice.getProperties2<
		vk::PhysicalDeviceProperties2,
		vk::PhysicalDeviceIDProperties
	>();

// Structured binding creates referenced types
auto [DeviceProperties, DeviceIDProperties] = DevicePropertyChain.get<vk::PhysicalDeviceProperties2,vk::PhysicalDeviceIDProperties>();
```