### PR TITLE
Fix the header generation for complex disabled extensions

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -1516,8 +1516,12 @@ void VulkanHppGenerator::readExtensionDisabledRequire(tinyxml2::XMLElement const
       else
       {
         // a type simply needs to be removed from the structs and vkTypes sets
-        assert(m_structures.find(nameAttribute->second) != m_structures.end());
+        assert(m_structures.find(nameAttribute->second) != m_structures.end() ||
+               m_bitmasks.find(nameAttribute->second) != m_bitmasks.end() ||
+               m_bitmaskBits.find(nameAttribute->second) != m_bitmaskBits.end());
         m_structures.erase(nameAttribute->second);
+        m_bitmasks.erase(nameAttribute->second);
+        m_bitmaskBits.erase(nameAttribute->second);
       }
     }
     else if (value == "enum")


### PR DESCRIPTION
It's the VK_ANDROID_native_buffer extension, which is a vendor extension hidden in between Vulkan loader and the ICD, so it's marked disabled.

Below are the enums causing header generation failures that were added in some later version of this extension:
```
typedef enum VkSwapchainImageUsageFlagBitsANDROID {
    VK_SWAPCHAIN_IMAGE_USAGE_SHARED_BIT_ANDROID = 0x00000001,
    VK_SWAPCHAIN_IMAGE_USAGE_FLAG_BITS_MAX_ENUM = 0x7FFFFFFF
} VkSwapchainImageUsageFlagBitsANDROID;
typedef VkFlags VkSwapchainImageUsageFlagsANDROID;
```

```xml
<extension name="VK_ANDROID_native_buffer" number="11" type="device" author="ANDROID" platform="android" contact="Jesse Hall @critsec" supported="disabled">                                                    
    <require>
        <comment>VK_ANDROID_native_buffer is used between the Android Vulkan loader and drivers to implement the WSI extensions. It isn't exposed to applications and uses types that aren't part of Android's stable public API, so it is left disabled to keep it out of the standard Vulkan headers.</comment>
        <enum value="8"                                                 name="VK_ANDROID_NATIVE_BUFFER_SPEC_VERSION"/>
        <enum value="11"                                                name="VK_ANDROID_NATIVE_BUFFER_NUMBER"/>
        <enum value="&quot;VK_ANDROID_native_buffer&quot;"              name="VK_ANDROID_NATIVE_BUFFER_NAME"/>
        <enum offset="0" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_NATIVE_BUFFER_ANDROID"/>
        <enum offset="1" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_SWAPCHAIN_IMAGE_CREATE_INFO_ANDROID"/>
        <enum offset="2" extends="VkStructureType"                      name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENTATION_PROPERTIES_ANDROID"/>
        <type name="VkNativeBufferANDROID"/>
        <type name="VkSwapchainImageCreateInfoANDROID"/>
        <type name="VkPhysicalDevicePresentationPropertiesANDROID"/>
        <type name="VkNativeBufferUsage2ANDROID"/>
        <type name="VkSwapchainImageUsageFlagBitsANDROID"/>
        <type name="VkSwapchainImageUsageFlagsANDROID"/>
        <command name="vkGetSwapchainGrallocUsageANDROID"/>
        <command name="vkAcquireImageANDROID"/>
        <command name="vkQueueSignalReleaseImageANDROID"/>
        <command name="vkGetSwapchainGrallocUsage2ANDROID"/>
    </require>
</extension>
```