### PR TITLE
Add find_package-based tinyxml2 linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,38 +44,24 @@ file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/vulkan/vulkan.hpp vulkan_hpp)
 string(REPLACE "\\" "\\\\" vulkan_hpp ${vulkan_hpp})
 add_definitions(-DVULKAN_HPP_FILE="${vulkan_hpp}")
 
-set(HEADERS
-  VulkanHppGenerator.hpp
-)
-
-set(SOURCES
-  VulkanHppGenerator.cpp
-)
-
-set(TINYXML2_SOURCES
-  tinyxml2/tinyxml2.cpp
-)
-
-set(TINYXML2_HEADERS
-  tinyxml2/tinyxml2.h
-)
-
-source_group(headers FILES ${HEADERS})
-source_group(sources FILES ${SOURCES})
-
-source_group(TinyXML2\\headers FILES ${TINYXML2_HEADERS})
-source_group(TinyXML2\\sources FILES ${TINYXML2_SOURCES})
+find_package(tinyxml2 QUIET)
+if(NOT tinyxml2_FOUND)
+set(BUILD_STATIC_LIBS ON CACHE BOOL "")
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "")
+set(BUILD_TESTS OFF CACHE BOOL "")
+add_subdirectory(tinyxml2)
+endif()
 
 add_executable(VulkanHppGenerator
-  ${HEADERS}
-  ${SOURCES}
-  ${TINYXML2_SOURCES}
-  ${TINYXML2_HEADERS}
+  VulkanHppGenerator.hpp
+  VulkanHppGenerator.cpp
+)
+target_link_libraries(VulkanHppGenerator
+  PRIVATE
+  tinyxml2
 )
 
 set_property(TARGET VulkanHppGenerator PROPERTY CXX_STANDARD 11)
-
-target_include_directories(VulkanHppGenerator PRIVATE "${CMAKE_SOURCE_DIR}/tinyxml2")
 
 option (SAMPLES_BUILD OFF)
 if (SAMPLES_BUILD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,11 @@ find_package(tinyxml2 QUIET)
 if(NOT tinyxml2_FOUND)
 add_library(tinyxml2
   SHARED
-  tinyxml2/tinyxml2.hpp
+  tinyxml2/tinyxml2.h
   tinyxml2/tinyxml2.cpp
+)
+target_include_directories(tinyxml2 PUBLIC
+  tinyxml2
 )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,10 +46,11 @@ add_definitions(-DVULKAN_HPP_FILE="${vulkan_hpp}")
 
 find_package(tinyxml2 QUIET)
 if(NOT tinyxml2_FOUND)
-set(BUILD_STATIC_LIBS ON CACHE BOOL "")
-set(BUILD_SHARED_LIBS OFF CACHE BOOL "")
-set(BUILD_TESTS OFF CACHE BOOL "")
-add_subdirectory(tinyxml2)
+add_library(tinyxml2
+  SHARED
+  tinyxml2/tinyxml2.hpp
+  tinyxml2/tinyxml2.cpp
+)
 endif()
 
 add_executable(VulkanHppGenerator


### PR DESCRIPTION
Will select between either the user-system's pre-existing tinyxml2 library, or utilize
the embedded git library within the repo.
When using the repo-tinyxml2, it will instead use `add_library` to link against the tinyxml2 target. 
Saves the need for a recursive git-clone in favor of linking against the user's already-compiled tinyxml2 library, making it build-ready straight from a `git clone` if the user already has tinyxml2 installed.
Implements suggestions based on #297