### PR TITLE
Fix typo.

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -4933,7 +4933,7 @@ int main( int argc, char **argv )
 #endif
 
 #if !defined(VULKAN_HPP_INLINE)
-# if defined(__clang___)
+# if defined(__clang__)
 #  if __has_attribute(always_inline)
 #   define VULKAN_HPP_INLINE __attribute__((always_inline)) __inline__
 #  else


### PR DESCRIPTION
I think this is supposed to be `__clang__` and not `__clang___` as seen in elsewhere in the repo and in online documentation.