### PR TITLE
Add type alias for underlying type of vk::UniqueHandle

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -4602,6 +4602,9 @@ int main( int argc, char **argv )
   private:
     using Deleter = typename UniqueHandleTraits<Type,Dispatch>::deleter;
   public:
+
+    using element_type = Type;
+
     explicit UniqueHandle( Type const& value = Type(), Deleter const& deleter = Deleter() )
       : Deleter( deleter)
       , m_value( value )
@@ -4684,8 +4687,6 @@ int main( int argc, char **argv )
       std::swap(m_value, rhs.m_value);
       std::swap(static_cast<Deleter&>(*this), static_cast<Deleter&>(rhs));
     }
-
-    using element_type = Type;
 
   private:
     Type    m_value;

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -4197,6 +4197,8 @@ int main( int argc, char **argv )
       return m_ptr;
     }
 
+    using element_type = Type;
+
   private:
     uint32_t  m_count;
     T *       m_ptr;

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -4197,8 +4197,6 @@ int main( int argc, char **argv )
       return m_ptr;
     }
 
-    using element_type = Type;
-
   private:
     uint32_t  m_count;
     T *       m_ptr;
@@ -4686,6 +4684,8 @@ int main( int argc, char **argv )
       std::swap(m_value, rhs.m_value);
       std::swap(static_cast<Deleter&>(*this), static_cast<Deleter&>(rhs));
     }
+
+    using element_type = Type;
 
   private:
     Type    m_value;

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -509,6 +509,9 @@ namespace VULKAN_HPP_NAMESPACE
   private:
     using Deleter = typename UniqueHandleTraits<Type,Dispatch>::deleter;
   public:
+
+    using element_type = Type;
+
     explicit UniqueHandle( Type const& value = Type(), Deleter const& deleter = Deleter() )
       : Deleter( deleter)
       , m_value( value )


### PR DESCRIPTION
In the same spirit of `std::unique_ptr::element_type`--want to be able to easily retrieve the type of the class managed by the UniqueHandle.