### PR TITLE
Add explicit casts to DispatchLoaderDynamic::init(vk::Instance const&, vk::Device const&)

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -2367,7 +2367,7 @@ void VulkanHppGenerator::writeDispatchLoaderDynamic(std::ostream &os)
     // This interface is designed to be used for per-device function pointers in combination with a linked vulkan library.
     void init(vk::Instance const& instance, vk::Device const& device = {})
     {
-      init(instance, ::vkGetInstanceProcAddr, device, device ? ::vkGetDeviceProcAddr : nullptr);
+      init(static_cast<VkInstance>(instance), ::vkGetInstanceProcAddr, static_cast<VkDevice>(device), device ? ::vkGetDeviceProcAddr : nullptr);
     }
 #endif // !defined(VK_NO_PROTOTYPES)
 

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -56921,7 +56921,7 @@ namespace VULKAN_HPP_NAMESPACE
     // This interface is designed to be used for per-device function pointers in combination with a linked vulkan library.
     void init(vk::Instance const& instance, vk::Device const& device = {})
     {
-      init(instance, ::vkGetInstanceProcAddr, device, device ? ::vkGetDeviceProcAddr : nullptr);
+      init(static_cast<VkInstance>(instance), ::vkGetInstanceProcAddr, static_cast<VkDevice>(device), device ? ::vkGetDeviceProcAddr : nullptr);
     }
 #endif // !defined(VK_NO_PROTOTYPES)
 


### PR DESCRIPTION
Fixes compilation issues on 32-bit platforms (or where `VULKAN_HPP_TYPESAFE_CONVERSION` is not defined).

See: #343