### PR TITLE
Change (most of) the samples to use the DispatchLoaderDynamic by default

### DIFF
--- a/samples/01_InitInstance/CMakeLists.txt
+++ b/samples/01_InitInstance/CMakeLists.txt
@@ -26,6 +26,8 @@ set(SOURCES
 source_group(headers FILES ${HEADERS})
 source_group(sources FILES ${SOURCES})
 
+add_definitions(-DVULKAN_HPP_DISPATCH_LOADER_DYNAMIC=0)
+
 add_executable(01_InitInstance
   ${HEADERS}
   ${SOURCES}

--- a/samples/16_Vulkan_1_1/16_Vulkan_1_1.cpp
+++ b/samples/16_Vulkan_1_1/16_Vulkan_1_1.cpp
@@ -41,6 +41,13 @@ int main(int /*argc*/, char ** /*argv*/)
     desiredVersionString += ".";
     desiredVersionString += std::to_string(desiredMinorVersion);
 
+#if (VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1)
+    // initialize the DipatchLoaderDynamic to use
+    static vk::DynamicLoader dl;
+    PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr = dl.getProcAddress<PFN_vkGetInstanceProcAddr>("vkGetInstanceProcAddr");
+    VULKAN_HPP_DEFAULT_DISPATCHER.init(vkGetInstanceProcAddr);
+#endif
+
     // Determine what API version is available
     uint32_t apiVersion = vk::enumerateInstanceVersion();
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -26,6 +26,8 @@ else()
   error("unhandled platform !")
 endif()
 
+add_definitions(-DVULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1)
+
 FILE (GLOB linkunits ${CMAKE_CURRENT_SOURCE_DIR}/*)
 
 if (SAMPLES_BUILD_WITH_LOCAL_VULKAN_HPP)

--- a/samples/CreateDebugUtilsMessenger/CMakeLists.txt
+++ b/samples/CreateDebugUtilsMessenger/CMakeLists.txt
@@ -26,6 +26,8 @@ set(SOURCES
 source_group(headers FILES ${HEADERS})
 source_group(sources FILES ${SOURCES})
 
+add_definitions(-DVULKAN_HPP_DISPATCH_LOADER_DYNAMIC=0)
+
 add_executable(CreateDebugUtilsMessenger
   ${HEADERS}
   ${SOURCES}

--- a/samples/EnableValidationWithCallback/CMakeLists.txt
+++ b/samples/EnableValidationWithCallback/CMakeLists.txt
@@ -26,6 +26,8 @@ set(SOURCES
 source_group(headers FILES ${HEADERS})
 source_group(sources FILES ${SOURCES})
 
+add_definitions(-DVULKAN_HPP_DISPATCH_LOADER_DYNAMIC=0)
+
 add_executable(EnableValidationWithCallback
   ${HEADERS}
   ${SOURCES}

--- a/samples/EnableValidationWithCallback/EnableValidationWithCallback.cpp
+++ b/samples/EnableValidationWithCallback/EnableValidationWithCallback.cpp
@@ -21,6 +21,8 @@
 #include <iostream>
 #include <sstream>
 
+using namespace std::string_literals;
+
 static char const* AppName = "EnableValidationWithCallback";
 static char const* EngineName = "Vulkan.hpp";
 
@@ -41,45 +43,44 @@ VKAPI_ATTR void VKAPI_CALL vkDestroyDebugUtilsMessengerEXT(VkInstance instance, 
 VkBool32 debugMessageFunc(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageTypes,
   VkDebugUtilsMessengerCallbackDataEXT const * pCallbackData, void * /*pUserData*/)
 {
-  std::ostringstream message;
+  std::string message;
 
-  message << vk::to_string(static_cast<vk::DebugUtilsMessageSeverityFlagBitsEXT>(messageSeverity)) << ": " << vk::to_string(static_cast<vk::DebugUtilsMessageTypeFlagsEXT>(messageTypes)) << ":\n";
-  message << "\t" << "messageIDName   = <" << pCallbackData->pMessageIdName << ">\n";
-  message << "\t" << "messageIdNumber = " << pCallbackData->messageIdNumber << "\n";
-  message << "\t" << "message         = <" << pCallbackData->pMessage << ">\n";
+  message += vk::to_string(static_cast<vk::DebugUtilsMessageSeverityFlagBitsEXT>(messageSeverity)) + ": " + vk::to_string(static_cast<vk::DebugUtilsMessageTypeFlagsEXT>(messageTypes)) + ":\n";
+  message += "\t"s + "messageIDName   = <" + pCallbackData->pMessageIdName + ">\n";
+  message += "\t"s + "messageIdNumber = " + std::to_string(pCallbackData->messageIdNumber) + "\n";
+  message += "\t"s + "message         = <" + pCallbackData->pMessage + ">\n";
   if (0 < pCallbackData->queueLabelCount)
   {
-    message << "\t" << "Queue Labels:\n";
+    message += "\t"s + "Queue Labels:\n";
     for (uint8_t i = 0; i < pCallbackData->queueLabelCount; i++)
     {
-      message << "\t\t" << "lableName = <" << pCallbackData->pQueueLabels[i].pLabelName << ">\n";
+      message += "\t\t"s + "lableName = <" + pCallbackData->pQueueLabels[i].pLabelName + ">\n";
     }
   }
   if (0 < pCallbackData->cmdBufLabelCount)
   {
-    message << "\t" << "CommandBuffer Labels:\n";
+    message += "\t"s + "CommandBuffer Labels:\n";
     for (uint8_t i = 0; i < pCallbackData->cmdBufLabelCount; i++)
     {
-      message << "\t\t" << "labelName = <" << pCallbackData->pCmdBufLabels[i].pLabelName << ">\n";
+      message += "\t\t"s + "labelName = <" + pCallbackData->pCmdBufLabels[i].pLabelName + ">\n";
     }
   }
   if (0 < pCallbackData->objectCount)
   {
-    message << "\t" << "Objects:\n";
     for (uint8_t i = 0; i < pCallbackData->objectCount; i++)
     {
-      message << "\t\t" << "Object " << i << "\n";
-      message << "\t\t\t" << "objectType   = " << vk::to_string(static_cast<vk::ObjectType>(pCallbackData->pObjects[i].objectType)) << "\n";
-      message << "\t\t\t" << "objectHandle = " << pCallbackData->pObjects[i].objectHandle << "\n";
+      message += "\t"s + "Object " + std::to_string(i) + "\n";
+      message += "\t\t"s + "objectType   = " + vk::to_string(static_cast<vk::ObjectType>(pCallbackData->pObjects[i].objectType)) + "\n";
+      message += "\t\t"s + "objectHandle = " + std::to_string(pCallbackData->pObjects[i].objectHandle) + "\n";
       if (pCallbackData->pObjects[i].pObjectName)
       {
-        message << "\t\t\t" << "objectName   = <" << pCallbackData->pObjects[i].pObjectName << ">\n";
+        message += "\t\t"s + "objectName   = <" + pCallbackData->pObjects[i].pObjectName + ">\n";
       }
   }
 }
 
 #ifdef _WIN32
-  MessageBox(NULL, message.str().c_str(), "Alert", MB_OK);
+  MessageBox(NULL, message.c_str(), "Alert", MB_OK);
 #else
   std::cout << message.str() << std::endl;
 #endif

--- a/samples/InstanceExtensionProperties/CMakeLists.txt
+++ b/samples/InstanceExtensionProperties/CMakeLists.txt
@@ -26,6 +26,8 @@ set(SOURCES
 source_group(headers FILES ${HEADERS})
 source_group(sources FILES ${SOURCES})
 
+add_definitions(-DVULKAN_HPP_DISPATCH_LOADER_DYNAMIC=0)
+
 add_executable(InstanceExtensionProperties
   ${HEADERS}
   ${SOURCES}

--- a/samples/InstanceLayerExtensionProperties/CMakeLists.txt
+++ b/samples/InstanceLayerExtensionProperties/CMakeLists.txt
@@ -26,6 +26,8 @@ set(SOURCES
 source_group(headers FILES ${HEADERS})
 source_group(sources FILES ${SOURCES})
 
+add_definitions(-DVULKAN_HPP_DISPATCH_LOADER_DYNAMIC=0)
+
 add_executable(InstanceLayerExtensionProperties
   ${HEADERS}
   ${SOURCES}

--- a/samples/InstanceLayerProperties/CMakeLists.txt
+++ b/samples/InstanceLayerProperties/CMakeLists.txt
@@ -26,6 +26,8 @@ set(SOURCES
 source_group(headers FILES ${HEADERS})
 source_group(sources FILES ${SOURCES})
 
+add_definitions(-DVULKAN_HPP_DISPATCH_LOADER_DYNAMIC=0)
+
 add_executable(InstanceLayerProperties
   ${HEADERS}
   ${SOURCES}

--- a/samples/PushDescriptors/PushDescriptors.cpp
+++ b/samples/PushDescriptors/PushDescriptors.cpp
@@ -30,6 +30,13 @@ int main(int /*argc*/, char ** /*argv*/)
 {
   try
   {
+#if (VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1)
+    // initialize the DipatchLoaderDynamic to use
+    static vk::DynamicLoader dl;
+    PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr = dl.getProcAddress<PFN_vkGetInstanceProcAddr>("vkGetInstanceProcAddr");
+    VULKAN_HPP_DEFAULT_DISPATCHER.init(vkGetInstanceProcAddr);
+#endif
+
     /* VULKAN_KEY_START */
 
     // To use PUSH_DESCRIPTOR, you must also specify GET_PHYSICAL_DEVICE_PROPERTIES_2

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -72072,9 +72072,10 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_ASSERT(getInstanceProcAddr);
 
       vkGetInstanceProcAddr = getInstanceProcAddr;
+      vkCreateInstance = PFN_vkCreateInstance( vkGetInstanceProcAddr( NULL, "vkCreateInstance" ) );
       vkEnumerateInstanceExtensionProperties = PFN_vkEnumerateInstanceExtensionProperties( vkGetInstanceProcAddr( NULL, "vkEnumerateInstanceExtensionProperties" ) );
       vkEnumerateInstanceLayerProperties = PFN_vkEnumerateInstanceLayerProperties( vkGetInstanceProcAddr( NULL, "vkEnumerateInstanceLayerProperties" ) );
-      vkCreateInstance = PFN_vkCreateInstance( vkGetInstanceProcAddr( NULL, "vkCreateInstance" ) );
+      vkEnumerateInstanceVersion = PFN_vkEnumerateInstanceVersion( vkGetInstanceProcAddr( NULL, "vkEnumerateInstanceVersion" ) );
     }
 
     // This interface does not require a linked vulkan library.
@@ -72096,10 +72097,6 @@ namespace VULKAN_HPP_NAMESPACE
 
     void init( vk::Instance instance )
     {
-      vkCreateInstance = PFN_vkCreateInstance( vkGetInstanceProcAddr( instance, "vkCreateInstance" ) );
-      vkEnumerateInstanceExtensionProperties = PFN_vkEnumerateInstanceExtensionProperties( vkGetInstanceProcAddr( instance, "vkEnumerateInstanceExtensionProperties" ) );
-      vkEnumerateInstanceLayerProperties = PFN_vkEnumerateInstanceLayerProperties( vkGetInstanceProcAddr( instance, "vkEnumerateInstanceLayerProperties" ) );
-      vkEnumerateInstanceVersion = PFN_vkEnumerateInstanceVersion( vkGetInstanceProcAddr( instance, "vkEnumerateInstanceVersion" ) );
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
       vkCreateAndroidSurfaceKHR = PFN_vkCreateAndroidSurfaceKHR( vkGetInstanceProcAddr( instance, "vkCreateAndroidSurfaceKHR" ) );
 #endif /*VK_USE_PLATFORM_ANDROID_KHR*/


### PR DESCRIPTION
The utility function vk::su::createInstance either creates a default DispatchLoaderDynamic, or prepares usage of DebugUtilsMessenger with a DispatchLoaderStatic as the default.