### PR TITLE
Make ConstExpressionArrayCopy::copy() a constexpr with C++14 earliest.

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -4924,7 +4924,7 @@ static const std::string constExpressionArrayCopy = R"(
   class ConstExpressionArrayCopy
   {
     public:
-      VULKAN_HPP_CONSTEXPR static void copy(T dst[N], std::array<T,N> const& src)
+      VULKAN_HPP_CONSTEXPR_14 static void copy(T dst[N], std::array<T,N> const& src)
       {
         dst[I-1] = src[I-1];
         ConstExpressionArrayCopy<T, N, I - 1>::copy(dst, src);
@@ -4935,7 +4935,7 @@ static const std::string constExpressionArrayCopy = R"(
   class ConstExpressionArrayCopy<T, N, 0>
   {
     public:
-      VULKAN_HPP_CONSTEXPR static void copy(T /*dst*/[N], std::array<T,N> const& /*src*/) {}
+      VULKAN_HPP_CONSTEXPR_14 static void copy(T /*dst*/[N], std::array<T,N> const& /*src*/) {}
   };
 )";
 

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -2660,7 +2660,7 @@ namespace VULKAN_HPP_NAMESPACE
   class ConstExpressionArrayCopy
   {
     public:
-      VULKAN_HPP_CONSTEXPR static void copy(T dst[N], std::array<T,N> const& src)
+      VULKAN_HPP_CONSTEXPR_14 static void copy(T dst[N], std::array<T,N> const& src)
       {
         dst[I-1] = src[I-1];
         ConstExpressionArrayCopy<T, N, I - 1>::copy(dst, src);
@@ -2671,7 +2671,7 @@ namespace VULKAN_HPP_NAMESPACE
   class ConstExpressionArrayCopy<T, N, 0>
   {
     public:
-      VULKAN_HPP_CONSTEXPR static void copy(T /*dst*/[N], std::array<T,N> const& /*src*/) {}
+      VULKAN_HPP_CONSTEXPR_14 static void copy(T /*dst*/[N], std::array<T,N> const& /*src*/) {}
   };
 
   using Bool32 = uint32_t;


### PR DESCRIPTION
Resolves #393.