### PR TITLE
Add a static const(expr) member vk::ObjectType to the vk object class…

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -3455,6 +3455,8 @@ void VulkanHppGenerator::writeHandle(std::ostream & os, std::pair<std::string, H
   public:
     using CType = Vk${className};
 
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::e${className};
+
   public:
     VULKAN_HPP_CONSTEXPR ${className}()
       : m_${memberName}(VK_NULL_HANDLE)
@@ -3516,6 +3518,12 @@ ${commands}
     Vk${className} m_${memberName};
   };
   static_assert( sizeof( ${className} ) == sizeof( Vk${className} ), "handle and wrapper have different size!" );
+
+  template <>
+  struct cpp_type<ObjectType::e${className}>
+  {
+    using type = ${className};
+  };
 )";
 
       os << replaceWithMap(templateString, {
@@ -4810,8 +4818,10 @@ int main( int argc, char **argv )
 
 #if defined(_MSC_VER) && (_MSC_VER <= 1800)
 # define VULKAN_HPP_CONSTEXPR
+# define VULKAN_HPP_CONST_OR_CONSTEXPR  const
 #else
 # define VULKAN_HPP_CONSTEXPR constexpr
+# define VULKAN_HPP_CONST_OR_CONSTEXPR  constexpr
 #endif
 
 #if !defined(VULKAN_HPP_NAMESPACE)
@@ -5052,6 +5062,13 @@ namespace std
 #endif
 )";
 
+  static const std::string typeTraits = R"(
+  template<ObjectType value>
+  struct cpp_type
+  {
+  };
+)";
+
   try {
     tinyxml2::XMLDocument doc;
 
@@ -5150,6 +5167,7 @@ namespace std
       << std::endl;
     generator.writeBaseTypes(ofs);
     generator.writeEnums(ofs);
+    ofs << typeTraits;
     generator.writeBitmasks(ofs);
     ofs << "} // namespace VULKAN_HPP_NAMESPACE" << std::endl
       << is_error_code_enum

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -123,8 +123,10 @@ static_assert( VK_HEADER_VERSION ==  108 , "Wrong VK_HEADER_VERSION!" );
 
 #if defined(_MSC_VER) && (_MSC_VER <= 1800)
 # define VULKAN_HPP_CONSTEXPR
+# define VULKAN_HPP_CONST_OR_CONSTEXPR  const
 #else
 # define VULKAN_HPP_CONSTEXPR constexpr
+# define VULKAN_HPP_CONST_OR_CONSTEXPR  constexpr
 #endif
 
 #if !defined(VULKAN_HPP_NAMESPACE)
@@ -5780,6 +5782,11 @@ namespace VULKAN_HPP_NAMESPACE
     }
   }
 
+  template<ObjectType value>
+  struct cpp_type
+  {
+  };
+
   enum class AccessFlagBits
   {
     eIndirectCommandRead = VK_ACCESS_INDIRECT_COMMAND_READ_BIT,
@@ -11348,6 +11355,8 @@ namespace VULKAN_HPP_NAMESPACE
   public:
     using CType = VkSurfaceKHR;
 
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eSurfaceKHR;
+
   public:
     VULKAN_HPP_CONSTEXPR SurfaceKHR()
       : m_surfaceKHR(VK_NULL_HANDLE)
@@ -11410,10 +11419,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( SurfaceKHR ) == sizeof( VkSurfaceKHR ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eSurfaceKHR>
+  {
+    using type = SurfaceKHR;
+  };
+
   class DebugReportCallbackEXT
   {
   public:
     using CType = VkDebugReportCallbackEXT;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eDebugReportCallbackEXT;
 
   public:
     VULKAN_HPP_CONSTEXPR DebugReportCallbackEXT()
@@ -11477,10 +11494,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( DebugReportCallbackEXT ) == sizeof( VkDebugReportCallbackEXT ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eDebugReportCallbackEXT>
+  {
+    using type = DebugReportCallbackEXT;
+  };
+
   class DebugUtilsMessengerEXT
   {
   public:
     using CType = VkDebugUtilsMessengerEXT;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eDebugUtilsMessengerEXT;
 
   public:
     VULKAN_HPP_CONSTEXPR DebugUtilsMessengerEXT()
@@ -11544,10 +11569,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( DebugUtilsMessengerEXT ) == sizeof( VkDebugUtilsMessengerEXT ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eDebugUtilsMessengerEXT>
+  {
+    using type = DebugUtilsMessengerEXT;
+  };
+
   class DisplayKHR
   {
   public:
     using CType = VkDisplayKHR;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eDisplayKHR;
 
   public:
     VULKAN_HPP_CONSTEXPR DisplayKHR()
@@ -11611,10 +11644,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( DisplayKHR ) == sizeof( VkDisplayKHR ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eDisplayKHR>
+  {
+    using type = DisplayKHR;
+  };
+
   class SwapchainKHR
   {
   public:
     using CType = VkSwapchainKHR;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eSwapchainKHR;
 
   public:
     VULKAN_HPP_CONSTEXPR SwapchainKHR()
@@ -11678,10 +11719,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( SwapchainKHR ) == sizeof( VkSwapchainKHR ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eSwapchainKHR>
+  {
+    using type = SwapchainKHR;
+  };
+
   class Semaphore
   {
   public:
     using CType = VkSemaphore;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eSemaphore;
 
   public:
     VULKAN_HPP_CONSTEXPR Semaphore()
@@ -11745,10 +11794,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( Semaphore ) == sizeof( VkSemaphore ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eSemaphore>
+  {
+    using type = Semaphore;
+  };
+
   class Fence
   {
   public:
     using CType = VkFence;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eFence;
 
   public:
     VULKAN_HPP_CONSTEXPR Fence()
@@ -11812,10 +11869,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( Fence ) == sizeof( VkFence ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eFence>
+  {
+    using type = Fence;
+  };
+
   class QueryPool
   {
   public:
     using CType = VkQueryPool;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eQueryPool;
 
   public:
     VULKAN_HPP_CONSTEXPR QueryPool()
@@ -11879,10 +11944,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( QueryPool ) == sizeof( VkQueryPool ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eQueryPool>
+  {
+    using type = QueryPool;
+  };
+
   class Buffer
   {
   public:
     using CType = VkBuffer;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eBuffer;
 
   public:
     VULKAN_HPP_CONSTEXPR Buffer()
@@ -11946,10 +12019,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( Buffer ) == sizeof( VkBuffer ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eBuffer>
+  {
+    using type = Buffer;
+  };
+
   class PipelineLayout
   {
   public:
     using CType = VkPipelineLayout;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::ePipelineLayout;
 
   public:
     VULKAN_HPP_CONSTEXPR PipelineLayout()
@@ -12013,10 +12094,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( PipelineLayout ) == sizeof( VkPipelineLayout ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::ePipelineLayout>
+  {
+    using type = PipelineLayout;
+  };
+
   class DescriptorSet
   {
   public:
     using CType = VkDescriptorSet;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eDescriptorSet;
 
   public:
     VULKAN_HPP_CONSTEXPR DescriptorSet()
@@ -12080,10 +12169,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( DescriptorSet ) == sizeof( VkDescriptorSet ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eDescriptorSet>
+  {
+    using type = DescriptorSet;
+  };
+
   class Pipeline
   {
   public:
     using CType = VkPipeline;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::ePipeline;
 
   public:
     VULKAN_HPP_CONSTEXPR Pipeline()
@@ -12147,10 +12244,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( Pipeline ) == sizeof( VkPipeline ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::ePipeline>
+  {
+    using type = Pipeline;
+  };
+
   class ImageView
   {
   public:
     using CType = VkImageView;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eImageView;
 
   public:
     VULKAN_HPP_CONSTEXPR ImageView()
@@ -12214,10 +12319,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( ImageView ) == sizeof( VkImageView ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eImageView>
+  {
+    using type = ImageView;
+  };
+
   class Image
   {
   public:
     using CType = VkImage;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eImage;
 
   public:
     VULKAN_HPP_CONSTEXPR Image()
@@ -12281,10 +12394,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( Image ) == sizeof( VkImage ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eImage>
+  {
+    using type = Image;
+  };
+
   class AccelerationStructureNV
   {
   public:
     using CType = VkAccelerationStructureNV;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eAccelerationStructureNV;
 
   public:
     VULKAN_HPP_CONSTEXPR AccelerationStructureNV()
@@ -12348,10 +12469,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( AccelerationStructureNV ) == sizeof( VkAccelerationStructureNV ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eAccelerationStructureNV>
+  {
+    using type = AccelerationStructureNV;
+  };
+
   class DescriptorUpdateTemplate
   {
   public:
     using CType = VkDescriptorUpdateTemplate;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eDescriptorUpdateTemplate;
 
   public:
     VULKAN_HPP_CONSTEXPR DescriptorUpdateTemplate()
@@ -12414,12 +12543,20 @@ namespace VULKAN_HPP_NAMESPACE
     VkDescriptorUpdateTemplate m_descriptorUpdateTemplate;
   };
   static_assert( sizeof( DescriptorUpdateTemplate ) == sizeof( VkDescriptorUpdateTemplate ), "handle and wrapper have different size!" );
+
+  template <>
+  struct cpp_type<ObjectType::eDescriptorUpdateTemplate>
+  {
+    using type = DescriptorUpdateTemplate;
+  };
   using DescriptorUpdateTemplateKHR = DescriptorUpdateTemplate;
 
   class Event
   {
   public:
     using CType = VkEvent;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eEvent;
 
   public:
     VULKAN_HPP_CONSTEXPR Event()
@@ -12483,10 +12620,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( Event ) == sizeof( VkEvent ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eEvent>
+  {
+    using type = Event;
+  };
+
   class CommandBuffer
   {
   public:
     using CType = VkCommandBuffer;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eCommandBuffer;
 
   public:
     VULKAN_HPP_CONSTEXPR CommandBuffer()
@@ -13004,10 +13149,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( CommandBuffer ) == sizeof( VkCommandBuffer ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eCommandBuffer>
+  {
+    using type = CommandBuffer;
+  };
+
   class DeviceMemory
   {
   public:
     using CType = VkDeviceMemory;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eDeviceMemory;
 
   public:
     VULKAN_HPP_CONSTEXPR DeviceMemory()
@@ -13071,10 +13224,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( DeviceMemory ) == sizeof( VkDeviceMemory ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eDeviceMemory>
+  {
+    using type = DeviceMemory;
+  };
+
   class BufferView
   {
   public:
     using CType = VkBufferView;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eBufferView;
 
   public:
     VULKAN_HPP_CONSTEXPR BufferView()
@@ -13138,10 +13299,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( BufferView ) == sizeof( VkBufferView ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eBufferView>
+  {
+    using type = BufferView;
+  };
+
   class CommandPool
   {
   public:
     using CType = VkCommandPool;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eCommandPool;
 
   public:
     VULKAN_HPP_CONSTEXPR CommandPool()
@@ -13205,10 +13374,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( CommandPool ) == sizeof( VkCommandPool ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eCommandPool>
+  {
+    using type = CommandPool;
+  };
+
   class PipelineCache
   {
   public:
     using CType = VkPipelineCache;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::ePipelineCache;
 
   public:
     VULKAN_HPP_CONSTEXPR PipelineCache()
@@ -13272,10 +13449,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( PipelineCache ) == sizeof( VkPipelineCache ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::ePipelineCache>
+  {
+    using type = PipelineCache;
+  };
+
   class DescriptorPool
   {
   public:
     using CType = VkDescriptorPool;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eDescriptorPool;
 
   public:
     VULKAN_HPP_CONSTEXPR DescriptorPool()
@@ -13339,10 +13524,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( DescriptorPool ) == sizeof( VkDescriptorPool ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eDescriptorPool>
+  {
+    using type = DescriptorPool;
+  };
+
   class DescriptorSetLayout
   {
   public:
     using CType = VkDescriptorSetLayout;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eDescriptorSetLayout;
 
   public:
     VULKAN_HPP_CONSTEXPR DescriptorSetLayout()
@@ -13406,10 +13599,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( DescriptorSetLayout ) == sizeof( VkDescriptorSetLayout ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eDescriptorSetLayout>
+  {
+    using type = DescriptorSetLayout;
+  };
+
   class Framebuffer
   {
   public:
     using CType = VkFramebuffer;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eFramebuffer;
 
   public:
     VULKAN_HPP_CONSTEXPR Framebuffer()
@@ -13473,10 +13674,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( Framebuffer ) == sizeof( VkFramebuffer ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eFramebuffer>
+  {
+    using type = Framebuffer;
+  };
+
   class IndirectCommandsLayoutNVX
   {
   public:
     using CType = VkIndirectCommandsLayoutNVX;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eIndirectCommandsLayoutNVX;
 
   public:
     VULKAN_HPP_CONSTEXPR IndirectCommandsLayoutNVX()
@@ -13540,10 +13749,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( IndirectCommandsLayoutNVX ) == sizeof( VkIndirectCommandsLayoutNVX ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eIndirectCommandsLayoutNVX>
+  {
+    using type = IndirectCommandsLayoutNVX;
+  };
+
   class ObjectTableNVX
   {
   public:
     using CType = VkObjectTableNVX;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eObjectTableNVX;
 
   public:
     VULKAN_HPP_CONSTEXPR ObjectTableNVX()
@@ -13607,10 +13824,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( ObjectTableNVX ) == sizeof( VkObjectTableNVX ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eObjectTableNVX>
+  {
+    using type = ObjectTableNVX;
+  };
+
   class RenderPass
   {
   public:
     using CType = VkRenderPass;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eRenderPass;
 
   public:
     VULKAN_HPP_CONSTEXPR RenderPass()
@@ -13674,10 +13899,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( RenderPass ) == sizeof( VkRenderPass ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eRenderPass>
+  {
+    using type = RenderPass;
+  };
+
   class Sampler
   {
   public:
     using CType = VkSampler;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eSampler;
 
   public:
     VULKAN_HPP_CONSTEXPR Sampler()
@@ -13741,10 +13974,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( Sampler ) == sizeof( VkSampler ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eSampler>
+  {
+    using type = Sampler;
+  };
+
   class SamplerYcbcrConversion
   {
   public:
     using CType = VkSamplerYcbcrConversion;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eSamplerYcbcrConversion;
 
   public:
     VULKAN_HPP_CONSTEXPR SamplerYcbcrConversion()
@@ -13807,12 +14048,20 @@ namespace VULKAN_HPP_NAMESPACE
     VkSamplerYcbcrConversion m_samplerYcbcrConversion;
   };
   static_assert( sizeof( SamplerYcbcrConversion ) == sizeof( VkSamplerYcbcrConversion ), "handle and wrapper have different size!" );
+
+  template <>
+  struct cpp_type<ObjectType::eSamplerYcbcrConversion>
+  {
+    using type = SamplerYcbcrConversion;
+  };
   using SamplerYcbcrConversionKHR = SamplerYcbcrConversion;
 
   class ShaderModule
   {
   public:
     using CType = VkShaderModule;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eShaderModule;
 
   public:
     VULKAN_HPP_CONSTEXPR ShaderModule()
@@ -13876,10 +14125,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( ShaderModule ) == sizeof( VkShaderModule ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eShaderModule>
+  {
+    using type = ShaderModule;
+  };
+
   class ValidationCacheEXT
   {
   public:
     using CType = VkValidationCacheEXT;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eValidationCacheEXT;
 
   public:
     VULKAN_HPP_CONSTEXPR ValidationCacheEXT()
@@ -13943,10 +14200,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( ValidationCacheEXT ) == sizeof( VkValidationCacheEXT ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eValidationCacheEXT>
+  {
+    using type = ValidationCacheEXT;
+  };
+
   class Queue
   {
   public:
     using CType = VkQueue;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eQueue;
 
   public:
     VULKAN_HPP_CONSTEXPR Queue()
@@ -14065,6 +14330,12 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( Queue ) == sizeof( VkQueue ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eQueue>
+  {
+    using type = Queue;
+  };
+
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
   class Device;
   template <typename Dispatch> class UniqueHandleTraits<AccelerationStructureNV, Dispatch> { public: using deleter = ObjectDestroy<Device, Dispatch>; };
@@ -14129,6 +14400,8 @@ namespace VULKAN_HPP_NAMESPACE
   {
   public:
     using CType = VkDevice;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eDevice;
 
   public:
     VULKAN_HPP_CONSTEXPR Device()
@@ -15731,10 +16004,18 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( Device ) == sizeof( VkDevice ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eDevice>
+  {
+    using type = Device;
+  };
+
   class DisplayModeKHR
   {
   public:
     using CType = VkDisplayModeKHR;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eDisplayModeKHR;
 
   public:
     VULKAN_HPP_CONSTEXPR DisplayModeKHR()
@@ -15798,6 +16079,12 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( DisplayModeKHR ) == sizeof( VkDisplayModeKHR ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::eDisplayModeKHR>
+  {
+    using type = DisplayModeKHR;
+  };
+
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
   template <typename Dispatch> class UniqueHandleTraits<Device, Dispatch> { public: using deleter = ObjectDestroy<NoParent, Dispatch>; };
   using UniqueDevice = UniqueHandle<Device, DispatchLoaderDefault>;
@@ -15807,6 +16094,8 @@ namespace VULKAN_HPP_NAMESPACE
   {
   public:
     using CType = VkPhysicalDevice;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::ePhysicalDevice;
 
   public:
     VULKAN_HPP_CONSTEXPR PhysicalDevice()
@@ -16395,6 +16684,12 @@ namespace VULKAN_HPP_NAMESPACE
   };
   static_assert( sizeof( PhysicalDevice ) == sizeof( VkPhysicalDevice ), "handle and wrapper have different size!" );
 
+  template <>
+  struct cpp_type<ObjectType::ePhysicalDevice>
+  {
+    using type = PhysicalDevice;
+  };
+
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
   class Instance;
   template <typename Dispatch> class UniqueHandleTraits<DebugReportCallbackEXT, Dispatch> { public: using deleter = ObjectDestroy<Instance, Dispatch>; };
@@ -16409,6 +16704,8 @@ namespace VULKAN_HPP_NAMESPACE
   {
   public:
     using CType = VkInstance;
+
+    static VULKAN_HPP_CONST_OR_CONSTEXPR ObjectType objectType = ObjectType::eInstance;
 
   public:
     VULKAN_HPP_CONSTEXPR Instance()
@@ -16755,6 +17052,12 @@ namespace VULKAN_HPP_NAMESPACE
     VkInstance m_instance;
   };
   static_assert( sizeof( Instance ) == sizeof( VkInstance ), "handle and wrapper have different size!" );
+
+  template <>
+  struct cpp_type<ObjectType::eInstance>
+  {
+    using type = Instance;
+  };
 
 #ifndef VULKAN_HPP_NO_SMART_HANDLE
   template <typename Dispatch> class UniqueHandleTraits<Instance, Dispatch> { public: using deleter = ObjectDestroy<NoParent, Dispatch>; };


### PR DESCRIPTION
…es; add a type_trait cpp_type<> to get the cpp-type from a vk::ObjectType.

Fixes #350.