### PR TITLE
Disable CTAD on ArrayProxy's constructors

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -4383,7 +4383,7 @@ int main( int argc, char **argv )
       , m_ptr(nullptr)
     {}
 
-    ArrayProxy(T & ptr) VULKAN_HPP_NOEXCEPT
+    ArrayProxy(typename std::remove_reference<T>::type & ptr) VULKAN_HPP_NOEXCEPT
       : m_count(1)
       , m_ptr(&ptr)
     {}

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -4417,7 +4417,7 @@ int main( int argc, char **argv )
       , m_ptr(data.data())
     {}
 
-    ArrayProxy(std::initializer_list<T> const& data) VULKAN_HPP_NOEXCEPT
+    ArrayProxy(std::initializer_list<typename std::remove_reference<T>::type> const& data) VULKAN_HPP_NOEXCEPT
       : m_count(static_cast<uint32_t>(data.end() - data.begin()))
       , m_ptr(data.begin())
     {}

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -168,7 +168,7 @@ namespace VULKAN_HPP_NAMESPACE
       , m_ptr(nullptr)
     {}
 
-    ArrayProxy(T & ptr) VULKAN_HPP_NOEXCEPT
+    ArrayProxy(typename std::remove_reference<T>::type & ptr) VULKAN_HPP_NOEXCEPT
       : m_count(1)
       , m_ptr(&ptr)
     {}

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -202,7 +202,7 @@ namespace VULKAN_HPP_NAMESPACE
       , m_ptr(data.data())
     {}
 
-    ArrayProxy(std::initializer_list<T> const& data) VULKAN_HPP_NOEXCEPT
+    ArrayProxy(std::initializer_list<typename std::remove_reference<T>::type> const& data) VULKAN_HPP_NOEXCEPT
       : m_count(static_cast<uint32_t>(data.end() - data.begin()))
       , m_ptr(data.begin())
     {}


### PR DESCRIPTION
When you use `vk::ArrayProxy` with C++17 Class Template Argument Deduction(CTAD), template parameter `T` always deduced into argument type of constructor because `ArrayProxy(T & ptr)` always produces best match than other constructors for `std::array` or `std::vector`.  
```cpp
std::array<int, 42> array;
vk::ArrayProxy prox = array;  // vk::ArrayProxy<std::array<int, 42>>
prox.size(); // 1!
```
This is very counter-intuitive and potentially becomes a source of nasty bugs.  
This PR disables CTAD on `ArrayProxy(T &)` by changing it to `ArrayProxy(typename std::remove_reference<T>::type &)` so compilers no longer be able to deduce `T` from argument.  
I'll probably do the same on `ArrayProxy(std::initializer_list<T> const&)` too.

In the future, we can add deduction guides to enable CTAD with C++17 support.