### PR TITLE
Corrected inline if, which should be evaluated before writing output

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -2083,7 +2083,7 @@ void VulkanHppGenerator::writeArgumentPlainType(std::ostream & os, ParamData con
       if (paramData.type.type == "char")
       {
         // it's a const pointer to char -> it's a string -> get the data via c_str()
-        os << parameterName << paramData.optional ? (" ? " + parameterName + "->c_str() : nullptr") : ".c_str()";
+        os << parameterName << (paramData.optional ? (" ? " + parameterName + "->c_str() : nullptr") : ".c_str()");
       }
       else
       {


### PR DESCRIPTION
This PR fixes an expression of the form
`os << someOptional ? x : y`, which should be
`os << (someOptional ? x : y)`.

Otherwise, it discards the result of the inline if due to the higher precedence of the `<<` operator.

While this change could technically change the resulting `vulkan.hpp`, it does in fact not change the current one, as the the faulty path is apparently not taken for the latest xml spec.