### PR TITLE
Add a couple of new samples, improved some others:

### DIFF
--- a/samples/InstanceLayerProperties/InstanceLayerProperties.cpp
+++ b/samples/InstanceLayerProperties/InstanceLayerProperties.cpp
@@ -24,12 +24,6 @@
 static char const* AppName = "InstanceLayerProperties";
 static char const* EngineName = "Vulkan.hpp";
 
-void extract_version(uint32_t version, uint32_t &major, uint32_t &minor, uint32_t &patch) {
-  major = version >> 22;
-  minor = (version >> 12) & 0x3ff;
-  patch = version & 0xfff;
-}
-
 int main(int /*argc*/, char ** /*argv*/)
 {
   try

--- a/samples/InstanceVersion/CMakeLists.txt
+++ b/samples/InstanceVersion/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Copyright(c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.2)
+
+project(InstanceVersion)
+
+set(HEADERS
+)
+
+set(SOURCES
+  InstanceVersion.cpp
+)
+
+source_group(headers FILES ${HEADERS})
+source_group(sources FILES ${SOURCES})
+
+add_definitions(-DVULKAN_HPP_DISPATCH_LOADER_DYNAMIC=0)
+
+add_executable(InstanceVersion
+  ${HEADERS}
+  ${SOURCES}
+)
+
+set_target_properties(InstanceVersion PROPERTIES FOLDER "Samples")
+target_link_libraries(InstanceVersion PUBLIC "${Vulkan_LIBRARIES}")

--- a/samples/InstanceVersion/InstanceVersion.cpp
+++ b/samples/InstanceVersion/InstanceVersion.cpp
@@ -12,15 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// VulkanHpp Samples : InstanceExtensionProperties
-//                     Get global extension properties to know what extension are available to enable at CreateInstance time.
+// VulkanHpp Samples : InstanceVersion
+//                     Get the version of instance-level functionality supported by the implementation.
 
 #include "vulkan/vulkan.hpp"
 #include <iostream>
 #include <sstream>
 
-static char const* AppName = "InstanceExtensionProperties";
+static char const* AppName = "InstanceVersion";
 static char const* EngineName = "Vulkan.hpp";
+
+std::string decodeAPIVersion(uint32_t apiVersion)
+{
+  return std::to_string(VK_VERSION_MAJOR(apiVersion)) + "." + std::to_string(VK_VERSION_MINOR(apiVersion)) + "." + std::to_string(VK_VERSION_PATCH(apiVersion));
+}
 
 int main(int /*argc*/, char ** /*argv*/)
 {
@@ -28,19 +33,8 @@ int main(int /*argc*/, char ** /*argv*/)
   {
     /* VULKAN_KEY_START */
 
-    std::vector<vk::ExtensionProperties> extensionProperties = vk::enumerateInstanceExtensionProperties();
-
-    // sort the extensions alphabetically
-
-    std::sort(extensionProperties.begin(), extensionProperties.end(), [](vk::ExtensionProperties const& a, vk::ExtensionProperties const& b) { return strcmp(a.extensionName, b.extensionName) < 0; });
-
-    std::cout << "Instance Extensions:" << std::endl;
-    for (auto const& ep : extensionProperties)
-    {
-      std::cout << ep.extensionName << ":" << std::endl;
-      std::cout << "\tVersion: " << ep.specVersion << std::endl;
-      std::cout << std::endl;
-    }
+    uint32_t apiVersion = vk::enumerateInstanceVersion();
+    std::cout << "APIVersion = " << decodeAPIVersion(apiVersion);
 
     /* VULKAN_KEY_END */
   }

--- a/samples/PhysicalDeviceExtensions/CMakeLists.txt
+++ b/samples/PhysicalDeviceExtensions/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright(c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.2)
+
+project(PhysicalDeviceExtensions)
+
+set(HEADERS
+  ../utils/utils.hpp
+)
+
+set(SOURCES
+  PhysicalDeviceExtensions.cpp
+  ../utils/utils.cpp
+)
+
+source_group(headers FILES ${HEADERS})
+source_group(sources FILES ${SOURCES})
+
+add_executable(PhysicalDeviceExtensions
+  ${HEADERS}
+  ${SOURCES}
+)
+
+set_target_properties(PhysicalDeviceExtensions PROPERTIES FOLDER "Samples")
+target_link_libraries(PhysicalDeviceExtensions PUBLIC "$ENV{VULKAN_SDK}/Lib/vulkan-1.lib"
+)

--- a/samples/PhysicalDeviceExtensions/PhysicalDeviceExtensions.cpp
+++ b/samples/PhysicalDeviceExtensions/PhysicalDeviceExtensions.cpp
@@ -1,0 +1,72 @@
+// Copyright(c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// VulkanHpp Samples : DeviceExtensionProperties
+//                     Get extension properties per physical device.
+
+#include "../utils/utils.hpp"
+#include "vulkan/vulkan.hpp"
+#include <vector>
+
+static char const* AppName = "DeviceExtensionProperties";
+static char const* EngineName = "Vulkan.hpp";
+
+int main(int /*argc*/, char ** /*argv*/)
+{
+  try
+  {
+    vk::UniqueInstance instance = vk::su::createInstance(AppName, EngineName);
+#if !defined(NDEBUG)
+    vk::UniqueDebugUtilsMessengerEXT debugUtilsMessenger = vk::su::createDebugUtilsMessenger(instance);
+#endif
+
+    // enumerate the physicalDevices
+    std::vector<vk::PhysicalDevice> physicalDevices = instance->enumeratePhysicalDevices();
+
+    /* VULKAN_KEY_START */
+
+    for (size_t i=0 ; i<physicalDevices.size() ; i++)
+    {
+      std::cout << "PhysicalDevice " << i << "\n";
+      std::vector<vk::ExtensionProperties> extensionProperties = physicalDevices[i].enumerateDeviceExtensionProperties();
+
+      // sort the extensions alphabetically
+      std::sort(extensionProperties.begin(), extensionProperties.end(), [](vk::ExtensionProperties const& a, vk::ExtensionProperties const& b) { return strcmp(a.extensionName, b.extensionName) < 0; });
+      for (auto const& ep : extensionProperties)
+      {
+        std::cout << "\t" << ep.extensionName << ":" << std::endl;
+        std::cout << "\t\tVersion: " << ep.specVersion << std::endl;
+        std::cout << std::endl;
+      }
+    }
+
+    /* VULKAN_KEY_END */
+  }
+  catch (vk::SystemError err)
+  {
+    std::cout << "vk::SystemError: " << err.what() << std::endl;
+    exit(-1);
+  }
+  catch (std::runtime_error err)
+  {
+    std::cout << "std::runtime_error: " << err.what() << std::endl;
+    exit(-1);
+  }
+  catch (...)
+  {
+    std::cout << "unknown error\n";
+    exit(-1);
+  }
+  return 0;
+}

--- a/samples/PhysicalDeviceFeatures/CMakeLists.txt
+++ b/samples/PhysicalDeviceFeatures/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright(c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.2)
+
+project(PhysicalDeviceFeatures)
+
+set(HEADERS
+  ../utils/utils.hpp
+)
+
+set(SOURCES
+  PhysicalDeviceFeatures.cpp
+  ../utils/utils.cpp
+)
+
+source_group(headers FILES ${HEADERS})
+source_group(sources FILES ${SOURCES})
+
+add_executable(PhysicalDeviceFeatures
+  ${HEADERS}
+  ${SOURCES}
+)
+
+set_target_properties(PhysicalDeviceFeatures PROPERTIES FOLDER "Samples")
+target_link_libraries(PhysicalDeviceFeatures PUBLIC "$ENV{VULKAN_SDK}/Lib/vulkan-1.lib"
+)

--- a/samples/PhysicalDeviceFeatures/PhysicalDeviceFeatures.cpp
+++ b/samples/PhysicalDeviceFeatures/PhysicalDeviceFeatures.cpp
@@ -1,0 +1,584 @@
+// Copyright(c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// VulkanHpp Samples : PhysicalDeviceFeatures
+//                     Get the fine-grained features of the physical devices that can be supported by an implementation.
+
+#include "../utils/utils.hpp"
+#include "vulkan/vulkan.hpp"
+#include <vector>
+
+static char const* AppName = "PhysicalDeviceFeatures";
+static char const* EngineName = "Vulkan.hpp";
+
+int main(int /*argc*/, char ** /*argv*/)
+{
+  try
+  {
+    vk::UniqueInstance instance = vk::su::createInstance(AppName, EngineName);
+#if !defined(NDEBUG)
+    vk::UniqueDebugUtilsMessengerEXT debugUtilsMessenger = vk::su::createDebugUtilsMessenger(instance);
+#endif
+
+    // enumerate the physicalDevices
+    std::vector<vk::PhysicalDevice> physicalDevices = instance->enumeratePhysicalDevices();
+
+    /* VULKAN_KEY_START */
+
+    std::cout << std::boolalpha;
+    for (size_t i=0 ; i<physicalDevices.size() ; i++)
+    {
+      // some features are only valid, if a corresponding extension is available!
+      std::vector<vk::ExtensionProperties> extensionProperties = physicalDevices[i].enumerateDeviceExtensionProperties();
+
+      std::cout << "PhysicalDevice " << i << "\n";
+      auto features2 = physicalDevices[i].getFeatures2<vk::PhysicalDeviceFeatures2, vk::PhysicalDevice16BitStorageFeatures, vk::PhysicalDevice8BitStorageFeaturesKHR,
+                                                       vk::PhysicalDeviceASTCDecodeFeaturesEXT, vk::PhysicalDeviceBlendOperationAdvancedFeaturesEXT,
+                                                       vk::PhysicalDeviceBufferDeviceAddressFeaturesEXT, vk::PhysicalDeviceCoherentMemoryFeaturesAMD,
+                                                       vk::PhysicalDeviceComputeShaderDerivativesFeaturesNV, vk::PhysicalDeviceConditionalRenderingFeaturesEXT,
+                                                       vk::PhysicalDeviceCooperativeMatrixFeaturesNV, vk::PhysicalDeviceCornerSampledImageFeaturesNV,
+                                                       vk::PhysicalDeviceCoverageReductionModeFeaturesNV, vk::PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV,
+                                                       vk::PhysicalDeviceDepthClipEnableFeaturesEXT, vk::PhysicalDeviceDescriptorIndexingFeaturesEXT, vk::PhysicalDeviceExclusiveScissorFeaturesNV,
+                                                       vk::PhysicalDeviceFragmentDensityMapFeaturesEXT, vk::PhysicalDeviceFragmentShaderBarycentricFeaturesNV,
+                                                       vk::PhysicalDeviceFragmentShaderInterlockFeaturesEXT, vk::PhysicalDeviceHostQueryResetFeaturesEXT,
+                                                       vk::PhysicalDeviceImagelessFramebufferFeaturesKHR, vk::PhysicalDeviceIndexTypeUint8FeaturesEXT,
+                                                       vk::PhysicalDeviceInlineUniformBlockFeaturesEXT, vk::PhysicalDeviceLineRasterizationFeaturesEXT,
+                                                       vk::PhysicalDeviceMemoryPriorityFeaturesEXT, vk::PhysicalDeviceMeshShaderFeaturesNV, vk::PhysicalDeviceMultiviewFeatures,
+                                                       vk::PhysicalDevicePipelineExecutablePropertiesFeaturesKHR, vk::PhysicalDeviceProtectedMemoryFeatures,
+                                                       vk::PhysicalDeviceRepresentativeFragmentTestFeaturesNV, vk::PhysicalDeviceSamplerYcbcrConversionFeatures,
+                                                       vk::PhysicalDeviceScalarBlockLayoutFeaturesEXT, vk::PhysicalDeviceShaderAtomicInt64FeaturesKHR,
+                                                       vk::PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT, vk::PhysicalDeviceShaderDrawParametersFeatures,
+                                                       vk::PhysicalDeviceShaderFloat16Int8FeaturesKHR, vk::PhysicalDeviceShaderImageFootprintFeaturesNV,
+                                                       vk::PhysicalDeviceShaderIntegerFunctions2FeaturesINTEL, vk::PhysicalDeviceShaderSMBuiltinsFeaturesNV,
+                                                       vk::PhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR, vk::PhysicalDeviceShadingRateImageFeaturesNV,
+                                                       vk::PhysicalDeviceSubgroupSizeControlFeaturesEXT, vk::PhysicalDeviceTexelBufferAlignmentFeaturesEXT,
+                                                       vk::PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT, vk::PhysicalDeviceTimelineSemaphoreFeaturesKHR,
+                                                       vk::PhysicalDeviceTransformFeedbackFeaturesEXT, vk::PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR,
+                                                       vk::PhysicalDeviceVariablePointersFeatures, vk::PhysicalDeviceVertexAttributeDivisorFeaturesEXT,
+                                                       vk::PhysicalDeviceVulkanMemoryModelFeaturesKHR, vk::PhysicalDeviceYcbcrImageArraysFeaturesEXT>();
+      vk::PhysicalDeviceFeatures const& features = features2.get<vk::PhysicalDeviceFeatures2>().features;
+      std::cout << "\tFeatures:\n";
+      std::cout << "\t\talphaToOne                              : " << static_cast<bool>(features.alphaToOne) << "\n";
+      std::cout << "\t\tdepthBiasClamp                          : " << static_cast<bool>(features.depthBiasClamp) << "\n";
+      std::cout << "\t\tdepthBounds                             : " << static_cast<bool>(features.depthBounds) << "\n";
+      std::cout << "\t\tdepthClamp                              : " << static_cast<bool>(features.depthClamp) << "\n";
+      std::cout << "\t\tdrawIndirectFirstInstance               : " << static_cast<bool>(features.drawIndirectFirstInstance) << "\n";
+      std::cout << "\t\tdualSrcBlend                            : " << static_cast<bool>(features.dualSrcBlend) << "\n";
+      std::cout << "\t\tfillModeNonSolid                        : " << static_cast<bool>(features.fillModeNonSolid) << "\n";
+      std::cout << "\t\tfragmentStoresAndAtomics                : " << static_cast<bool>(features.fragmentStoresAndAtomics) << "\n";
+      std::cout << "\t\tfullDrawIndexUint32                     : " << static_cast<bool>(features.fullDrawIndexUint32) << "\n";
+      std::cout << "\t\tgeometryShader                          : " << static_cast<bool>(features.geometryShader) << "\n";
+      std::cout << "\t\timageCubeArray                          : " << static_cast<bool>(features.imageCubeArray) << "\n";
+      std::cout << "\t\tindependentBlend                        : " << static_cast<bool>(features.independentBlend) << "\n";
+      std::cout << "\t\tinheritedQueries                        : " << static_cast<bool>(features.inheritedQueries) << "\n";
+      std::cout << "\t\tlargePoints                             : " << static_cast<bool>(features.largePoints) << "\n";
+      std::cout << "\t\tlogicOp                                 : " << static_cast<bool>(features.logicOp) << "\n";
+      std::cout << "\t\tmultiDrawIndirect                       : " << static_cast<bool>(features.multiDrawIndirect) << "\n";
+      std::cout << "\t\tmultiViewport                           : " << static_cast<bool>(features.multiViewport) << "\n";
+      std::cout << "\t\tocclusionQueryPrecise                   : " << static_cast<bool>(features.occlusionQueryPrecise) << "\n";
+      std::cout << "\t\tpipelineStatisticsQuery                 : " << static_cast<bool>(features.pipelineStatisticsQuery) << "\n";
+      std::cout << "\t\trobustBufferAccess                      : " << static_cast<bool>(features.robustBufferAccess) << "\n";
+      std::cout << "\t\tsamplerAnisotropy                       : " << static_cast<bool>(features.samplerAnisotropy) << "\n";
+      std::cout << "\t\tsampleRateShading                       : " << static_cast<bool>(features.sampleRateShading) << "\n";
+      std::cout << "\t\tshaderClipDistance                      : " << static_cast<bool>(features.shaderClipDistance) << "\n";
+      std::cout << "\t\tshaderCullDistance                      : " << static_cast<bool>(features.shaderCullDistance) << "\n";
+      std::cout << "\t\tshaderFloat64                           : " << static_cast<bool>(features.shaderFloat64) << "\n";
+      std::cout << "\t\tshaderImageGatherExtended               : " << static_cast<bool>(features.shaderImageGatherExtended) << "\n";
+      std::cout << "\t\tshaderInt16                             : " << static_cast<bool>(features.shaderInt16) << "\n";
+      std::cout << "\t\tshaderInt64                             : " << static_cast<bool>(features.shaderInt64) << "\n";
+      std::cout << "\t\tshaderResourceMinLod                    : " << static_cast<bool>(features.shaderResourceMinLod) << "\n";
+      std::cout << "\t\tshaderResourceResidency                 : " << static_cast<bool>(features.shaderResourceResidency) << "\n";
+      std::cout << "\t\tshaderSampledImageArrayDynamicIndexing  : " << static_cast<bool>(features.shaderSampledImageArrayDynamicIndexing) << "\n";
+      std::cout << "\t\tshaderStorageBufferArrayDynamicIndexing : " << static_cast<bool>(features.shaderStorageBufferArrayDynamicIndexing) << "\n";
+      std::cout << "\t\tshaderStorageImageArrayDynamicIndexing  : " << static_cast<bool>(features.shaderStorageImageArrayDynamicIndexing) << "\n";
+      std::cout << "\t\tshaderStorageImageExtendedFormats       : " << static_cast<bool>(features.shaderStorageImageExtendedFormats) << "\n";
+      std::cout << "\t\tshaderStorageImageMultisample           : " << static_cast<bool>(features.shaderStorageImageMultisample) << "\n";
+      std::cout << "\t\tshaderStorageImageReadWithoutFormat     : " << static_cast<bool>(features.shaderStorageImageReadWithoutFormat) << "\n";
+      std::cout << "\t\tshaderStorageImageWriteWithoutFormat    : " << static_cast<bool>(features.shaderStorageImageWriteWithoutFormat) << "\n";
+      std::cout << "\t\tshaderTessellationAndGeometryPointSize  : " << static_cast<bool>(features.shaderTessellationAndGeometryPointSize) << "\n";
+      std::cout << "\t\tshaderUniformBufferArrayDynamicIndexing : " << static_cast<bool>(features.shaderUniformBufferArrayDynamicIndexing) << "\n";
+      std::cout << "\t\tsparseBinding                           : " << static_cast<bool>(features.sparseBinding) << "\n";
+      std::cout << "\t\tsparseResidency16Samples                : " << static_cast<bool>(features.sparseResidency16Samples) << "\n";
+      std::cout << "\t\tsparseResidency2Samples                 : " << static_cast<bool>(features.sparseResidency2Samples) << "\n";
+      std::cout << "\t\tsparseResidency4Samples                 : " << static_cast<bool>(features.sparseResidency4Samples) << "\n";
+      std::cout << "\t\tsparseResidency8Samples                 : " << static_cast<bool>(features.sparseResidency8Samples) << "\n";
+      std::cout << "\t\tsparseResidencyAliased                  : " << static_cast<bool>(features.sparseResidencyAliased) << "\n";
+      std::cout << "\t\tsparseResidencyBuffer                   : " << static_cast<bool>(features.sparseResidencyBuffer) << "\n";
+      std::cout << "\t\tsparseResidencyImage2D                  : " << static_cast<bool>(features.sparseResidencyImage2D) << "\n";
+      std::cout << "\t\tsparseResidencyImage3D                  : " << static_cast<bool>(features.sparseResidencyImage3D) << "\n";
+      std::cout << "\t\ttessellationShader                      : " << static_cast<bool>(features.tessellationShader) << "\n";
+      std::cout << "\t\ttextureCompressionASTC_LDR              : " << static_cast<bool>(features.textureCompressionASTC_LDR) << "\n";
+      std::cout << "\t\ttextureCompressionBC                    : " << static_cast<bool>(features.textureCompressionBC) << "\n";
+      std::cout << "\t\ttextureCompressionETC2                  : " << static_cast<bool>(features.textureCompressionETC2) << "\n";
+      std::cout << "\t\tvariableMultisampleRate                 : " << static_cast<bool>(features.variableMultisampleRate) << "\n";
+      std::cout << "\t\tvertexPipelineStoresAndAtomics          : " << static_cast<bool>(features.vertexPipelineStoresAndAtomics) << "\n";
+      std::cout << "\t\twideLines                               : " << static_cast<bool>(features.wideLines) << "\n";
+      std::cout << "\n";
+
+      vk::PhysicalDevice16BitStorageFeatures const& sixteenBitStorageFeatures = features2.get<vk::PhysicalDevice16BitStorageFeatures>();
+      std::cout << "\t16BitStorageFeatures:\n";
+      std::cout << "\t\tstorageBuffer16BitAccess            : " << static_cast<bool>(sixteenBitStorageFeatures.storageBuffer16BitAccess) << "\n";
+      std::cout << "\t\tstorageInputOutput16                : " << static_cast<bool>(sixteenBitStorageFeatures.storageInputOutput16) << "\n";
+      std::cout << "\t\tstoragePushConstant16               : " << static_cast<bool>(sixteenBitStorageFeatures.storagePushConstant16) << "\n";
+      std::cout << "\t\tuniformAndStorageBuffer16BitAccess  : " << static_cast<bool>(sixteenBitStorageFeatures.uniformAndStorageBuffer16BitAccess) << "\n";
+      std::cout << "\n";
+
+      if (vk::su::contains(extensionProperties, "VK_KHR_8bit_storage"))
+      {
+        vk::PhysicalDevice8BitStorageFeaturesKHR const& eightBitStorageFeatures = features2.get<vk::PhysicalDevice8BitStorageFeaturesKHR>();
+        std::cout << "\t8BitStorageFeatures:\n";
+        std::cout << "\t\tstorageBuffer8BitAccess           : " << static_cast<bool>(eightBitStorageFeatures.storageBuffer8BitAccess) << "\n";
+        std::cout << "\t\tstoragePushConstant8              : " << static_cast<bool>(eightBitStorageFeatures.storagePushConstant8) << "\n";
+        std::cout << "\t\tuniformAndStorageBuffer8BitAccess : " << static_cast<bool>(eightBitStorageFeatures.uniformAndStorageBuffer8BitAccess) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_astc_decode_mode"))
+      {
+        vk::PhysicalDeviceASTCDecodeFeaturesEXT const& astcDecodeFeatures = features2.get<vk::PhysicalDeviceASTCDecodeFeaturesEXT>();
+        std::cout << "\tASTCDecodeFeature:\n";
+        std::cout << "\t\tdecodeModeSharedExponent  : " << static_cast<bool>(astcDecodeFeatures.decodeModeSharedExponent) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_blend_operation_advanced"))
+      {
+        vk::PhysicalDeviceBlendOperationAdvancedFeaturesEXT const& blendOperationAdvancedFeatures = features2.get<vk::PhysicalDeviceBlendOperationAdvancedFeaturesEXT>();
+        std::cout << "\tBlendOperationAdvancedFeatures:\n";
+        std::cout << "\t\tadvancedBlendCoherentOperations : " << static_cast<bool>(blendOperationAdvancedFeatures.advancedBlendCoherentOperations) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_buffer_device_address"))
+      {
+        vk::PhysicalDeviceBufferDeviceAddressFeaturesEXT const& bufferDeviceAddressFeatures = features2.get<vk::PhysicalDeviceBufferDeviceAddressFeaturesEXT>();
+        std::cout << "\tBufferDeviceAddressFeatures:\n";
+        std::cout << "\t\tbufferDeviceAddress               : " << static_cast<bool>(bufferDeviceAddressFeatures.bufferDeviceAddress) << "\n";
+        std::cout << "\t\tbufferDeviceAddressCaptureReplay  : " << static_cast<bool>(bufferDeviceAddressFeatures.bufferDeviceAddressCaptureReplay) << "\n";
+        std::cout << "\t\tbufferDeviceAddressMultiDevice    : " << static_cast<bool>(bufferDeviceAddressFeatures.bufferDeviceAddressMultiDevice) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_AMD_device_coherent_memory"))
+      {
+        vk::PhysicalDeviceCoherentMemoryFeaturesAMD const& coherentMemoryFeatures = features2.get<vk::PhysicalDeviceCoherentMemoryFeaturesAMD>();
+        std::cout << "\tCoherentMemoryFeatures:\n";
+        std::cout << "\t\tdeviceCoherentMemory  : " << static_cast<bool>(coherentMemoryFeatures.deviceCoherentMemory) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_NV_compute_shader_derivatives"))
+      {
+        vk::PhysicalDeviceComputeShaderDerivativesFeaturesNV const& computeShaderDerivativesFeatures = features2.get<vk::PhysicalDeviceComputeShaderDerivativesFeaturesNV>();
+        std::cout << "\tComputeShaderDerivativeFeatures:\n";
+        std::cout << "\t\tcomputeDerivativeGroupLinear  : " << static_cast<bool>(computeShaderDerivativesFeatures.computeDerivativeGroupLinear) << "\n";
+        std::cout << "\t\tcomputeDerivativeGroupQuads   : " << static_cast<bool>(computeShaderDerivativesFeatures.computeDerivativeGroupQuads) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_conditional_rendering"))
+      {
+        vk::PhysicalDeviceConditionalRenderingFeaturesEXT const& conditionalRenderingFeatures = features2.get<vk::PhysicalDeviceConditionalRenderingFeaturesEXT>();
+        std::cout << "\tConditionalRenderingFeatures:\n";
+        std::cout << "\t\tconditionalRendering          : " << static_cast<bool>(conditionalRenderingFeatures.conditionalRendering) << "\n";
+        std::cout << "\t\tinheritedConditionalRendering : " << static_cast<bool>(conditionalRenderingFeatures.inheritedConditionalRendering) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_NV_cooperative_matrix"))
+      {
+        vk::PhysicalDeviceCooperativeMatrixFeaturesNV const& cooperativeMatrixFeatures = features2.get<vk::PhysicalDeviceCooperativeMatrixFeaturesNV>();
+        std::cout << "\tCooperativeMatrixFeatures:\n";
+        std::cout << "\t\tcooperativeMatrix                   : " << static_cast<bool>(cooperativeMatrixFeatures.cooperativeMatrix) << "\n";
+        std::cout << "\t\tcooperativeMatrixRobustBufferAccess : " << static_cast<bool>(cooperativeMatrixFeatures.cooperativeMatrixRobustBufferAccess) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_NV_corner_sampled_image"))
+      {
+        vk::PhysicalDeviceCornerSampledImageFeaturesNV const& cornerSampledImageFeatures = features2.get<vk::PhysicalDeviceCornerSampledImageFeaturesNV>();
+        std::cout << "\tCornerSampledImageFeatures:\n";
+        std::cout << "\t\tcornerSampledImage  : " << static_cast<bool>(cornerSampledImageFeatures.cornerSampledImage) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_NV_coverage_reduction_mode"))
+      {
+        vk::PhysicalDeviceCoverageReductionModeFeaturesNV const& coverageReductionModeFeatures = features2.get<vk::PhysicalDeviceCoverageReductionModeFeaturesNV>();
+        std::cout << "\tCoverageReductionModeFeatures:\n";
+        std::cout << "\t\tcoverageReductionMode : " << static_cast<bool>(coverageReductionModeFeatures.coverageReductionMode) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_NV_dedicated_allocation_image_aliasing"))
+      {
+        vk::PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV const& dedicatedAllocationImageAliasingFeatures = features2.get<vk::PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV>();
+        std::cout << "\tDedicatedAllocationAliasingFeatures:\n";
+        std::cout << "\t\tdedicatedAllocationImageAliasing  : " << static_cast<bool>(dedicatedAllocationImageAliasingFeatures.dedicatedAllocationImageAliasing) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_depth_clip_enable"))
+      {
+        vk::PhysicalDeviceDepthClipEnableFeaturesEXT const& depthClipEnabledFeatures = features2.get<vk::PhysicalDeviceDepthClipEnableFeaturesEXT>();
+        std::cout << "\tDepthClipEnabledFeatures:\n";
+        std::cout << "\t\tdepthClipEnable : " << static_cast<bool>(depthClipEnabledFeatures.depthClipEnable) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_descriptor_indexing"))
+      {
+        vk::PhysicalDeviceDescriptorIndexingFeaturesEXT const& descriptorIndexingFeatures = features2.get<vk::PhysicalDeviceDescriptorIndexingFeaturesEXT>();
+        std::cout << "\tDescriptorIndexingFeatures:\n";
+        std::cout << "\t\tdescriptorBindingPartiallyBound                     : " << static_cast<bool>(descriptorIndexingFeatures.descriptorBindingPartiallyBound) << "\n";
+        std::cout << "\t\tdescriptorBindingSampledImageUpdateAfterBind        : " << static_cast<bool>(descriptorIndexingFeatures.descriptorBindingSampledImageUpdateAfterBind) << "\n";
+        std::cout << "\t\tdescriptorBindingStorageBufferUpdateAfterBind       : " << static_cast<bool>(descriptorIndexingFeatures.descriptorBindingStorageBufferUpdateAfterBind) << "\n";
+        std::cout << "\t\tdescriptorBindingStorageImageUpdateAfterBind        : " << static_cast<bool>(descriptorIndexingFeatures.descriptorBindingStorageImageUpdateAfterBind) << "\n";
+        std::cout << "\t\tdescriptorBindingStorageTexelBufferUpdateAfterBind  : " << static_cast<bool>(descriptorIndexingFeatures.descriptorBindingStorageTexelBufferUpdateAfterBind) << "\n";
+        std::cout << "\t\tdescriptorBindingUniformBufferUpdateAfterBind       : " << static_cast<bool>(descriptorIndexingFeatures.descriptorBindingUniformBufferUpdateAfterBind) << "\n";
+        std::cout << "\t\tdescriptorBindingUniformTexelBufferUpdateAfterBind  : " << static_cast<bool>(descriptorIndexingFeatures.descriptorBindingUniformTexelBufferUpdateAfterBind) << "\n";
+        std::cout << "\t\tdescriptorBindingUpdateUnusedWhilePending           : " << static_cast<bool>(descriptorIndexingFeatures.descriptorBindingUpdateUnusedWhilePending) << "\n";
+        std::cout << "\t\tdescriptorBindingVariableDescriptorCount            : " << static_cast<bool>(descriptorIndexingFeatures.descriptorBindingVariableDescriptorCount) << "\n";
+        std::cout << "\t\truntimeDescriptorArray                              : " << static_cast<bool>(descriptorIndexingFeatures.runtimeDescriptorArray) << "\n";
+        std::cout << "\t\tshaderInputAttachmentArrayDynamicIndexing           : " << static_cast<bool>(descriptorIndexingFeatures.shaderInputAttachmentArrayDynamicIndexing) << "\n";
+        std::cout << "\t\tshaderInputAttachmentArrayNonUniformIndexing        : " << static_cast<bool>(descriptorIndexingFeatures.shaderInputAttachmentArrayNonUniformIndexing) << "\n";
+        std::cout << "\t\tshaderSampledImageArrayNonUniformIndexing           : " << static_cast<bool>(descriptorIndexingFeatures.shaderSampledImageArrayNonUniformIndexing) << "\n";
+        std::cout << "\t\tshaderStorageBufferArrayNonUniformIndexing          : " << static_cast<bool>(descriptorIndexingFeatures.shaderStorageBufferArrayNonUniformIndexing) << "\n";
+        std::cout << "\t\tshaderStorageImageArrayNonUniformIndexing           : " << static_cast<bool>(descriptorIndexingFeatures.shaderStorageImageArrayNonUniformIndexing) << "\n";
+        std::cout << "\t\tshaderStorageTexelBufferArrayDynamicIndexing        : " << static_cast<bool>(descriptorIndexingFeatures.shaderStorageTexelBufferArrayDynamicIndexing) << "\n";
+        std::cout << "\t\tshaderStorageTexelBufferArrayNonUniformIndexing     : " << static_cast<bool>(descriptorIndexingFeatures.shaderStorageTexelBufferArrayNonUniformIndexing) << "\n";
+        std::cout << "\t\tshaderUniformBufferArrayNonUniformIndexing          : " << static_cast<bool>(descriptorIndexingFeatures.shaderUniformBufferArrayNonUniformIndexing) << "\n";
+        std::cout << "\t\tshaderUniformTexelBufferArrayDynamicIndexing        : " << static_cast<bool>(descriptorIndexingFeatures.shaderUniformTexelBufferArrayDynamicIndexing) << "\n";
+        std::cout << "\t\tshaderUniformTexelBufferArrayNonUniformIndexing     : " << static_cast<bool>(descriptorIndexingFeatures.shaderUniformTexelBufferArrayNonUniformIndexing) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_NV_scissor_exclusive"))
+      {
+        vk::PhysicalDeviceExclusiveScissorFeaturesNV const& exclusiveScissorFeatures = features2.get<vk::PhysicalDeviceExclusiveScissorFeaturesNV>();
+        std::cout << "\tExclusiveScissorFeatures:\n";
+        std::cout << "\t\texclusiveScissor  : " << static_cast<bool>(exclusiveScissorFeatures.exclusiveScissor) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_fragment_density_map"))
+      {
+        vk::PhysicalDeviceFragmentDensityMapFeaturesEXT const& fragmentDensityMapFeatures = features2.get<vk::PhysicalDeviceFragmentDensityMapFeaturesEXT>();
+        std::cout << "\tFragmentDensityMapFeatures:\n";
+        std::cout << "\t\tfragmentDensityMap                    : " << static_cast<bool>(fragmentDensityMapFeatures.fragmentDensityMap) << "\n";
+        std::cout << "\t\tfragmentDensityMapDynamic             : " << static_cast<bool>(fragmentDensityMapFeatures.fragmentDensityMapDynamic) << "\n";
+        std::cout << "\t\tfragmentDensityMapNonSubsampledImages : " << static_cast<bool>(fragmentDensityMapFeatures.fragmentDensityMapNonSubsampledImages) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_NV_fragment_shader_barycentric"))
+      {
+        vk::PhysicalDeviceFragmentShaderBarycentricFeaturesNV const& fragmentShaderBarycentricFeatures = features2.get<vk::PhysicalDeviceFragmentShaderBarycentricFeaturesNV>();
+        std::cout << "\tFragmentShaderBarycentricFeatures:\n";
+        std::cout << "\t\tfragmentShaderBarycentric : " << static_cast<bool>(fragmentShaderBarycentricFeatures.fragmentShaderBarycentric) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_fragment_shader_interlock"))
+      {
+        vk::PhysicalDeviceFragmentShaderInterlockFeaturesEXT const& fragmentShaderInterlockFeatures = features2.get<vk::PhysicalDeviceFragmentShaderInterlockFeaturesEXT>();
+        std::cout << "\tFragmentShaderInterlockFeatures:\n";
+        std::cout << "\t\tfragmentShaderPixelInterlock        : " << static_cast<bool>(fragmentShaderInterlockFeatures.fragmentShaderPixelInterlock) << "\n";
+        std::cout << "\t\tfragmentShaderSampleInterlock       : " << static_cast<bool>(fragmentShaderInterlockFeatures.fragmentShaderSampleInterlock) << "\n";
+        std::cout << "\t\tfragmentShaderShadingRateInterlock  : " << static_cast<bool>(fragmentShaderInterlockFeatures.fragmentShaderShadingRateInterlock) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_host_query_reset"))
+      {
+        vk::PhysicalDeviceHostQueryResetFeaturesEXT const& hostQueryResetFeatures = features2.get<vk::PhysicalDeviceHostQueryResetFeaturesEXT>();
+        std::cout << "\tHostQueryResetFeatures:\n";
+        std::cout << "\t\thostQueryReset  : " << static_cast<bool>(hostQueryResetFeatures.hostQueryReset) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_KHR_imageless_framebuffer"))
+      {
+        vk::PhysicalDeviceImagelessFramebufferFeaturesKHR const& imagelessFramebufferFeatures = features2.get<vk::PhysicalDeviceImagelessFramebufferFeaturesKHR>();
+        std::cout << "\tImagelessFramebufferFeatures:\n";
+        std::cout << "\t\timagelessFramebuffer  : " << static_cast<bool>(imagelessFramebufferFeatures.imagelessFramebuffer) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_index_type_uint8"))
+      {
+        vk::PhysicalDeviceIndexTypeUint8FeaturesEXT const& indexTypeUint8Features = features2.get<vk::PhysicalDeviceIndexTypeUint8FeaturesEXT>();
+        std::cout << "\tIndexTypeUint8Features:\n";
+        std::cout << "\t\tindexTypeUint8  : " << static_cast<bool>(indexTypeUint8Features.indexTypeUint8) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_inline_uniform_block"))
+      {
+        vk::PhysicalDeviceInlineUniformBlockFeaturesEXT const& inlineUniformBlockFeatures = features2.get<vk::PhysicalDeviceInlineUniformBlockFeaturesEXT>();
+        std::cout << "\tInlineUniformBlockFeatures:\n";
+        std::cout << "\t\tdescriptorBindingInlineUniformBlockUpdateAfterBind  : " << static_cast<bool>(inlineUniformBlockFeatures.descriptorBindingInlineUniformBlockUpdateAfterBind) << "\n";
+        std::cout << "\t\tinlineUniformBlock                                  : " << static_cast<bool>(inlineUniformBlockFeatures.inlineUniformBlock) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_line_rasterization"))
+      {
+        vk::PhysicalDeviceLineRasterizationFeaturesEXT const& lineRasterizationFeatures = features2.get<vk::PhysicalDeviceLineRasterizationFeaturesEXT>();
+        std::cout << "\tLineRasterizationFeatures:\n";
+        std::cout << "\t\tbresenhamLines            : " << static_cast<bool>(lineRasterizationFeatures.bresenhamLines) << "\n";
+        std::cout << "\t\trectangularLines          : " << static_cast<bool>(lineRasterizationFeatures.rectangularLines) << "\n";
+        std::cout << "\t\tsmoothLines               : " << static_cast<bool>(lineRasterizationFeatures.smoothLines) << "\n";
+        std::cout << "\t\tstippledBresenhamLines    : " << static_cast<bool>(lineRasterizationFeatures.stippledBresenhamLines) << "\n";
+        std::cout << "\t\tstippledRectangularLines  : " << static_cast<bool>(lineRasterizationFeatures.stippledRectangularLines) << "\n";
+        std::cout << "\t\tstippledSmoothLines       : " << static_cast<bool>(lineRasterizationFeatures.stippledSmoothLines) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_memory_priority"))
+      {
+        vk::PhysicalDeviceMemoryPriorityFeaturesEXT const& memoryPriorityFeatures = features2.get<vk::PhysicalDeviceMemoryPriorityFeaturesEXT>();
+        std::cout << "\tMemoryPriorityFeatures:\n";
+        std::cout << "\t\tmemoryPriority  : " << static_cast<bool>(memoryPriorityFeatures.memoryPriority) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_NV_mesh_shader"))
+      {
+        vk::PhysicalDeviceMeshShaderFeaturesNV const& meshShaderFeatures = features2.get<vk::PhysicalDeviceMeshShaderFeaturesNV>();
+        std::cout << "\tMeshShaderFeatures:\n";
+        std::cout << "\t\tmeshShader  : " << static_cast<bool>(meshShaderFeatures.meshShader) << "\n";
+        std::cout << "\t\ttaskShader  : " << static_cast<bool>(meshShaderFeatures.taskShader) << "\n";
+        std::cout << "\n";
+      }
+
+      vk::PhysicalDeviceMultiviewFeatures const& multiviewFeatures = features2.get<vk::PhysicalDeviceMultiviewFeatures>();
+      std::cout << "\tMultiviewFeatures:\n";
+      std::cout << "\t\tmultiview                   : " << static_cast<bool>(multiviewFeatures.multiview) << "\n";
+      std::cout << "\t\tmultiviewGeometryShader     : " << static_cast<bool>(multiviewFeatures.multiviewGeometryShader) << "\n";
+      std::cout << "\t\tmultiviewTessellationShader : " << static_cast<bool>(multiviewFeatures.multiviewTessellationShader) << "\n";
+      std::cout << "\n";
+
+      if (vk::su::contains(extensionProperties, "VK_KHR_pipeline_executable_properties"))
+      {
+        vk::PhysicalDevicePipelineExecutablePropertiesFeaturesKHR const& pipelineExecutablePropertiesFeatures = features2.get<vk::PhysicalDevicePipelineExecutablePropertiesFeaturesKHR>();
+        std::cout << "\tPipelineExectuablePropertiesFeatures:\n";
+        std::cout << "\t\tpipelineExecutableInfo  : " << static_cast<bool>(pipelineExecutablePropertiesFeatures.pipelineExecutableInfo) << "\n";
+        std::cout << "\n";
+      }
+
+      vk::PhysicalDeviceProtectedMemoryFeatures const& protectedMemoryFeatures = features2.get<vk::PhysicalDeviceProtectedMemoryFeatures>();
+      std::cout << "\tProtectedMemoryFeatures:\n";
+      std::cout << "\t\tprotectedMemory : " << static_cast<bool>(protectedMemoryFeatures.protectedMemory) << "\n";
+      std::cout << "\n";
+
+      if (vk::su::contains(extensionProperties, "VK_NV_representative_fragment_test"))
+      {
+        vk::PhysicalDeviceRepresentativeFragmentTestFeaturesNV const& representativeFragmentTestFeatures = features2.get<vk::PhysicalDeviceRepresentativeFragmentTestFeaturesNV>();
+        std::cout << "\tRepresentativeFragmentTestFeatures:\n";
+        std::cout << "\t\trepresentativeFragmentTest  : " << static_cast<bool>(representativeFragmentTestFeatures.representativeFragmentTest) << "\n";
+        std::cout << "\n";
+      }
+
+      vk::PhysicalDeviceSamplerYcbcrConversionFeatures const& samplerYcbcrConversionFeatures = features2.get<vk::PhysicalDeviceSamplerYcbcrConversionFeatures>();
+      std::cout << "\tSamplerYcbcrConversionFeatures:\n";
+      std::cout << "\t\tsamplerYcbcrConversion  : " << static_cast<bool>(samplerYcbcrConversionFeatures.samplerYcbcrConversion) << "\n";
+      std::cout << "\n";
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_scalar_block_layout"))
+      {
+        vk::PhysicalDeviceScalarBlockLayoutFeaturesEXT const& scalarBlockLayoutFeatures = features2.get<vk::PhysicalDeviceScalarBlockLayoutFeaturesEXT>();
+        std::cout << "\tScalarBlockLayoutFeatures:\n";
+        std::cout << "\t\tscalarBlockLayout : " << static_cast<bool>(scalarBlockLayoutFeatures.scalarBlockLayout) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_KHR_shader_atomic_int64"))
+      {
+        vk::PhysicalDeviceShaderAtomicInt64FeaturesKHR const& shaderAtomicInt64Features = features2.get<vk::PhysicalDeviceShaderAtomicInt64FeaturesKHR>();
+        std::cout << "\tShaderAtomicInt64Features:\n";
+        std::cout << "\t\tshaderBufferInt64Atomics  : " << static_cast<bool>(shaderAtomicInt64Features.shaderBufferInt64Atomics) << "\n";
+        std::cout << "\t\tshaderSharedInt64Atomics  : " << static_cast<bool>(shaderAtomicInt64Features.shaderSharedInt64Atomics) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_shader_demote_to_helper_invocation"))
+      {
+        vk::PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT const& shaderDemoteToHelperInvocationFeatures = features2.get<vk::PhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT>();
+        std::cout << "\tShaderDemoteToHelperInvocationFeatures:\n";
+        std::cout << "\t\tshaderDemoteToHelperInvocation  : " << static_cast<bool>(shaderDemoteToHelperInvocationFeatures.shaderDemoteToHelperInvocation) << "\n";
+        std::cout << "\n";
+      }
+
+      vk::PhysicalDeviceShaderDrawParametersFeatures const& shaderDrawParametersFeature = features2.get<vk::PhysicalDeviceShaderDrawParametersFeatures>();
+      std::cout << "\tShaderDrawParametersFeature:\n";
+      std::cout << "\t\tshaderDrawParameters  : " << static_cast<bool>(shaderDrawParametersFeature.shaderDrawParameters) << "\n";
+      std::cout << "\n";
+
+      if (vk::su::contains(extensionProperties, "VK_KHR_shader_float16_int8"))
+      {
+        vk::PhysicalDeviceShaderFloat16Int8FeaturesKHR const& shaderFloat16Int8Features = features2.get<vk::PhysicalDeviceShaderFloat16Int8FeaturesKHR>();
+        std::cout << "\tShaderFloat16Int8Features:\n";
+        std::cout << "\t\tshaderFloat16 : " << static_cast<bool>(shaderFloat16Int8Features.shaderFloat16) << "\n";
+        std::cout << "\t\tshaderInt8    : " << static_cast<bool>(shaderFloat16Int8Features.shaderInt8) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_NV_shader_image_footprint"))
+      {
+        vk::PhysicalDeviceShaderImageFootprintFeaturesNV const& shaderImageFootprintFeatures = features2.get<vk::PhysicalDeviceShaderImageFootprintFeaturesNV>();
+        std::cout << "\tShaderImageFootprintFeatures:\n";
+        std::cout << "\t\timageFootprint  : " << static_cast<bool>(shaderImageFootprintFeatures.imageFootprint) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_INTEL_shader_integer_functions2"))
+      {
+        vk::PhysicalDeviceShaderIntegerFunctions2FeaturesINTEL const& shaderIntegerFunctions2Features = features2.get<vk::PhysicalDeviceShaderIntegerFunctions2FeaturesINTEL>();
+        std::cout << "\tShaderIntegerFunctions2Features:\n";
+        std::cout << "\t\tshaderIntegerFunctions2 : " << static_cast<bool>(shaderIntegerFunctions2Features.shaderIntegerFunctions2) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_NV_shader_sm_builtins"))
+      {
+        vk::PhysicalDeviceShaderSMBuiltinsFeaturesNV const& shaderSMBuiltinsFeatures = features2.get<vk::PhysicalDeviceShaderSMBuiltinsFeaturesNV>();
+        std::cout << "\tShaderSMBuiltinsFeatures:\n";
+        std::cout << "\t\tshaderSMBuiltins  : " << static_cast<bool>(shaderSMBuiltinsFeatures.shaderSMBuiltins) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_KHR_shader_subgroup_extended_types"))
+      {
+        vk::PhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR const& shaderSubgroupExtendedTypesFeatures = features2.get<vk::PhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR>();
+        std::cout << "\tShaderSubgroupExtendedTypeFeatures:\n";
+        std::cout << "\t\tshaderSubgroupExtendedTypes : " << static_cast<bool>(shaderSubgroupExtendedTypesFeatures.shaderSubgroupExtendedTypes) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_NV_shading_rate_image"))
+      {
+        vk::PhysicalDeviceShadingRateImageFeaturesNV const& shadingRateImageFeatures = features2.get<vk::PhysicalDeviceShadingRateImageFeaturesNV>();
+        std::cout << "\tShadingRateImageFeatures:\n";
+        std::cout << "\t\tshadingRateCoarseSampleOrder  : " << static_cast<bool>(shadingRateImageFeatures.shadingRateCoarseSampleOrder) << "\n";
+        std::cout << "\t\tshadingRateImage              : " << static_cast<bool>(shadingRateImageFeatures.shadingRateImage) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_subgroup_size_control"))
+      {
+        vk::PhysicalDeviceSubgroupSizeControlFeaturesEXT const& subgroupSizeControlFeatures = features2.get<vk::PhysicalDeviceSubgroupSizeControlFeaturesEXT>();
+        std::cout << "\tSubgroupSizeControlFeatures:\n";
+        std::cout << "\t\tcomputeFullSubgroups  : " << static_cast<bool>(subgroupSizeControlFeatures.computeFullSubgroups) << "\n";
+        std::cout << "\t\tsubgroupSizeControl   : " << static_cast<bool>(subgroupSizeControlFeatures.subgroupSizeControl) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_texel_buffer_alignment"))
+      {
+        vk::PhysicalDeviceTexelBufferAlignmentFeaturesEXT const& texelBufferAlignmentFeatures = features2.get<vk::PhysicalDeviceTexelBufferAlignmentFeaturesEXT>();
+        std::cout << "\tTexelBufferAlignmentFeatures:\n";
+        std::cout << "\t\ttexelBufferAlignment  : " << static_cast<bool>(texelBufferAlignmentFeatures.texelBufferAlignment) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_texture_compression_astc_hdr"))
+      {
+        vk::PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT const& textureCompressionASTCHDRFeatures = features2.get<vk::PhysicalDeviceTextureCompressionASTCHDRFeaturesEXT>();
+        std::cout << "\tTextureCompressionASTCHHRFeatures:\n";
+        std::cout << "\t\ttextureCompressionASTC_HDR  : " << static_cast<bool>(textureCompressionASTCHDRFeatures.textureCompressionASTC_HDR) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_KHR_timeline_semaphore"))
+      {
+        vk::PhysicalDeviceTimelineSemaphoreFeaturesKHR const& timelineSemaphoreFeatures = features2.get<vk::PhysicalDeviceTimelineSemaphoreFeaturesKHR>();
+        std::cout << "\tTimelineSemaphoreFeatures:\n";
+        std::cout << "\t\ttimelineSemaphore :" << static_cast<bool>(timelineSemaphoreFeatures.timelineSemaphore) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_transform_feedback"))
+      {
+        vk::PhysicalDeviceTransformFeedbackFeaturesEXT const& transformFeedbackFeatures = features2.get<vk::PhysicalDeviceTransformFeedbackFeaturesEXT>();
+        std::cout << "\tTransformFeedbackFeatures:\n";
+        std::cout << "\t\tgeometryStreams : " << static_cast<bool>(transformFeedbackFeatures.geometryStreams) << "\n";
+        std::cout << "\t\ttransformFeedback : " << static_cast<bool>(transformFeedbackFeatures.transformFeedback) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_KHR_uniform_buffer_standard_layout"))
+      {
+        vk::PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR const& uniformBufferStandardLayoutFeatures = features2.get<vk::PhysicalDeviceUniformBufferStandardLayoutFeaturesKHR>();
+        std::cout << "\tUniformBufferStandardLayoutFeatures:\n";
+        std::cout << "\t\tuniformBufferStandardLayout : " << static_cast<bool>(uniformBufferStandardLayoutFeatures.uniformBufferStandardLayout) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_KHR_variable_pointers"))
+      {
+        vk::PhysicalDeviceVariablePointersFeatures const& variablePointersFeatures = features2.get<vk::PhysicalDeviceVariablePointersFeatures>();
+        std::cout << "\tVariablePointersFeatures:\n";
+        std::cout << "\t\tvariablePointers              : " << static_cast<bool>(variablePointersFeatures.variablePointers) << "\n";
+        std::cout << "\t\tvariablePointersStorageBuffer : " << static_cast<bool>(variablePointersFeatures.variablePointersStorageBuffer) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_vertex_attribute_divisor"))
+      {
+        vk::PhysicalDeviceVertexAttributeDivisorFeaturesEXT const& vertexAttributeDivisorFeatures = features2.get<vk::PhysicalDeviceVertexAttributeDivisorFeaturesEXT>();
+        std::cout << "\tVertexAttributeDivisorFeature:\n";
+        std::cout << "\t\tvertexAttributeInstanceRateDivisor      : " << static_cast<bool>(vertexAttributeDivisorFeatures.vertexAttributeInstanceRateDivisor) << "\n";
+        std::cout << "\t\tvertexAttributeInstanceRateZeroDivisor  : " << static_cast<bool>(vertexAttributeDivisorFeatures.vertexAttributeInstanceRateZeroDivisor) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_KHR_vulkan_memory_model"))
+      {
+        vk::PhysicalDeviceVulkanMemoryModelFeaturesKHR const& vulkanMemoryModelFeatures = features2.get<vk::PhysicalDeviceVulkanMemoryModelFeaturesKHR>();
+        std::cout << "\tVulkanMemoryModelFeatures:\n";
+        std::cout << "\t\tvulkanMemoryModel                             : " << static_cast<bool>(vulkanMemoryModelFeatures.vulkanMemoryModel) << "\n";
+        std::cout << "\t\tvulkanMemoryModelAvailabilityVisibilityChains : " << static_cast<bool>(vulkanMemoryModelFeatures.vulkanMemoryModelAvailabilityVisibilityChains) << "\n";
+        std::cout << "\t\tvulkanMemoryModelDeviceScope                  : " << static_cast<bool>(vulkanMemoryModelFeatures.vulkanMemoryModelDeviceScope) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_KHR_sampler_ycbcr_conversion"))
+      {
+        vk::PhysicalDeviceYcbcrImageArraysFeaturesEXT const& ycbcrImageArraysFeatures = features2.get<vk::PhysicalDeviceYcbcrImageArraysFeaturesEXT>();
+        std::cout << "\tYcbcrImageArraysFeatures:\n";
+        std::cout << "\t\tycbcrImageArrays  : " << static_cast<bool>(ycbcrImageArraysFeatures.ycbcrImageArrays) << "\n";
+        std::cout << "\n";
+      }
+    }
+
+    /* VULKAN_KEY_END */
+  }
+  catch (vk::SystemError err)
+  {
+    std::cout << "vk::SystemError: " << err.what() << std::endl;
+    exit(-1);
+  }
+  catch (std::runtime_error err)
+  {
+    std::cout << "std::runtime_error: " << err.what() << std::endl;
+    exit(-1);
+  }
+  catch (...)
+  {
+    std::cout << "unknown error\n";
+    exit(-1);
+  }
+    return 0;
+}

--- a/samples/PhysicalDeviceGroups/CMakeLists.txt
+++ b/samples/PhysicalDeviceGroups/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright(c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.2)
+
+project(PhysicalDeviceGroups)
+
+set(HEADERS
+  ../utils/utils.hpp
+)
+
+set(SOURCES
+  PhysicalDeviceGroups.cpp
+  ../utils/utils.cpp
+)
+
+source_group(headers FILES ${HEADERS})
+source_group(sources FILES ${SOURCES})
+
+add_executable(PhysicalDeviceGroups
+  ${HEADERS}
+  ${SOURCES}
+)
+
+set_target_properties(PhysicalDeviceGroups PROPERTIES FOLDER "Samples")
+target_link_libraries(PhysicalDeviceGroups PUBLIC "$ENV{VULKAN_SDK}/Lib/vulkan-1.lib"
+)

--- a/samples/PhysicalDeviceGroups/PhysicalDeviceGroups.cpp
+++ b/samples/PhysicalDeviceGroups/PhysicalDeviceGroups.cpp
@@ -1,0 +1,95 @@
+// Copyright(c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// VulkanHpp Samples : PhysicalDeviceGroups
+//                     Get the PhysicalDeviceGroups.
+
+#include "../utils/utils.hpp"
+#include "vulkan/vulkan.hpp"
+#include <vector>
+
+static char const* AppName = "PhysicalDeviceGroups";
+static char const* EngineName = "Vulkan.hpp";
+
+int main(int /*argc*/, char ** /*argv*/)
+{
+  try
+  {
+    vk::UniqueInstance instance = vk::su::createInstance(AppName, EngineName);
+#if !defined(NDEBUG)
+    vk::UniqueDebugUtilsMessengerEXT debugUtilsMessenger = vk::su::createDebugUtilsMessenger(instance);
+#endif
+
+    /* VULKAN_KEY_START */
+
+    std::vector<vk::PhysicalDeviceGroupProperties> groupProperties = instance->enumeratePhysicalDeviceGroups();
+
+    std::cout << std::boolalpha;
+    for (size_t i=0 ; i< groupProperties.size() ; i++)
+    {
+      std::cout << "Group Properties " << i << "\n";
+      std::cout << "\t" << "physicalDeviceCount = " << groupProperties[i].physicalDeviceCount << "\n";
+      std::cout << "\t" << "physicalDevices:\n";
+      for (size_t j = 0; j < groupProperties[i].physicalDeviceCount; j++)
+      {
+        std::cout << "\t\t" << j << " : " << groupProperties[i].physicalDevices[j] << "\n";
+      }
+      std::cout << "\t" << "subsetAllocation    = " << static_cast<bool>(groupProperties[i].subsetAllocation) << "\n";
+      std::cout << "\n";
+
+      if (1 < groupProperties[i].physicalDeviceCount)
+      {
+        vk::PhysicalDevice physicalDevice = groupProperties[i].physicalDevices[0];
+
+        // get the QueueFamilyProperties of the first PhysicalDevice
+        std::vector<vk::QueueFamilyProperties> queueFamilyProperties = physicalDevice.getQueueFamilyProperties();
+
+        // get the first index into queueFamiliyProperties which supports graphics
+        size_t graphicsQueueFamilyIndex = std::distance(queueFamilyProperties.begin(),
+                                                        std::find_if(queueFamilyProperties.begin(),
+                                                                     queueFamilyProperties.end(),
+                                                                     [](vk::QueueFamilyProperties const& qfp) { return qfp.queueFlags & vk::QueueFlagBits::eGraphics; }));
+        assert(graphicsQueueFamilyIndex < queueFamilyProperties.size());
+
+        // create a UniqueDevice
+        float queuePriority = 0.0f;
+        vk::DeviceQueueCreateInfo deviceQueueCreateInfo(vk::DeviceQueueCreateFlags(), static_cast<uint32_t>(graphicsQueueFamilyIndex), 1, &queuePriority);
+        vk::DeviceCreateInfo deviceCreateInfo(vk::DeviceCreateFlags(), 1, &deviceQueueCreateInfo);
+
+        vk::DeviceGroupDeviceCreateInfo deviceGroupDeviceCreateInfo(groupProperties[i].physicalDeviceCount, groupProperties[i].physicalDevices);
+        deviceCreateInfo.pNext = &deviceGroupDeviceCreateInfo;
+
+        vk::UniqueDevice device = physicalDevice.createDeviceUnique(deviceCreateInfo);
+      }
+    }
+
+    /* VULKAN_KEY_END */
+  }
+  catch (vk::SystemError err)
+  {
+    std::cout << "vk::SystemError: " << err.what() << std::endl;
+    exit(-1);
+  }
+  catch (std::runtime_error err)
+  {
+    std::cout << "std::runtime_error: " << err.what() << std::endl;
+    exit(-1);
+  }
+  catch (...)
+  {
+    std::cout << "unknown error\n";
+    exit(-1);
+  }
+  return 0;
+}

--- a/samples/PhysicalDeviceMemoryProperties/CMakeLists.txt
+++ b/samples/PhysicalDeviceMemoryProperties/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright(c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.2)
+
+project(PhysicalDeviceMemoryProperties)
+
+set(HEADERS
+  ../utils/utils.hpp
+)
+
+set(SOURCES
+  PhysicalDeviceMemoryProperties.cpp
+  ../utils/utils.cpp
+)
+
+source_group(headers FILES ${HEADERS})
+source_group(sources FILES ${SOURCES})
+
+add_executable(PhysicalDeviceMemoryProperties
+  ${HEADERS}
+  ${SOURCES}
+)
+
+set_target_properties(PhysicalDeviceMemoryProperties PROPERTIES FOLDER "Samples")
+target_link_libraries(PhysicalDeviceMemoryProperties PUBLIC "$ENV{VULKAN_SDK}/Lib/vulkan-1.lib"
+)

--- a/samples/PhysicalDeviceMemoryProperties/PhysicalDeviceMemoryProperties.cpp
+++ b/samples/PhysicalDeviceMemoryProperties/PhysicalDeviceMemoryProperties.cpp
@@ -1,0 +1,106 @@
+// Copyright(c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// VulkanHpp Samples : PhysicalDeviceMemoryProperties
+//                     Get memory properties per physical device.
+
+#include "../utils/utils.hpp"
+#include "vulkan/vulkan.hpp"
+#include <sstream>
+#include <vector>
+
+static char const* AppName = "PhysicalDeviceMemoryProperties";
+static char const* EngineName = "Vulkan.hpp";
+
+std::string formatSize(vk::DeviceSize size)
+{
+  std::ostringstream oss;
+  if (size < 1024)
+  {
+    oss << size << " B";
+  }
+  else if (size < 1024 * 1024)
+  {
+    oss << size / 1024.f << " KB";
+  }
+  else if (size < 1024 * 1024 * 1024)
+  {
+    oss << size / (1024.0f * 1024.0f) << " MB";
+  }
+  else
+  {
+    oss << size / (1024.0f * 1024.0f * 1024.0f) << " GB";
+  }
+  return oss.str();
+}
+
+int main(int /*argc*/, char ** /*argv*/)
+{
+  try
+  {
+    vk::UniqueInstance instance = vk::su::createInstance(AppName, EngineName);
+#if !defined(NDEBUG)
+    vk::UniqueDebugUtilsMessengerEXT debugUtilsMessenger = vk::su::createDebugUtilsMessenger(instance);
+#endif
+
+    // enumerate the physicalDevices
+    std::vector<vk::PhysicalDevice> physicalDevices = instance->enumeratePhysicalDevices();
+
+    /* VULKAN_KEY_START */
+
+    for (size_t i=0 ; i<physicalDevices.size() ; i++)
+    {
+      // some properties are only valid, if a corresponding extension is available!
+      std::vector<vk::ExtensionProperties> extensionProperties = physicalDevices[i].enumerateDeviceExtensionProperties();
+      bool containsMemoryBudget = vk::su::contains(extensionProperties, "VK_EXT_memory_budget");
+
+      std::cout << "PhysicalDevice " << i << "\n";
+      auto memoryProperties2 = physicalDevices[i].getMemoryProperties2<vk::PhysicalDeviceMemoryProperties2, vk::PhysicalDeviceMemoryBudgetPropertiesEXT>();
+      vk::PhysicalDeviceMemoryProperties const& memoryProperties = memoryProperties2.get<vk::PhysicalDeviceMemoryProperties2>().memoryProperties;
+      vk::PhysicalDeviceMemoryBudgetPropertiesEXT const& memoryBudgetProperties = memoryProperties2.get<vk::PhysicalDeviceMemoryBudgetPropertiesEXT>();
+      std::cout << "memoryHeapCount: " << memoryProperties.memoryHeapCount << "\n";
+      for (uint32_t j = 0; j < memoryProperties.memoryHeapCount; j++)
+      {
+        std::cout << "  " << j << ": size = " << formatSize(memoryProperties.memoryHeaps[j].size) << ", flags = " << vk::to_string(memoryProperties.memoryHeaps[j].flags) << "\n";
+        if (containsMemoryBudget)
+        {
+          std::cout << "     heapBudget = " << formatSize(memoryBudgetProperties.heapBudget[j]) << ", heapUsage = " << formatSize(memoryBudgetProperties.heapUsage[j]) << "\n";
+        }
+      }
+      std::cout << "memoryTypeCount: " << memoryProperties.memoryTypeCount << "\n";
+      for (uint32_t j = 0; j < memoryProperties.memoryTypeCount; j++)
+      {
+        std::cout << "  " << j << ": heapIndex = " << memoryProperties.memoryTypes[j].heapIndex << ", flags = " << vk::to_string(memoryProperties.memoryTypes[j].propertyFlags) << "\n";
+      }
+    }
+
+    /* VULKAN_KEY_END */
+  }
+  catch (vk::SystemError err)
+  {
+    std::cout << "vk::SystemError: " << err.what() << std::endl;
+    exit(-1);
+  }
+  catch (std::runtime_error err)
+  {
+    std::cout << "std::runtime_error: " << err.what() << std::endl;
+    exit(-1);
+  }
+  catch (...)
+  {
+    std::cout << "unknown error\n";
+    exit(-1);
+  }
+  return 0;
+}

--- a/samples/PhysicalDeviceProperties/CMakeLists.txt
+++ b/samples/PhysicalDeviceProperties/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright(c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.2)
+
+project(PhysicalDeviceProperties)
+
+set(HEADERS
+  ../utils/utils.hpp
+)
+
+set(SOURCES
+  PhysicalDeviceProperties.cpp
+  ../utils/utils.cpp
+)
+
+source_group(headers FILES ${HEADERS})
+source_group(sources FILES ${SOURCES})
+
+add_executable(PhysicalDeviceProperties
+  ${HEADERS}
+  ${SOURCES}
+)
+
+set_target_properties(PhysicalDeviceProperties PROPERTIES FOLDER "Samples")
+target_link_libraries(PhysicalDeviceProperties PUBLIC "$ENV{VULKAN_SDK}/Lib/vulkan-1.lib"
+)

--- a/samples/PhysicalDeviceProperties/PhysicalDeviceProperties.cpp
+++ b/samples/PhysicalDeviceProperties/PhysicalDeviceProperties.cpp
@@ -1,0 +1,669 @@
+// Copyright(c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// VulkanHpp Samples : PhysicalDeviceProperties
+//                     Get properties per physical device.
+
+#include "../utils/utils.hpp"
+#include "vulkan/vulkan.hpp"
+#include <iomanip>
+#include <sstream>
+#include <vector>
+
+static char const* AppName = "PhysicalDeviceProperties";
+static char const* EngineName = "Vulkan.hpp";
+
+std::string decodeAPIVersion(uint32_t apiVersion)
+{
+  return std::to_string(VK_VERSION_MAJOR(apiVersion)) + "." + std::to_string(VK_VERSION_MINOR(apiVersion)) + "." + std::to_string(VK_VERSION_PATCH(apiVersion));
+}
+
+std::string decodeDriverVersion(uint32_t driverVersion, uint32_t vendorID)
+{
+  switch (vendorID)
+  {
+    case 4318:
+      return std::to_string((driverVersion >> 22) & 0x3FF) + "." + std::to_string((driverVersion >> 14) & 0xFF) + "." + std::to_string((driverVersion >> 6) & 0xFF) + "." + std::to_string(driverVersion & 0x3F);
+    case 0x8086:
+      return std::to_string((driverVersion >> 14) & 0x3FFFF) + "." + std::to_string((driverVersion & 0x3FFF));
+    default:
+      return decodeAPIVersion(driverVersion);
+  }
+}
+
+std::string decodeVendorID(uint32_t vendorID)
+{
+  // below 0x10000 are the PCI vendor IDs (https://pcisig.com/membership/member-companies)
+  if (vendorID < 0x10000)
+  {
+    switch (vendorID)
+    {
+    case 0x1022:
+      return "Advanced Micro Devices";
+    case 0x10DE:
+      return "NVidia Corporation";
+    case 0x8086:
+      return "Intel Corporation";
+    default:
+      return std::to_string(vendorID);
+    }
+  }
+  else
+  {
+    // above 0x10000 should be vkVendorIDs
+    return vk::to_string(vk::VendorId(vendorID));
+  }
+}
+
+namespace vk
+{
+  namespace su
+  {
+    struct LUID
+    {
+    public:
+      LUID(uint8_t const data[VK_LUID_SIZE])
+      {
+        memcpy(m_data, data, VK_LUID_SIZE * sizeof(uint8_t));
+      }
+
+      uint8_t m_data[VK_LUID_SIZE];
+    };
+
+    std::ostream& operator<<(std::ostream& os, LUID const& uuid)
+    {
+      os << std::setfill('0') << std::hex;
+      for (int j = 0; j < VK_LUID_SIZE; ++j)
+      {
+        os << std::setw(2) << static_cast<uint32_t>(uuid.m_data[j]);
+        if (j == 3 || j == 5)
+        {
+          std::cout << '-';
+        }
+      }
+      os << std::setfill(' ') << std::dec;
+      return os;
+    }
+  }
+}
+
+int main(int /*argc*/, char ** /*argv*/)
+{
+  try
+  {
+    vk::UniqueInstance instance = vk::su::createInstance(AppName, EngineName);
+#if !defined(NDEBUG)
+    vk::UniqueDebugUtilsMessengerEXT debugUtilsMessenger = vk::su::createDebugUtilsMessenger(instance);
+#endif
+
+    // enumerate the physicalDevices
+    std::vector<vk::PhysicalDevice> physicalDevices = instance->enumeratePhysicalDevices();
+
+    /* VULKAN_KEY_START */
+
+    std::cout << std::boolalpha;
+    for (size_t i=0 ; i<physicalDevices.size() ; i++)
+    {
+      // some properties are only valid, if a corresponding extension is available!
+      std::vector<vk::ExtensionProperties> extensionProperties = physicalDevices[i].enumerateDeviceExtensionProperties();
+
+      std::cout << "PhysicalDevice " << i << "\n";
+      auto properties2 = physicalDevices[i].getProperties2<vk::PhysicalDeviceProperties2, vk::PhysicalDeviceBlendOperationAdvancedPropertiesEXT,
+                                                           vk::PhysicalDeviceConservativeRasterizationPropertiesEXT, vk::PhysicalDeviceCooperativeMatrixPropertiesNV,
+                                                           vk::PhysicalDeviceDepthStencilResolvePropertiesKHR, vk::PhysicalDeviceDescriptorIndexingPropertiesEXT,
+                                                           vk::PhysicalDeviceDiscardRectanglePropertiesEXT, vk::PhysicalDeviceDriverPropertiesKHR,
+                                                           vk::PhysicalDeviceExternalMemoryHostPropertiesEXT, vk::PhysicalDeviceFloatControlsPropertiesKHR,
+                                                           vk::PhysicalDeviceFragmentDensityMapPropertiesEXT, vk::PhysicalDeviceIDProperties, vk::PhysicalDeviceInlineUniformBlockPropertiesEXT,
+                                                           vk::PhysicalDeviceLineRasterizationPropertiesEXT, vk::PhysicalDeviceMaintenance3Properties, vk::PhysicalDeviceMeshShaderPropertiesNV,
+                                                           vk::PhysicalDeviceMultiviewPerViewAttributesPropertiesNVX, vk::PhysicalDeviceMultiviewProperties,
+                                                           vk::PhysicalDevicePCIBusInfoPropertiesEXT, vk::PhysicalDevicePointClippingProperties, vk::PhysicalDeviceProtectedMemoryProperties,
+                                                           vk::PhysicalDevicePushDescriptorPropertiesKHR, vk::PhysicalDeviceRayTracingPropertiesNV, vk::PhysicalDeviceSampleLocationsPropertiesEXT,
+                                                           vk::PhysicalDeviceSamplerFilterMinmaxPropertiesEXT, vk::PhysicalDeviceShaderCoreProperties2AMD,
+                                                           vk::PhysicalDeviceShaderCorePropertiesAMD, vk::PhysicalDeviceShaderSMBuiltinsPropertiesNV,
+                                                           vk::PhysicalDeviceShadingRateImagePropertiesNV, vk::PhysicalDeviceSubgroupProperties,
+                                                           vk::PhysicalDeviceSubgroupSizeControlPropertiesEXT, vk::PhysicalDeviceTimelineSemaphorePropertiesKHR,
+                                                           vk::PhysicalDeviceTexelBufferAlignmentPropertiesEXT, vk::PhysicalDeviceTransformFeedbackPropertiesEXT,
+                                                           vk::PhysicalDeviceVertexAttributeDivisorPropertiesEXT>();
+      vk::PhysicalDeviceProperties const& properties = properties2.get<vk::PhysicalDeviceProperties2>().properties;
+      std::cout << "\t" << "Properties:\n";
+      std::cout << "\t\t" << "apiVersion        = " << decodeAPIVersion(properties.apiVersion) << "\n";
+      std::cout << "\t\t" << "driverVersion     = " << decodeDriverVersion(properties.driverVersion, properties.vendorID) << "\n";
+      std::cout << "\t\t" << "vendorID          = " << decodeVendorID(properties.vendorID) << "\n";
+      std::cout << "\t\t" << "deviceID          = " << properties.deviceID << "\n";
+      std::cout << "\t\t" << "deviceType        = " << vk::to_string(properties.deviceType) << "\n";
+      std::cout << "\t\t" << "deviceName        = " << properties.deviceName << "\n";
+      std::cout << "\t\t" << "pipelineCacheUUID = " << vk::su::UUID(properties.pipelineCacheUUID) << "\n";
+      std::cout << "\t\t" << "limits:\n";
+      std::cout << "\t\t\t" << "bufferImageGranularity                          = " << properties.limits.bufferImageGranularity << "\n";
+      std::cout << "\t\t\t" << "discreteQueuePriorities                         = " << properties.limits.discreteQueuePriorities << "\n";
+      std::cout << "\t\t\t" << "framebufferColorSampleCounts                    = " << vk::to_string(properties.limits.framebufferColorSampleCounts) << "\n";
+      std::cout << "\t\t\t" << "framebufferDepthSampleCounts                    = " << vk::to_string(properties.limits.framebufferDepthSampleCounts) << "\n";
+      std::cout << "\t\t\t" << "framebufferNoAttachmentsSampleCounts            = " << vk::to_string(properties.limits.framebufferNoAttachmentsSampleCounts) << "\n";
+      std::cout << "\t\t\t" << "framebufferStencilSampleCounts                  = " << vk::to_string(properties.limits.framebufferStencilSampleCounts) << "\n";
+      std::cout << "\t\t\t" << "lineWidthGranularity                            = " << properties.limits.lineWidthGranularity << "\n";
+      std::cout << "\t\t\t" << "lineWidthRange                                  = " << "[" << properties.limits.lineWidthRange[0] << ", " << properties.limits.lineWidthRange[1] << "]" << "\n";
+      std::cout << "\t\t\t" << "maxBoundDescriptorSets                          = " << properties.limits.maxBoundDescriptorSets << "\n";
+      std::cout << "\t\t\t" << "maxClipDistances                                = " << properties.limits.maxClipDistances << "\n";
+      std::cout << "\t\t\t" << "maxColorAttachments                             = " << properties.limits.maxColorAttachments << "\n";
+      std::cout << "\t\t\t" << "maxCombinedClipAndCullDistances                 = " << properties.limits.maxCombinedClipAndCullDistances << "\n";
+      std::cout << "\t\t\t" << "maxComputeSharedMemorySize                      = " << properties.limits.maxComputeSharedMemorySize << "\n";
+      std::cout << "\t\t\t" << "maxComputeWorkGroupCount                        = " << "[" << properties.limits.maxComputeWorkGroupCount[0] << ", " << properties.limits.maxComputeWorkGroupCount[1] << ", " << properties.limits.maxComputeWorkGroupCount[2] << "]" << "\n";
+      std::cout << "\t\t\t" << "maxComputeWorkGroupInvocations                  = " << properties.limits.maxComputeWorkGroupInvocations << "\n";
+      std::cout << "\t\t\t" << "maxComputeWorkGroupSize                         = " << "[" << properties.limits.maxComputeWorkGroupSize[0] << ", " << properties.limits.maxComputeWorkGroupSize[1] << ", " << properties.limits.maxComputeWorkGroupSize[2] << "]" << "\n";
+      std::cout << "\t\t\t" << "maxCullDistances                                = " << properties.limits.maxCullDistances << "\n";
+      std::cout << "\t\t\t" << "maxDescriptorSetInputAttachments                = " << properties.limits.maxDescriptorSetInputAttachments << "\n";
+      std::cout << "\t\t\t" << "maxDescriptorSetSampledImages                   = " << properties.limits.maxDescriptorSetSampledImages << "\n";
+      std::cout << "\t\t\t" << "maxDescriptorSetSamplers                        = " << properties.limits.maxDescriptorSetSamplers << "\n";
+      std::cout << "\t\t\t" << "maxDescriptorSetStorageBuffers                  = " << properties.limits.maxDescriptorSetStorageBuffers << "\n";
+      std::cout << "\t\t\t" << "maxDescriptorSetStorageBuffersDynamic           = " << properties.limits.maxDescriptorSetStorageBuffersDynamic << "\n";
+      std::cout << "\t\t\t" << "maxDescriptorSetStorageImages                   = " << properties.limits.maxDescriptorSetStorageImages << "\n";
+      std::cout << "\t\t\t" << "maxDescriptorSetUniformBuffers                  = " << properties.limits.maxDescriptorSetUniformBuffers << "\n";
+      std::cout << "\t\t\t" << "maxDescriptorSetUniformBuffersDynamic           = " << properties.limits.maxDescriptorSetUniformBuffersDynamic << "\n";
+      std::cout << "\t\t\t" << "maxDrawIndexedIndexValue                        = " << properties.limits.maxDrawIndexedIndexValue << "\n";
+      std::cout << "\t\t\t" << "maxDrawIndirectCount                            = " << properties.limits.maxDrawIndirectCount << "\n";
+      std::cout << "\t\t\t" << "maxFragmentCombinedOutputResources              = " << properties.limits.maxFragmentCombinedOutputResources << "\n";
+      std::cout << "\t\t\t" << "maxFragmentDualSrcAttachments                   = " << properties.limits.maxFragmentDualSrcAttachments << "\n";
+      std::cout << "\t\t\t" << "maxFragmentInputComponents                      = " << properties.limits.maxFragmentInputComponents << "\n";
+      std::cout << "\t\t\t" << "maxFragmentOutputAttachments                    = " << properties.limits.maxFragmentOutputAttachments << "\n";
+      std::cout << "\t\t\t" << "maxFramebufferHeight                            = " << properties.limits.maxFramebufferHeight << "\n";
+      std::cout << "\t\t\t" << "maxFramebufferLayers                            = " << properties.limits.maxFramebufferLayers << "\n";
+      std::cout << "\t\t\t" << "maxFramebufferWidth                             = " << properties.limits.maxFramebufferWidth << "\n";
+      std::cout << "\t\t\t" << "maxGeometryInputComponents                      = " << properties.limits.maxGeometryInputComponents << "\n";
+      std::cout << "\t\t\t" << "maxGeometryOutputComponents                     = " << properties.limits.maxGeometryOutputComponents << "\n";
+      std::cout << "\t\t\t" << "maxGeometryOutputVertices                       = " << properties.limits.maxGeometryOutputVertices << "\n";
+      std::cout << "\t\t\t" << "maxGeometryShaderInvocations                    = " << properties.limits.maxGeometryShaderInvocations << "\n";
+      std::cout << "\t\t\t" << "maxGeometryTotalOutputComponents                = " << properties.limits.maxGeometryTotalOutputComponents << "\n";
+      std::cout << "\t\t\t" << "maxImageArrayLayers                             = " << properties.limits.maxImageArrayLayers << "\n";
+      std::cout << "\t\t\t" << "maxImageDimension1D                             = " << properties.limits.maxImageDimension1D << "\n";
+      std::cout << "\t\t\t" << "maxImageDimension2D                             = " << properties.limits.maxImageDimension2D << "\n";
+      std::cout << "\t\t\t" << "maxImageDimension3D                             = " << properties.limits.maxImageDimension3D << "\n";
+      std::cout << "\t\t\t" << "maxImageDimensionCube                           = " << properties.limits.maxImageDimensionCube << "\n";
+      std::cout << "\t\t\t" << "maxInterpolationOffset                          = " << properties.limits.maxInterpolationOffset << "\n";
+      std::cout << "\t\t\t" << "maxMemoryAllocationCount                        = " << properties.limits.maxMemoryAllocationCount << "\n";
+      std::cout << "\t\t\t" << "maxPerStageDescriptorInputAttachments           = " << properties.limits.maxPerStageDescriptorInputAttachments << "\n";
+      std::cout << "\t\t\t" << "maxPerStageDescriptorSampledImages              = " << properties.limits.maxPerStageDescriptorSampledImages << "\n";
+      std::cout << "\t\t\t" << "maxPerStageDescriptorSamplers                   = " << properties.limits.maxPerStageDescriptorSamplers << "\n";
+      std::cout << "\t\t\t" << "maxPerStageDescriptorStorageBuffers             = " << properties.limits.maxPerStageDescriptorStorageBuffers << "\n";
+      std::cout << "\t\t\t" << "maxPerStageDescriptorStorageImages              = " << properties.limits.maxPerStageDescriptorStorageImages << "\n";
+      std::cout << "\t\t\t" << "maxPerStageDescriptorUniformBuffers             = " << properties.limits.maxPerStageDescriptorUniformBuffers << "\n";
+      std::cout << "\t\t\t" << "maxPerStageResources                            = " << properties.limits.maxPerStageResources << "\n";
+      std::cout << "\t\t\t" << "maxPushConstantsSize                            = " << properties.limits.maxPushConstantsSize << "\n";
+      std::cout << "\t\t\t" << "maxSampleMaskWords                              = " << properties.limits.maxSampleMaskWords << "\n";
+      std::cout << "\t\t\t" << "maxSamplerAllocationCount                       = " << properties.limits.maxSamplerAllocationCount << "\n";
+      std::cout << "\t\t\t" << "maxSamplerAnisotropy                            = " << properties.limits.maxSamplerAnisotropy << "\n";
+      std::cout << "\t\t\t" << "maxSamplerLodBias                               = " << properties.limits.maxSamplerLodBias << "\n";
+      std::cout << "\t\t\t" << "maxStorageBufferRange                           = " << properties.limits.maxStorageBufferRange << "\n";
+      std::cout << "\t\t\t" << "maxTessellationControlPerPatchOutputComponents  = " << properties.limits.maxTessellationControlPerPatchOutputComponents << "\n";
+      std::cout << "\t\t\t" << "maxTessellationControlPerVertexInputComponents  = " << properties.limits.maxTessellationControlPerVertexInputComponents << "\n";
+      std::cout << "\t\t\t" << "maxTessellationControlPerVertexOutputComponents = " << properties.limits.maxTessellationControlPerVertexOutputComponents << "\n";
+      std::cout << "\t\t\t" << "maxTessellationControlTotalOutputComponents     = " << properties.limits.maxTessellationControlTotalOutputComponents << "\n";
+      std::cout << "\t\t\t" << "maxTessellationEvaluationInputComponents        = " << properties.limits.maxTessellationEvaluationInputComponents << "\n";
+      std::cout << "\t\t\t" << "maxTessellationEvaluationOutputComponents       = " << properties.limits.maxTessellationEvaluationOutputComponents << "\n";
+      std::cout << "\t\t\t" << "maxTessellationGenerationLevel                  = " << properties.limits.maxTessellationGenerationLevel << "\n";
+      std::cout << "\t\t\t" << "maxTessellationPatchSize                        = " << properties.limits.maxTessellationPatchSize << "\n";
+      std::cout << "\t\t\t" << "maxTexelBufferElements                          = " << properties.limits.maxTexelBufferElements << "\n";
+      std::cout << "\t\t\t" << "maxTexelGatherOffset                            = " << properties.limits.maxTexelGatherOffset << "\n";
+      std::cout << "\t\t\t" << "maxTexelOffset                                  = " << properties.limits.maxTexelOffset << "\n";
+      std::cout << "\t\t\t" << "maxUniformBufferRange                           = " << properties.limits.maxUniformBufferRange << "\n";
+      std::cout << "\t\t\t" << "maxVertexInputAttributeOffset                   = " << properties.limits.maxVertexInputAttributeOffset << "\n";
+      std::cout << "\t\t\t" << "maxVertexInputAttributes                        = " << properties.limits.maxVertexInputAttributes << "\n";
+      std::cout << "\t\t\t" << "maxVertexInputBindings                          = " << properties.limits.maxVertexInputBindings << "\n";
+      std::cout << "\t\t\t" << "maxVertexInputBindingStride                     = " << properties.limits.maxVertexInputBindingStride << "\n";
+      std::cout << "\t\t\t" << "maxVertexOutputComponents                       = " << properties.limits.maxVertexOutputComponents << "\n";
+      std::cout << "\t\t\t" << "maxViewportDimensions                           = " << "[" << properties.limits.maxViewportDimensions[0] << ", " << properties.limits.maxViewportDimensions[1] << "]" << "\n";
+      std::cout << "\t\t\t" << "maxViewports                                    = " << properties.limits.maxViewports << "\n";
+      std::cout << "\t\t\t" << "minInterpolationOffset                          = " << properties.limits.minInterpolationOffset << "\n";
+      std::cout << "\t\t\t" << "minMemoryMapAlignment                           = " << properties.limits.minMemoryMapAlignment << "\n";
+      std::cout << "\t\t\t" << "minStorageBufferOffsetAlignment                 = " << properties.limits.minStorageBufferOffsetAlignment << "\n";
+      std::cout << "\t\t\t" << "minTexelBufferOffsetAlignment                   = " << properties.limits.minTexelBufferOffsetAlignment << "\n";
+      std::cout << "\t\t\t" << "minTexelGatherOffset                            = " << properties.limits.minTexelGatherOffset << "\n";
+      std::cout << "\t\t\t" << "minTexelOffset                                  = " << properties.limits.minTexelOffset << "\n";
+      std::cout << "\t\t\t" << "minUniformBufferOffsetAlignment                 = " << properties.limits.minUniformBufferOffsetAlignment << "\n";
+      std::cout << "\t\t\t" << "mipmapPrecisionBits                             = " << properties.limits.mipmapPrecisionBits << "\n";
+      std::cout << "\t\t\t" << "nonCoherentAtomSize                             = " << properties.limits.nonCoherentAtomSize << "\n";
+      std::cout << "\t\t\t" << "optimalBufferCopyOffsetAlignment                = " << properties.limits.optimalBufferCopyOffsetAlignment << "\n";
+      std::cout << "\t\t\t" << "optimalBufferCopyRowPitchAlignment              = " << properties.limits.optimalBufferCopyRowPitchAlignment << "\n";
+      std::cout << "\t\t\t" << "pointSizeGranularity                            = " << properties.limits.pointSizeGranularity << "\n";
+      std::cout << "\t\t\t" << "pointSizeRange                                  = " << "[" << properties.limits.pointSizeRange[0] << ", " << properties.limits.pointSizeRange[1] << "]" << "\n";
+      std::cout << "\t\t\t" << "sampledImageColorSampleCounts                   = " << vk::to_string(properties.limits.sampledImageColorSampleCounts) << "\n";
+      std::cout << "\t\t\t" << "sampledImageDepthSampleCounts                   = " << vk::to_string(properties.limits.sampledImageDepthSampleCounts) << "\n";
+      std::cout << "\t\t\t" << "sampledImageIntegerSampleCounts                 = " << vk::to_string(properties.limits.sampledImageIntegerSampleCounts) << "\n";
+      std::cout << "\t\t\t" << "sampledImageStencilSampleCounts                 = " << vk::to_string(properties.limits.sampledImageStencilSampleCounts) << "\n";
+      std::cout << "\t\t\t" << "sparseAddressSpaceSize                          = " << properties.limits.sparseAddressSpaceSize << "\n";
+      std::cout << "\t\t\t" << "standardSampleLocations                         = " << static_cast<bool>(properties.limits.standardSampleLocations) << "\n";
+      std::cout << "\t\t\t" << "storageImageSampleCounts                        = " << vk::to_string(properties.limits.storageImageSampleCounts) << "\n";
+      std::cout << "\t\t\t" << "strictLines                                     = " << static_cast<bool>(properties.limits.strictLines) << "\n";
+      std::cout << "\t\t\t" << "subPixelInterpolationOffsetBits                 = " << properties.limits.subPixelInterpolationOffsetBits << "\n";
+      std::cout << "\t\t\t" << "subPixelPrecisionBits                           = " << properties.limits.subPixelPrecisionBits << "\n";
+      std::cout << "\t\t\t" << "subTexelPrecisionBits                           = " << properties.limits.subTexelPrecisionBits << "\n";
+      std::cout << "\t\t\t" << "timestampComputeAndGraphics                     = " << static_cast<bool>(properties.limits.timestampComputeAndGraphics) << "\n";
+      std::cout << "\t\t\t" << "timestampPeriod                                 = " << properties.limits.timestampPeriod << "\n";
+      std::cout << "\t\t\t" << "viewportBoundsRange                             = " << "[" << properties.limits.viewportBoundsRange[0] << ", " << properties.limits.viewportBoundsRange[1] << "]" << "\n";
+      std::cout << "\t\t\t" << "viewportSubPixelBits                            = " << properties.limits.viewportSubPixelBits << "\n";
+      std::cout << "\t\t" << "sparseProperties:\n";
+      std::cout << "\t\t\t" << "residencyAlignedMipSize                   = " << static_cast<bool>(properties.sparseProperties.residencyAlignedMipSize) << "\n";
+      std::cout << "\t\t\t" << "residencyNonResidentStrict                = " << static_cast<bool>(properties.sparseProperties.residencyNonResidentStrict) << "\n";
+      std::cout << "\t\t\t" << "residencyStandard2DBlockShape             = " << static_cast<bool>(properties.sparseProperties.residencyStandard2DBlockShape) << "\n";
+      std::cout << "\t\t\t" << "residencyStandard2DMultisampleBlockShape  = " << static_cast<bool>(properties.sparseProperties.residencyStandard2DMultisampleBlockShape) << "\n";
+      std::cout << "\t\t\t" << "residencyStandard3DBlockShape             = " << static_cast<bool>(properties.sparseProperties.residencyStandard3DBlockShape) << "\n";
+      std::cout << "\n";
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_blend_operation_advanced"))
+      {
+        vk::PhysicalDeviceBlendOperationAdvancedPropertiesEXT const& blendOperationAdvancedProperties = properties2.get<vk::PhysicalDeviceBlendOperationAdvancedPropertiesEXT>();
+        std::cout << "\t" << "BlendOperationAdvancedProperties:\n";
+        std::cout << "\t\t" << "advancedBlendAllOperations            = " << static_cast<bool>(blendOperationAdvancedProperties.advancedBlendAllOperations) << "\n";
+        std::cout << "\t\t" << "advancedBlendCorrelatedOverlap        = " << static_cast<bool>(blendOperationAdvancedProperties.advancedBlendCorrelatedOverlap) << "\n";
+        std::cout << "\t\t" << "advancedBlendIndependentBlend         = " << static_cast<bool>(blendOperationAdvancedProperties.advancedBlendIndependentBlend) << "\n";
+        std::cout << "\t\t" << "advancedBlendMaxColorAttachments      = " << blendOperationAdvancedProperties.advancedBlendMaxColorAttachments << "\n";
+        std::cout << "\t\t" << "advancedBlendNonPremultipliedDstColor = " << static_cast<bool>(blendOperationAdvancedProperties.advancedBlendNonPremultipliedDstColor) << "\n";
+        std::cout << "\t\t" << "advancedBlendNonPremultipliedSrcColor = " << static_cast<bool>(blendOperationAdvancedProperties.advancedBlendNonPremultipliedSrcColor) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_conservative_rasterization"))
+      {
+        vk::PhysicalDeviceConservativeRasterizationPropertiesEXT const& conservativeRasterizationProperties = properties2.get<vk::PhysicalDeviceConservativeRasterizationPropertiesEXT>();
+        std::cout << "\t" << "ConservativeRasterizationProperties:\n";
+        std::cout << "\t\t" << "conservativePointAndLineRasterization       = " << static_cast<bool>(conservativeRasterizationProperties.conservativePointAndLineRasterization) << "\n";
+        std::cout << "\t\t" << "conservativeRasterizationPostDepthCoverage  = " << static_cast<bool>(conservativeRasterizationProperties.conservativeRasterizationPostDepthCoverage) << "\n";
+        std::cout << "\t\t" << "degenerateLinesRasterized                   = " << static_cast<bool>(conservativeRasterizationProperties.degenerateLinesRasterized) << "\n";
+        std::cout << "\t\t" << "degenerateTrianglesRasterized               = " << static_cast<bool>(conservativeRasterizationProperties.degenerateTrianglesRasterized) << "\n";
+        std::cout << "\t\t" << "extraPrimitiveOverestimationSizeGranularity = " << conservativeRasterizationProperties.extraPrimitiveOverestimationSizeGranularity << "\n";
+        std::cout << "\t\t" << "fullyCoveredFragmentShaderInputVariable     = " << static_cast<bool>(conservativeRasterizationProperties.fullyCoveredFragmentShaderInputVariable) << "\n";
+        std::cout << "\t\t" << "maxExtraPrimitiveOverestimationSize         = " << conservativeRasterizationProperties.maxExtraPrimitiveOverestimationSize << "\n";
+        std::cout << "\t\t" << "primitiveOverestimationSize                 = " << conservativeRasterizationProperties.primitiveOverestimationSize << "\n";
+        std::cout << "\t\t" << "primitiveUnderestimation                    = " << static_cast<bool>(conservativeRasterizationProperties.primitiveUnderestimation) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_NV_cooperative_matrix"))
+      {
+        vk::PhysicalDeviceCooperativeMatrixPropertiesNV const& cooperativeMatrixProperties = properties2.get<vk::PhysicalDeviceCooperativeMatrixPropertiesNV>();
+        std::cout << "\t" << "CooperativeMatrixProperties:\n";
+        std::cout << "\t\t" << "cooperativeMatrixSupportedStages  = " << vk::to_string(cooperativeMatrixProperties.cooperativeMatrixSupportedStages) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_KHR_depth_stencil_resolve"))
+      {
+        vk::PhysicalDeviceDepthStencilResolvePropertiesKHR const& depthStencilResolveProperties = properties2.get<vk::PhysicalDeviceDepthStencilResolvePropertiesKHR>();
+        std::cout << "\t" << "DepthStencilResolveProperties:\n";
+        std::cout << "\t\t" << "independentResolve            = " << static_cast<bool>(depthStencilResolveProperties.independentResolve) << "\n";
+        std::cout << "\t\t" << "independentResolveNone        = " << static_cast<bool>(depthStencilResolveProperties.independentResolveNone) << "\n";
+        std::cout << "\t\t" << "supportedDepthResolveModes    = " << vk::to_string(depthStencilResolveProperties.supportedDepthResolveModes) << "\n";
+        std::cout << "\t\t" << "supportedStencilResolveModes  = " << vk::to_string(depthStencilResolveProperties.supportedStencilResolveModes) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_descriptor_indexing"))
+      {
+        vk::PhysicalDeviceDescriptorIndexingPropertiesEXT const& descriptorIndexingProperties = properties2.get<vk::PhysicalDeviceDescriptorIndexingPropertiesEXT>();
+        std::cout << "\t" << "DescriptorIndexingProperties:\n";
+        std::cout << "\t\t" << "maxDescriptorSetUpdateAfterBindInputAttachments       = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindInputAttachments << "\n";
+        std::cout << "\t\t" << "maxDescriptorSetUpdateAfterBindSampledImages          = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindSampledImages << "\n";
+        std::cout << "\t\t" << "maxDescriptorSetUpdateAfterBindSamplers               = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindSamplers << "\n";
+        std::cout << "\t\t" << "maxDescriptorSetUpdateAfterBindStorageBuffers         = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindStorageBuffers << "\n";
+        std::cout << "\t\t" << "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic  = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindStorageBuffersDynamic << "\n";
+        std::cout << "\t\t" << "maxDescriptorSetUpdateAfterBindStorageImages          = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindStorageImages << "\n";
+        std::cout << "\t\t" << "maxDescriptorSetUpdateAfterBindUniformBuffers         = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindUniformBuffers << "\n";
+        std::cout << "\t\t" << "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic  = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindUniformBuffersDynamic << "\n";
+        std::cout << "\t\t" << "maxPerStageDescriptorUpdateAfterBindInputAttachments  = " << descriptorIndexingProperties.maxPerStageDescriptorUpdateAfterBindInputAttachments << "\n";
+        std::cout << "\t\t" << "maxPerStageDescriptorUpdateAfterBindSampledImages     = " << descriptorIndexingProperties.maxPerStageDescriptorUpdateAfterBindSampledImages << "\n";
+        std::cout << "\t\t" << "maxPerStageDescriptorUpdateAfterBindSamplers          = " << descriptorIndexingProperties.maxPerStageDescriptorUpdateAfterBindSamplers << "\n";
+        std::cout << "\t\t" << "maxPerStageDescriptorUpdateAfterBindStorageBuffers    = " << descriptorIndexingProperties.maxPerStageDescriptorUpdateAfterBindStorageBuffers << "\n";
+        std::cout << "\t\t" << "maxPerStageDescriptorUpdateAfterBindStorageImages     = " << descriptorIndexingProperties.maxPerStageDescriptorUpdateAfterBindStorageImages << "\n";
+        std::cout << "\t\t" << "maxPerStageDescriptorUpdateAfterBindUniformBuffers    = " << descriptorIndexingProperties.maxPerStageDescriptorUpdateAfterBindUniformBuffers << "\n";
+        std::cout << "\t\t" << "maxPerStageUpdateAfterBindResources                   = " << descriptorIndexingProperties.maxPerStageUpdateAfterBindResources << "\n";
+        std::cout << "\t\t" << "maxUpdateAfterBindDescriptorsInAllPools               = " << descriptorIndexingProperties.maxUpdateAfterBindDescriptorsInAllPools << "\n";
+        std::cout << "\t\t" << "quadDivergentImplicitLod                              = " << static_cast<bool>(descriptorIndexingProperties.quadDivergentImplicitLod) << "\n";
+        std::cout << "\t\t" << "robustBufferAccessUpdateAfterBind                     = " << static_cast<bool>(descriptorIndexingProperties.robustBufferAccessUpdateAfterBind) << "\n";
+        std::cout << "\t\t" << "shaderInputAttachmentArrayNonUniformIndexingNative    = " << static_cast<bool>(descriptorIndexingProperties.shaderInputAttachmentArrayNonUniformIndexingNative) << "\n";
+        std::cout << "\t\t" << "shaderSampledImageArrayNonUniformIndexingNative       = " << static_cast<bool>(descriptorIndexingProperties.shaderSampledImageArrayNonUniformIndexingNative) << "\n";
+        std::cout << "\t\t" << "shaderStorageBufferArrayNonUniformIndexingNative      = " << static_cast<bool>(descriptorIndexingProperties.shaderStorageBufferArrayNonUniformIndexingNative) << "\n";
+        std::cout << "\t\t" << "shaderStorageImageArrayNonUniformIndexingNative       = " << static_cast<bool>(descriptorIndexingProperties.shaderStorageImageArrayNonUniformIndexingNative) << "\n";
+        std::cout << "\t\t" << "shaderUniformBufferArrayNonUniformIndexingNative      = " << static_cast<bool>(descriptorIndexingProperties.shaderUniformBufferArrayNonUniformIndexingNative) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_discard_rectangles"))
+      {
+        vk::PhysicalDeviceDiscardRectanglePropertiesEXT const& discardRectangleProperties = properties2.get<vk::PhysicalDeviceDiscardRectanglePropertiesEXT>();
+        std::cout << "\t" << "DiscardRectangleProperties:\n";
+        std::cout << "\t\t" << "maxDiscardRectangles  = " << discardRectangleProperties.maxDiscardRectangles << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_KHR_driver_properties"))
+      {
+        vk::PhysicalDeviceDriverPropertiesKHR const& driverProperties = properties2.get<vk::PhysicalDeviceDriverPropertiesKHR>();
+        std::cout << "\t" << "DriverProperties:\n";
+        std::cout << "\t\t" << "driverID            = " << vk::to_string(driverProperties.driverID) << "\n";
+        std::cout << "\t\t" << "driverName          = " << driverProperties.driverName << "\n";
+        std::cout << "\t\t" << "driverInfo          = " << driverProperties.driverInfo << "\n";
+        std::cout << "\t\t" << "conformanceVersion  = " << static_cast<uint32_t>(driverProperties.conformanceVersion.major) << "." << static_cast<uint32_t>(driverProperties.conformanceVersion.minor) << "." << static_cast<uint32_t>(driverProperties.conformanceVersion.subminor) << "." << static_cast<uint32_t>(driverProperties.conformanceVersion.patch) << std::dec << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_external_memory_host"))
+      {
+        vk::PhysicalDeviceExternalMemoryHostPropertiesEXT const& externalMemoryHostProperties = properties2.get<vk::PhysicalDeviceExternalMemoryHostPropertiesEXT>();
+        std::cout << "\t" << "ExternalMemoryHostProperties:\n";
+        std::cout << "\t\t" << "minImportedHostPointerAlignment = " << externalMemoryHostProperties.minImportedHostPointerAlignment << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_KHR_shader_float_controls"))
+      {
+        vk::PhysicalDeviceFloatControlsPropertiesKHR const& floatControlsProperties = properties2.get<vk::PhysicalDeviceFloatControlsPropertiesKHR>();
+        std::cout << "\t" << "FloatControlsProperties:\n";
+        std::cout << "\t\t" << "denormBehaviorIndependence            = " << vk::to_string(floatControlsProperties.denormBehaviorIndependence) << "\n";
+        std::cout << "\t\t" << "roundingModeIndependence              = " << vk::to_string(floatControlsProperties.roundingModeIndependence) << "\n";
+        std::cout << "\t\t" << "shaderDenormFlushToZeroFloat16        = " << static_cast<bool>(floatControlsProperties.shaderDenormFlushToZeroFloat16) << "\n";
+        std::cout << "\t\t" << "shaderDenormFlushToZeroFloat32        = " << static_cast<bool>(floatControlsProperties.shaderDenormFlushToZeroFloat32) << "\n";
+        std::cout << "\t\t" << "shaderDenormFlushToZeroFloat64        = " << static_cast<bool>(floatControlsProperties.shaderDenormFlushToZeroFloat64) << "\n";
+        std::cout << "\t\t" << "shaderDenormPreserveFloat16           = " << static_cast<bool>(floatControlsProperties.shaderDenormPreserveFloat16) << "\n";
+        std::cout << "\t\t" << "shaderDenormPreserveFloat32           = " << static_cast<bool>(floatControlsProperties.shaderDenormPreserveFloat32) << "\n";
+        std::cout << "\t\t" << "shaderDenormPreserveFloat64           = " << static_cast<bool>(floatControlsProperties.shaderDenormPreserveFloat64) << "\n";
+        std::cout << "\t\t" << "shaderRoundingModeRTEFloat16          = " << static_cast<bool>(floatControlsProperties.shaderRoundingModeRTEFloat16) << "\n";
+        std::cout << "\t\t" << "shaderRoundingModeRTEFloat32          = " << static_cast<bool>(floatControlsProperties.shaderRoundingModeRTEFloat32) << "\n";
+        std::cout << "\t\t" << "shaderRoundingModeRTEFloat64          = " << static_cast<bool>(floatControlsProperties.shaderRoundingModeRTEFloat64) << "\n";
+        std::cout << "\t\t" << "shaderRoundingModeRTZFloat16          = " << static_cast<bool>(floatControlsProperties.shaderRoundingModeRTZFloat16) << "\n";
+        std::cout << "\t\t" << "shaderRoundingModeRTZFloat32          = " << static_cast<bool>(floatControlsProperties.shaderRoundingModeRTZFloat32) << "\n";
+        std::cout << "\t\t" << "shaderRoundingModeRTZFloat64          = " << static_cast<bool>(floatControlsProperties.shaderRoundingModeRTZFloat64) << "\n";
+        std::cout << "\t\t" << "shaderSignedZeroInfNanPreserveFloat16 = " << static_cast<bool>(floatControlsProperties.shaderSignedZeroInfNanPreserveFloat16) << "\n";
+        std::cout << "\t\t" << "shaderSignedZeroInfNanPreserveFloat32 = " << static_cast<bool>(floatControlsProperties.shaderSignedZeroInfNanPreserveFloat32) << "\n";
+        std::cout << "\t\t" << "shaderSignedZeroInfNanPreserveFloat64 = " << static_cast<bool>(floatControlsProperties.shaderSignedZeroInfNanPreserveFloat64) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_fragment_density_map"))
+      {
+        vk::PhysicalDeviceFragmentDensityMapPropertiesEXT const& fragmentDensityMapProperties = properties2.get<vk::PhysicalDeviceFragmentDensityMapPropertiesEXT>();
+        std::cout << "\t" << "FragmentDensityProperties:\n";
+        std::cout << "\t\t" << "fragmentDensityInvocations  = " << static_cast<bool>(fragmentDensityMapProperties.fragmentDensityInvocations) << "\n";
+        std::cout << "\t\t" << "maxFragmentDensityTexelSize = " << fragmentDensityMapProperties.maxFragmentDensityTexelSize.width << " x " << fragmentDensityMapProperties.maxFragmentDensityTexelSize.height << "\n";
+        std::cout << "\t\t" << "minFragmentDensityTexelSize = " << fragmentDensityMapProperties.minFragmentDensityTexelSize.width << " x " << fragmentDensityMapProperties.minFragmentDensityTexelSize.height << "\n";
+        std::cout << "\n";
+      }
+
+      vk::PhysicalDeviceIDProperties const& idProperties = properties2.get<vk::PhysicalDeviceIDProperties>();
+      std::cout << "\t" << "IDProperties:\n";
+      std::cout << "\t\t" << "deviceUUID      = " << vk::su::UUID(idProperties.deviceUUID) << "\n";
+      std::cout << "\t\t" << "driverUUID      = " << vk::su::UUID(idProperties.driverUUID) << "\n";
+      std::cout << "\t\t" << "deviceLUID      = " << vk::su::LUID(idProperties.deviceLUID) << "\n";
+      std::cout << "\t\t" << "deviceNodeMask  = " << std::hex << idProperties.deviceNodeMask << std::dec << "\n";
+      std::cout << "\t\t" << "deviceLUIDValid = " << static_cast<bool>(idProperties.deviceLUIDValid) << "\n";
+      std::cout << "\n";
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_inline_uniform_block"))
+      {
+        vk::PhysicalDeviceInlineUniformBlockPropertiesEXT const& inlineUniformBlockProperties = properties2.get<vk::PhysicalDeviceInlineUniformBlockPropertiesEXT>();
+        std::cout << "\t" << "InlineUniformBlockProperties:\n";
+        std::cout << "\t\t" << "maxDescriptorSetInlineUniformBlocks                     = " << inlineUniformBlockProperties.maxDescriptorSetInlineUniformBlocks << "\n";
+        std::cout << "\t\t" << "maxDescriptorSetUpdateAfterBindInlineUniformBlocks      = " << inlineUniformBlockProperties.maxDescriptorSetUpdateAfterBindInlineUniformBlocks << "\n";
+        std::cout << "\t\t" << "maxInlineUniformBlockSize                               = " << inlineUniformBlockProperties.maxInlineUniformBlockSize << "\n";
+        std::cout << "\t\t" << "maxPerStageDescriptorInlineUniformBlocks                = " << inlineUniformBlockProperties.maxPerStageDescriptorInlineUniformBlocks << "\n";
+        std::cout << "\t\t" << "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks = " << inlineUniformBlockProperties.maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_line_rasterization"))
+      {
+        vk::PhysicalDeviceLineRasterizationPropertiesEXT const& lineRasterizationProperties = properties2.get<vk::PhysicalDeviceLineRasterizationPropertiesEXT>();
+        std::cout << "\t" << "LineRasterizationProperties:\n";
+        std::cout << "\t\t" << "lineSubPixelPrecisionBits = " << lineRasterizationProperties.lineSubPixelPrecisionBits << "\n";
+        std::cout << "\n";
+      }
+
+      vk::PhysicalDeviceMaintenance3Properties const& maintenance3Properties = properties2.get<vk::PhysicalDeviceMaintenance3Properties>();
+      std::cout << "\t" << "Maintenance3Properties:\n";
+      std::cout << "\t\t" << "maxMemoryAllocationSize = " << maintenance3Properties.maxMemoryAllocationSize << "\n";
+      std::cout << "\t\t" << "maxPerSetDescriptors    = " << maintenance3Properties.maxPerSetDescriptors << "\n";
+      std::cout << "\n";
+
+      if (vk::su::contains(extensionProperties, "VK_NV_mesh_shader"))
+      {
+        vk::PhysicalDeviceMeshShaderPropertiesNV const& meshShaderProperties = properties2.get<vk::PhysicalDeviceMeshShaderPropertiesNV>();
+        std::cout << "\t" << "MeshShaderProperties:\n";
+        std::cout << "\t\t" << "maxDrawMeshTasksCount             = " << meshShaderProperties.maxDrawMeshTasksCount << "\n";
+        std::cout << "\t\t" << "maxMeshMultiviewViewCount         = " << meshShaderProperties.maxMeshMultiviewViewCount << "\n";
+        std::cout << "\t\t" << "maxMeshOutputPrimitives           = " << meshShaderProperties.maxMeshOutputPrimitives << "\n";
+        std::cout << "\t\t" << "maxMeshOutputVertices             = " << meshShaderProperties.maxMeshOutputVertices << "\n";
+        std::cout << "\t\t" << "maxMeshTotalMemorySize            = " << meshShaderProperties.maxMeshTotalMemorySize << "\n";
+        std::cout << "\t\t" << "maxMeshWorkGroupInvocations       = " << meshShaderProperties.maxMeshWorkGroupInvocations << "\n";
+        std::cout << "\t\t" << "maxMeshWorkGroupSize              = " << "[" << meshShaderProperties.maxMeshWorkGroupSize[0] << ", " << meshShaderProperties.maxMeshWorkGroupSize[1] << ", " << meshShaderProperties.maxMeshWorkGroupSize[2] << "]" << "\n";
+        std::cout << "\t\t" << "maxTaskOutputCount                = " << meshShaderProperties.maxTaskOutputCount << "\n";
+        std::cout << "\t\t" << "maxTaskTotalMemorySize            = " << meshShaderProperties.maxTaskTotalMemorySize << "\n";
+        std::cout << "\t\t" << "maxTaskWorkGroupInvocations       = " << meshShaderProperties.maxTaskWorkGroupInvocations << "\n";
+        std::cout << "\t\t" << "maxTaskWorkGroupSize              = " << "[" << meshShaderProperties.maxTaskWorkGroupSize[0] << ", " << meshShaderProperties.maxTaskWorkGroupSize[1] << ", " << meshShaderProperties.maxTaskWorkGroupSize[2] << "]" << "\n";
+        std::cout << "\t\t" << "meshOutputPerPrimitiveGranularity = " << meshShaderProperties.meshOutputPerPrimitiveGranularity << "\n";
+        std::cout << "\t\t" << "meshOutputPerVertexGranularity    = " << meshShaderProperties.meshOutputPerVertexGranularity << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_NVX_multiview_per_view_attributes"))
+      {
+        vk::PhysicalDeviceMultiviewPerViewAttributesPropertiesNVX const& multiviewPerViewAttributesProperties = properties2.get<vk::PhysicalDeviceMultiviewPerViewAttributesPropertiesNVX>();
+        std::cout << "\t" << "MultiviewPerViewAttributesProperties:\n";
+        std::cout << "\t\t" << "perViewPositionAllComponents  = " << static_cast<bool>(multiviewPerViewAttributesProperties.perViewPositionAllComponents) << "\n";
+        std::cout << "\n";
+      }
+
+      vk::PhysicalDeviceMultiviewProperties const& multiviewProperties = properties2.get<vk::PhysicalDeviceMultiviewProperties>();
+      std::cout << "\t" << "MultiviewProperties:\n";
+      std::cout << "\t\t" << "maxMultiviewInstanceIndex = " << multiviewProperties.maxMultiviewInstanceIndex << "\n";
+      std::cout << "\t\t" << "maxMultiviewViewCount     = " << multiviewProperties.maxMultiviewViewCount << "\n";
+      std::cout << "\n";
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_pci_bus_info"))
+      {
+        vk::PhysicalDevicePCIBusInfoPropertiesEXT const& pciBusInfoProperties = properties2.get<vk::PhysicalDevicePCIBusInfoPropertiesEXT>();
+        std::cout << "\t" << "PCIBusInfoProperties:\n";
+        std::cout << "\t\t" << "pciDomain   = " << pciBusInfoProperties.pciDomain << "\n";
+        std::cout << "\t\t" << "pciBus      = " << pciBusInfoProperties.pciBus << "\n";
+        std::cout << "\t\t" << "pciDevice   = " << pciBusInfoProperties.pciDevice << "\n";
+        std::cout << "\t\t" << "pciFunction = " << pciBusInfoProperties.pciFunction << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_KHR_maintenance2"))
+      {
+        vk::PhysicalDevicePointClippingProperties const& pointClippingProperties = properties2.get<vk::PhysicalDevicePointClippingProperties>();
+        std::cout << "\t" << "PointClippingProperties:\n";
+        std::cout << "\t\t" << "pointClippingBehavior = " << vk::to_string(pointClippingProperties.pointClippingBehavior) << "\n";
+        std::cout << "\n";
+      }
+
+      vk::PhysicalDeviceProtectedMemoryProperties const& protectedMemoryProperties = properties2.get<vk::PhysicalDeviceProtectedMemoryProperties>();
+      std::cout << "\t" << "ProtectedMemoryProperties:\n";
+      std::cout << "\t\t" << "protectedNoFault  = " << static_cast<bool>(protectedMemoryProperties.protectedNoFault) << "\n";
+      std::cout << "\n";
+
+      if (vk::su::contains(extensionProperties, "VK_KHR_push_descriptor"))
+      {
+        vk::PhysicalDevicePushDescriptorPropertiesKHR const& pushDescriptorProperties = properties2.get<vk::PhysicalDevicePushDescriptorPropertiesKHR>();
+        std::cout << "\t" << "PushDescriptorProperties:\n";
+        std::cout << "\t\t" << "maxPushDescriptors  = " << pushDescriptorProperties.maxPushDescriptors << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_NV_ray_tracing"))
+      {
+        vk::PhysicalDeviceRayTracingPropertiesNV const& rayTracingProperties = properties2.get<vk::PhysicalDeviceRayTracingPropertiesNV>();
+        std::cout << "\t" << "RayTracingProperties:\n";
+        std::cout << "\t\t" << "maxDescriptorSetAccelerationStructures  = " << rayTracingProperties.maxDescriptorSetAccelerationStructures << "\n";
+        std::cout << "\t\t" << "maxGeometryCount                        = " << rayTracingProperties.maxGeometryCount << "\n";
+        std::cout << "\t\t" << "maxInstanceCount                        = " << rayTracingProperties.maxInstanceCount << "\n";
+        std::cout << "\t\t" << "maxRecursionDepth                       = " << rayTracingProperties.maxRecursionDepth << "\n";
+        std::cout << "\t\t" << "maxShaderGroupStride                    = " << rayTracingProperties.maxShaderGroupStride << "\n";
+        std::cout << "\t\t" << "maxTriangleCount                        = " << rayTracingProperties.maxTriangleCount << "\n";
+        std::cout << "\t\t" << "shaderGroupBaseAlignment                = " << rayTracingProperties.shaderGroupBaseAlignment << "\n";
+        std::cout << "\t\t" << "shaderGroupHandleSize                   = " << rayTracingProperties.shaderGroupHandleSize << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_sample_locations"))
+      {
+        vk::PhysicalDeviceSampleLocationsPropertiesEXT const& sampleLocationProperties = properties2.get<vk::PhysicalDeviceSampleLocationsPropertiesEXT>();
+        std::cout << "\t" << "SampleLocationProperties:\n";
+        std::cout << "\t\t" << "maxSampleLocationGridSize     = " << sampleLocationProperties.maxSampleLocationGridSize.width << " x " << sampleLocationProperties.maxSampleLocationGridSize.height << "\n";
+        std::cout << "\t\t" << "sampleLocationCoordinateRange = " << "[" << sampleLocationProperties.sampleLocationCoordinateRange[0] << ", " << sampleLocationProperties.sampleLocationCoordinateRange[1] << "]" << "\n";
+        std::cout << "\t\t" << "sampleLocationSampleCounts    = " << vk::to_string(sampleLocationProperties.sampleLocationSampleCounts) << "\n";
+        std::cout << "\t\t" << "sampleLocationSubPixelBits    = " << sampleLocationProperties.sampleLocationSubPixelBits << "\n";
+        std::cout << "\t\t" << "variableSampleLocations       = " << static_cast<bool>(sampleLocationProperties.variableSampleLocations) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_sampler_filter_minmax"))
+      {
+        vk::PhysicalDeviceSamplerFilterMinmaxPropertiesEXT const& samplerFilterMinmaxProperties = properties2.get<vk::PhysicalDeviceSamplerFilterMinmaxPropertiesEXT>();
+        std::cout << "\t" << "SamplerFilterMinmaxProperties:\n";
+        std::cout << "\t\t" << "filterMinmaxImageComponentMapping   = " << static_cast<bool>(samplerFilterMinmaxProperties.filterMinmaxImageComponentMapping) << "\n";
+        std::cout << "\t\t" << "filterMinmaxSingleComponentFormats  = " << static_cast<bool>(samplerFilterMinmaxProperties.filterMinmaxSingleComponentFormats) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_AMD_shader_core_properties2"))
+      {
+        vk::PhysicalDeviceShaderCoreProperties2AMD const& shaderCoreProperties2 = properties2.get<vk::PhysicalDeviceShaderCoreProperties2AMD>();
+        std::cout << "\t" << "ShaderCoreProperties2:\n";
+        std::cout << "\t\t" << "activeComputeUnitCount  = " << shaderCoreProperties2.activeComputeUnitCount << "\n";
+        std::cout << "\t\t" << "shaderCoreFeatures      = " << vk::to_string(shaderCoreProperties2.shaderCoreFeatures) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_AMD_shader_core_properties2"))
+      {
+        vk::PhysicalDeviceShaderCorePropertiesAMD const& shaderCoreProperties = properties2.get<vk::PhysicalDeviceShaderCorePropertiesAMD>();
+        std::cout << "\t" << "ShaderCoreProperties:\n";
+        std::cout << "\t\t" << "computeUnitsPerShaderArray  = " << shaderCoreProperties.computeUnitsPerShaderArray << "\n";
+        std::cout << "\t\t" << "maxSgprAllocation           = " << shaderCoreProperties.maxSgprAllocation << "\n";
+        std::cout << "\t\t" << "maxVgprAllocation           = " << shaderCoreProperties.maxVgprAllocation << "\n";
+        std::cout << "\t\t" << "minSgprAllocation           = " << shaderCoreProperties.minSgprAllocation << "\n";
+        std::cout << "\t\t" << "minVgprAllocation           = " << shaderCoreProperties.minVgprAllocation << "\n";
+        std::cout << "\t\t" << "sgprAllocationGranularity   = " << shaderCoreProperties.sgprAllocationGranularity << "\n";
+        std::cout << "\t\t" << "sgprsPerSimd                = " << shaderCoreProperties.sgprsPerSimd << "\n";
+        std::cout << "\t\t" << "shaderArraysPerEngineCount  = " << shaderCoreProperties.shaderArraysPerEngineCount << "\n";
+        std::cout << "\t\t" << "shaderEngineCount           = " << shaderCoreProperties.shaderEngineCount << "\n";
+        std::cout << "\t\t" << "simdPerComputeUnit          = " << shaderCoreProperties.simdPerComputeUnit << "\n";
+        std::cout << "\t\t" << "vgprAllocationGranularity   = " << shaderCoreProperties.vgprAllocationGranularity << "\n";
+        std::cout << "\t\t" << "vgprsPerSimd                = " << shaderCoreProperties.vgprsPerSimd << "\n";
+        std::cout << "\t\t" << "wavefrontSize               = " << shaderCoreProperties.wavefrontSize << "\n";
+        std::cout << "\t\t" << "wavefrontsPerSimd           = " << shaderCoreProperties.wavefrontsPerSimd << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_NV_shader_sm_builtins"))
+      {
+        vk::PhysicalDeviceShaderSMBuiltinsPropertiesNV const& shaderSMBuiltinsProperties = properties2.get<vk::PhysicalDeviceShaderSMBuiltinsPropertiesNV>();
+        std::cout << "\t" << "ShaderSMBuiltinsProperties:\n";
+        std::cout << "\t\t" << "shaderSMCount     = " << shaderSMBuiltinsProperties.shaderSMCount << "\n";
+        std::cout << "\t\t" << "shaderWarpsPerSM  = " << shaderSMBuiltinsProperties.shaderWarpsPerSM << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_NV_shading_rate_image"))
+      {
+        vk::PhysicalDeviceShadingRateImagePropertiesNV const& shadingRageImageProperties = properties2.get<vk::PhysicalDeviceShadingRateImagePropertiesNV>();
+        std::cout << "\t" << "ShadingRateImageProperties:\n";
+        std::cout << "\t\t" << "shadingRateMaxCoarseSamples = " << shadingRageImageProperties.shadingRateMaxCoarseSamples << "\n";
+        std::cout << "\t\t" << "shadingRatePaletteSize      = " << shadingRageImageProperties.shadingRatePaletteSize << "\n";
+        std::cout << "\t\t" << "shadingRatePaletteSize      = " << "[" << shadingRageImageProperties.shadingRateTexelSize.width << " x " << shadingRageImageProperties.shadingRateTexelSize.height << "]" << "\n";
+        std::cout << "\n";
+      }
+
+      vk::PhysicalDeviceSubgroupProperties const& subgroupProperties = properties2.get<vk::PhysicalDeviceSubgroupProperties>();
+      std::cout << "\t" << "SubgroupProperties:\n";
+      std::cout << "\t\t" << "quadOperationsInAllStages = " << static_cast<bool>(subgroupProperties.quadOperationsInAllStages) << "\n";
+      std::cout << "\t\t" << "subgroupSize              = " << subgroupProperties.subgroupSize << "\n";
+      std::cout << "\t\t" << "supportedOperations       = " << vk::to_string(subgroupProperties.supportedOperations) << "\n";
+      std::cout << "\t\t" << "supportedStages           = " << vk::to_string(subgroupProperties.supportedStages) << "\n";
+      std::cout << "\n";
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_subgroup_size_control"))
+      {
+        vk::PhysicalDeviceSubgroupSizeControlPropertiesEXT const& subgroupSizeControlProperties = properties2.get<vk::PhysicalDeviceSubgroupSizeControlPropertiesEXT>();
+        std::cout << "\t" << "SubgroupSizeControlProperties:\n";
+        std::cout << "\t\t" << "maxComputeWorkgroupSubgroups  = " << subgroupSizeControlProperties.maxComputeWorkgroupSubgroups << "\n";
+        std::cout << "\t\t" << "maxSubgroupSize               = " << subgroupSizeControlProperties.maxSubgroupSize << "\n";
+        std::cout << "\t\t" << "minSubgroupSize               = " << subgroupSizeControlProperties.minSubgroupSize << "\n";
+        std::cout << "\t\t" << "requiredSubgroupSizeStages    = " << vk::to_string(subgroupSizeControlProperties.requiredSubgroupSizeStages) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_KHR_timeline_semaphore"))
+      {
+        vk::PhysicalDeviceTimelineSemaphorePropertiesKHR const& timelineSemaphoreProperties = properties2.get<vk::PhysicalDeviceTimelineSemaphorePropertiesKHR>();
+        std::cout << "\t" << "TimelineSemaphoreProperties:\n";
+        std::cout << "\t\t" << "maxTimelineSemaphoreValueDifference = " << timelineSemaphoreProperties.maxTimelineSemaphoreValueDifference << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_texel_buffer_alignment"))
+      {
+        vk::PhysicalDeviceTexelBufferAlignmentPropertiesEXT const& texelBufferAlignmentProperties = properties2.get<vk::PhysicalDeviceTexelBufferAlignmentPropertiesEXT>();
+        std::cout << "\t" << "TexelBufferAlignmentProperties:\n";
+        std::cout << "\t\t" << "storageTexelBufferOffsetAlignmentBytes        = " << texelBufferAlignmentProperties.storageTexelBufferOffsetAlignmentBytes << "\n";
+        std::cout << "\t\t" << "storageTexelBufferOffsetSingleTexelAlignment  = " << static_cast<bool>(texelBufferAlignmentProperties.storageTexelBufferOffsetSingleTexelAlignment) << "\n";
+        std::cout << "\t\t" << "uniformTexelBufferOffsetAlignmentBytes        = " << texelBufferAlignmentProperties.uniformTexelBufferOffsetAlignmentBytes << "\n";
+        std::cout << "\t\t" << "uniformTexelBufferOffsetSingleTexelAlignment  = " << static_cast<bool>(texelBufferAlignmentProperties.uniformTexelBufferOffsetSingleTexelAlignment) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_transform_feedback"))
+      {
+        vk::PhysicalDeviceTransformFeedbackPropertiesEXT const& transformFeedbackProperties = properties2.get<vk::PhysicalDeviceTransformFeedbackPropertiesEXT>();
+        std::cout << "\t" << "TransformFeedbackProperties:\n";
+        std::cout << "\t\t" << "maxTransformFeedbackBufferDataSize          = " << transformFeedbackProperties.maxTransformFeedbackBufferDataSize << "\n";
+        std::cout << "\t\t" << "maxTransformFeedbackBufferDataStride        = " << transformFeedbackProperties.maxTransformFeedbackBufferDataStride << "\n";
+        std::cout << "\t\t" << "maxTransformFeedbackBuffers                 = " << transformFeedbackProperties.maxTransformFeedbackBuffers << "\n";
+        std::cout << "\t\t" << "maxTransformFeedbackBufferSize              = " << transformFeedbackProperties.maxTransformFeedbackBufferSize << "\n";
+        std::cout << "\t\t" << "maxTransformFeedbackStreamDataSize          = " << transformFeedbackProperties.maxTransformFeedbackStreamDataSize << "\n";
+        std::cout << "\t\t" << "maxTransformFeedbackStreams                 = " << transformFeedbackProperties.maxTransformFeedbackStreams << "\n";
+        std::cout << "\t\t" << "transformFeedbackDraw                       = " << static_cast<bool>(transformFeedbackProperties.transformFeedbackDraw) << "\n";
+        std::cout << "\t\t" << "transformFeedbackQueries                    = " << static_cast<bool>(transformFeedbackProperties.transformFeedbackQueries) << "\n";
+        std::cout << "\t\t" << "transformFeedbackRasterizationStreamSelect  = " << static_cast<bool>(transformFeedbackProperties.transformFeedbackRasterizationStreamSelect) << "\n";
+        std::cout << "\t\t" << "transformFeedbackStreamsLinesTriangles      = " << static_cast<bool>(transformFeedbackProperties.transformFeedbackStreamsLinesTriangles) << "\n";
+        std::cout << "\n";
+      }
+
+      if (vk::su::contains(extensionProperties, "VK_EXT_vertex_attribute_divisor"))
+      {
+        vk::PhysicalDeviceVertexAttributeDivisorPropertiesEXT const& vertexAttributeDivisorProperties = properties2.get<vk::PhysicalDeviceVertexAttributeDivisorPropertiesEXT>();
+        std::cout << "\t" << "VertexAttributeDivisorProperties:\n";
+        std::cout << "\t\t" << "maxVertexAttribDivisor  = " << vertexAttributeDivisorProperties.maxVertexAttribDivisor << "\n";
+        std::cout << "\n";
+      }
+    }
+
+    /* VULKAN_KEY_END */
+  }
+  catch (vk::SystemError err)
+  {
+    std::cout << "vk::SystemError: " << err.what() << std::endl;
+    exit(-1);
+  }
+  catch (std::runtime_error err)
+  {
+    std::cout << "std::runtime_error: " << err.what() << std::endl;
+    exit(-1);
+  }
+  catch (...)
+  {
+    std::cout << "unknown error\n";
+    exit(-1);
+  }
+  return 0;
+}

--- a/samples/PhysicalDeviceQueueFamilyProperties/CMakeLists.txt
+++ b/samples/PhysicalDeviceQueueFamilyProperties/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright(c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.2)
+
+project(PhysicalDeviceQueueFamilyProperties)
+
+set(HEADERS
+  ../utils/utils.hpp
+)
+
+set(SOURCES
+  PhysicalDeviceQueueFamilyProperties.cpp
+  ../utils/utils.cpp
+)
+
+source_group(headers FILES ${HEADERS})
+source_group(sources FILES ${SOURCES})
+
+add_executable(PhysicalDeviceQueueFamilyProperties
+  ${HEADERS}
+  ${SOURCES}
+)
+
+set_target_properties(PhysicalDeviceQueueFamilyProperties PROPERTIES FOLDER "Samples")
+target_link_libraries(PhysicalDeviceQueueFamilyProperties PUBLIC "$ENV{VULKAN_SDK}/Lib/vulkan-1.lib"
+)

--- a/samples/PhysicalDeviceQueueFamilyProperties/PhysicalDeviceQueueFamilyProperties.cpp
+++ b/samples/PhysicalDeviceQueueFamilyProperties/PhysicalDeviceQueueFamilyProperties.cpp
@@ -1,0 +1,117 @@
+// Copyright(c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// VulkanHpp Samples : PhysicalDeviceQueueFamilyProperties
+//                     Get queue family properties per physical device.
+
+#include "../utils/utils.hpp"
+#include "vulkan/vulkan.hpp"
+#include <iomanip>
+#include <sstream>
+#include <vector>
+
+static char const* AppName = "PhysicalDeviceQueueFamilyProperties";
+static char const* EngineName = "Vulkan.hpp";
+
+#define USE_WORKAROUND  1
+
+int main(int /*argc*/, char ** /*argv*/)
+{
+  try
+  {
+    vk::UniqueInstance instance = vk::su::createInstance(AppName, EngineName);
+#if !defined(NDEBUG)
+    vk::UniqueDebugUtilsMessengerEXT debugUtilsMessenger = vk::su::createDebugUtilsMessenger(instance);
+#endif
+
+    // enumerate the physicalDevices
+    std::vector<vk::PhysicalDevice> physicalDevices = instance->enumeratePhysicalDevices();
+
+    /* VULKAN_KEY_START */
+
+    std::cout << std::boolalpha;
+    for (size_t i=0 ; i<physicalDevices.size() ; i++)
+    {
+      // some features are only valid, if a corresponding extension is available!
+      std::vector<vk::ExtensionProperties> extensionProperties = physicalDevices[i].enumerateDeviceExtensionProperties();
+
+      std::cout << "PhysicalDevice " << i << "\n";
+
+#if USE_WORKAROUND
+      uint32_t queueFamilyPropertyCount;
+      VULKAN_HPP_DEFAULT_DISPATCHER.vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevices[i], &queueFamilyPropertyCount, nullptr);
+      std::vector<vk::QueueFamilyProperties2> queueFamilyProperties2(queueFamilyPropertyCount);
+      std::vector<vk::QueueFamilyCheckpointPropertiesNV> queueFamilyCheckpointProperties(queueFamilyPropertyCount);
+      for (uint32_t j=0 ; j<queueFamilyPropertyCount ; j++)
+      {
+        queueFamilyProperties2[j].pNext = &queueFamilyCheckpointProperties[j];
+      }
+      VULKAN_HPP_DEFAULT_DISPATCHER.vkGetPhysicalDeviceQueueFamilyProperties2(physicalDevices[i], &queueFamilyPropertyCount, reinterpret_cast<VkQueueFamilyProperties2*>(queueFamilyProperties2.data()));
+#else
+      // need to explicitly specify all the template arguments for getQueueFamilyProperties2 to make the compiler happy
+      using Chain = vk::StructureChain<vk::QueueFamilyProperties2, vk::QueueFamilyCheckpointPropertiesNV>;
+      auto queueFamilyProperties2 = physicalDevices[i].getQueueFamilyProperties2<Chain, std::allocator<Chain>, vk::DispatchLoaderDynamic>();
+#endif
+      for (size_t j = 0; j < queueFamilyProperties2.size(); j++)
+      {
+        std::cout << "\t" << "QueueFamily " << j << "\n";
+#if USE_WORKAROUND
+        vk::QueueFamilyProperties const& properties = queueFamilyProperties2[j].queueFamilyProperties;
+#else
+        vk::QueueFamilyProperties const& properties = queueFamilyProperties2[j].get<vk::QueueFamilyProperties2>().queueFamilyProperties;
+#endif
+        std::cout << "\t\t" << "QueueFamilyProperties:\n";
+        std::cout << "\t\t\t" << "queueFlags                  = " << vk::to_string(properties.queueFlags) << "\n";
+        std::cout << "\t\t\t" << "queueCount                  = " << properties.queueCount << "\n";
+        std::cout << "\t\t\t" << "timestampValidBits          = " << properties.timestampValidBits << "\n";
+        std::cout << "\t\t\t" << "minImageTransferGranularity = " << properties.minImageTransferGranularity.width << " x " << properties.minImageTransferGranularity.height << " x " << properties.minImageTransferGranularity.depth << "\n";
+        std::cout << "\n";
+
+        if (vk::su::contains(extensionProperties, "VK_NV_device_diagnostic_checkpoints"))
+        {
+#if USE_WORKAROUND
+          vk::QueueFamilyCheckpointPropertiesNV const* checkpointProperties = static_cast<vk::QueueFamilyCheckpointPropertiesNV const*>(queueFamilyProperties2[j].pNext);
+#else
+          vk::QueueFamilyCheckpointPropertiesNV const& checkpointProperties = queueFamilyProperties2[j].get<vk::QueueFamilyCheckpointPropertiesNV>();
+#endif
+          std::cout << "\t\t" << "CheckPointPropertiesNV:\n";
+#if USE_WORKAROUND
+          std::cout << "\t\t\t" << "checkpointExecutionStageMask  = " << vk::to_string(checkpointProperties->checkpointExecutionStageMask) << "\n";
+#else
+          std::cout << "\t\t\t" << "checkpointExecutionStageMask  = " << vk::to_string(checkpointProperties.checkpointExecutionStageMask) << "\n";
+#endif
+          std::cout << "\n";
+        }
+      }
+    }
+
+    /* VULKAN_KEY_END */
+  }
+  catch (vk::SystemError err)
+  {
+    std::cout << "vk::SystemError: " << err.what() << std::endl;
+    exit(-1);
+  }
+  catch (std::runtime_error err)
+  {
+    std::cout << "std::runtime_error: " << err.what() << std::endl;
+    exit(-1);
+  }
+  catch (...)
+  {
+    std::cout << "unknown error\n";
+    exit(-1);
+  }
+  return 0;
+}

--- a/samples/SurfaceCapabilities/CMakeLists.txt
+++ b/samples/SurfaceCapabilities/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright(c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.2)
+
+project(SurfaceCapabilities)
+
+set(HEADERS
+  ../utils/utils.hpp
+)
+
+set(SOURCES
+  SurfaceCapabilities.cpp
+  ../utils/utils.cpp
+)
+
+source_group(headers FILES ${HEADERS})
+source_group(sources FILES ${SOURCES})
+
+add_executable(SurfaceCapabilities
+  ${HEADERS}
+  ${SOURCES}
+)
+
+set_target_properties(SurfaceCapabilities PROPERTIES FOLDER "Samples")
+target_link_libraries(SurfaceCapabilities PUBLIC "$ENV{VULKAN_SDK}/Lib/vulkan-1.lib"
+)

--- a/samples/SurfaceCapabilities/SurfaceCapabilities.cpp
+++ b/samples/SurfaceCapabilities/SurfaceCapabilities.cpp
@@ -1,0 +1,148 @@
+// Copyright(c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// VulkanHpp Samples : SurfaceCapabilities
+//                     Get surface capabilities.
+
+#include "../utils/utils.hpp"
+#include "vulkan/vulkan.hpp"
+#include <iomanip>
+#include <sstream>
+#include <vector>
+
+static char const* AppName = "SurfaceCapabilities";
+static char const* EngineName = "Vulkan.hpp";
+
+void cout(vk::SurfaceCapabilitiesKHR const& surfaceCapabilities)
+{
+  std::cout << "\tCapabilities:\n";
+  std::cout << "\t\t" << "currentExtent           = " << surfaceCapabilities.currentExtent.width << " x " << surfaceCapabilities.currentExtent.height << "\n";
+  std::cout << "\t\t" << "currentTransform        = " << vk::to_string(surfaceCapabilities.currentTransform) << "\n";
+  std::cout << "\t\t" << "maxImageArrayLayers     = " << surfaceCapabilities.maxImageArrayLayers << "\n";
+  std::cout << "\t\t" << "maxImageCount           = " << surfaceCapabilities.maxImageCount << "\n";
+  std::cout << "\t\t" << "maxImageExtent          = " << surfaceCapabilities.maxImageExtent.width << " x " << surfaceCapabilities.maxImageExtent.height << "\n";
+  std::cout << "\t\t" << "minImageCount           = " << surfaceCapabilities.minImageCount << "\n";
+  std::cout << "\t\t" << "minImageExtent          = " << surfaceCapabilities.minImageExtent.width << " x " << surfaceCapabilities.minImageExtent.height << "\n";
+  std::cout << "\t\t" << "supportedCompositeAlpha = " << vk::to_string(surfaceCapabilities.supportedCompositeAlpha) << "\n";
+  std::cout << "\t\t" << "supportedTransforms     = " << vk::to_string(surfaceCapabilities.supportedTransforms) << "\n";
+  std::cout << "\t\t" << "supportedUsageFlags     = " << vk::to_string(surfaceCapabilities.supportedUsageFlags) << "\n";
+  std::cout << "\n";
+}
+
+int main(int /*argc*/, char ** /*argv*/)
+{
+  try
+  {
+    // need to initialize the dynamic dispatcher before the very first vulkan call
+#if (VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1)
+    static vk::DynamicLoader dl;
+    PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr = dl.getProcAddress<PFN_vkGetInstanceProcAddr>("vkGetInstanceProcAddr");
+    VULKAN_HPP_DEFAULT_DISPATCHER.init(vkGetInstanceProcAddr);
+#endif
+
+    std::vector<vk::ExtensionProperties> instanceExtensionProperties = vk::enumerateInstanceExtensionProperties();
+    bool supportsGetSurfaceCapabilities2 = (std::find_if(instanceExtensionProperties.begin(), instanceExtensionProperties.end(), [](vk::ExtensionProperties const& ep) { return strcmp(ep.extensionName, VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME) == 0; }) != instanceExtensionProperties.end());
+
+    std::vector<std::string> extensions = vk::su::getInstanceExtensions();
+    if (supportsGetSurfaceCapabilities2)
+    {
+      extensions.push_back(VK_KHR_GET_SURFACE_CAPABILITIES_2_EXTENSION_NAME);
+    }
+
+    vk::UniqueInstance instance = vk::su::createInstance(AppName, EngineName, {}, extensions);
+#if !defined(NDEBUG)
+    vk::UniqueDebugUtilsMessengerEXT debugUtilsMessenger = vk::su::createDebugUtilsMessenger(instance);
+#endif
+
+    // enumerate the physicalDevices
+    std::vector<vk::PhysicalDevice> physicalDevices = instance->enumeratePhysicalDevices();
+
+    vk::su::SurfaceData surfaceData(instance, AppName, AppName, vk::Extent2D(500, 500));
+
+    /* VULKAN_KEY_START */
+
+    std::cout << std::boolalpha;
+    for (size_t i=0 ; i<physicalDevices.size() ; i++)
+    {
+      // some properties are only valid, if a corresponding extension is available!
+      std::vector<vk::ExtensionProperties> extensionProperties = physicalDevices[i].enumerateDeviceExtensionProperties();
+
+      std::cout << "PhysicalDevice " << i << "\n";
+      if (supportsGetSurfaceCapabilities2)
+      {
+        auto surfaceCapabilities2 = physicalDevices[i].getSurfaceCapabilities2KHR<vk::SurfaceCapabilities2KHR, vk::DisplayNativeHdrSurfaceCapabilitiesAMD,
+          vk::SharedPresentSurfaceCapabilitiesKHR, vk::SurfaceCapabilitiesFullScreenExclusiveEXT,
+          vk::SurfaceProtectedCapabilitiesKHR>(*surfaceData.surface);
+
+        vk::SurfaceCapabilitiesKHR const& surfaceCapabilities = surfaceCapabilities2.get<vk::SurfaceCapabilities2KHR>().surfaceCapabilities;
+        cout(surfaceCapabilities);
+
+        if (vk::su::contains(extensionProperties, "VK_AMD_display_native_hdr"))
+        {
+          vk::DisplayNativeHdrSurfaceCapabilitiesAMD displayNativeHdrSurfaceCapabilities = surfaceCapabilities2.get<vk::DisplayNativeHdrSurfaceCapabilitiesAMD>();
+          std::cout << "\tDisplayNativeHdrSurfaceCapabilitiesAMD:\n";
+          std::cout << "\t\t" << "localDimmingSupport = " << static_cast<bool>(displayNativeHdrSurfaceCapabilities.localDimmingSupport) << "\n";
+          std::cout << "\n";
+        }
+
+        if (vk::su::contains(extensionProperties, "VK_KHR_shared_presentable_image"))
+        {
+          vk::SharedPresentSurfaceCapabilitiesKHR sharedPresentSurfaceCapabilities = surfaceCapabilities2.get<vk::SharedPresentSurfaceCapabilitiesKHR>();
+          std::cout << "\tSharedPresentSurfaceCapabilitiesKHR:\n";
+          std::cout << "\t\t" << "sharedPresentSupportedUsageFlags  = " << vk::to_string(sharedPresentSurfaceCapabilities.sharedPresentSupportedUsageFlags) << "\n";
+          std::cout << "\n";
+        }
+
+        if (vk::su::contains(extensionProperties, "VK_EXT_full_screen_exclusive"))
+        {
+          vk::SurfaceCapabilitiesFullScreenExclusiveEXT surfaceCapabilitiesFullScreenExclusive = surfaceCapabilities2.get<vk::SurfaceCapabilitiesFullScreenExclusiveEXT>();
+          std::cout << "\tSurfaceCapabilitiesFullScreenExclusiveEXT:\n";
+          std::cout << "\t\t" << "fullScreenExclusiveSupported  = " << static_cast<bool>(surfaceCapabilitiesFullScreenExclusive.fullScreenExclusiveSupported) << "\n";
+          std::cout << "\n";
+        }
+
+        if (vk::su::contains(extensionProperties, "VK_KHR_surface_protected_capabilities"))
+        {
+          vk::SurfaceProtectedCapabilitiesKHR surfaceProtectedCapabilities = surfaceCapabilities2.get<vk::SurfaceProtectedCapabilitiesKHR>();
+          std::cout << "\tSurfaceProtectedCapabilitiesKHR:\n";
+          std::cout << "\t\t" << "setSupportsProtected  = " << static_cast<bool>(surfaceProtectedCapabilities.setSupportsProtected) << "\n";
+          std::cout << "\n";
+        }
+      }
+      else
+      {
+        vk::SurfaceCapabilitiesKHR surfaceCapabilities = physicalDevices[i].getSurfaceCapabilitiesKHR(*surfaceData.surface);
+        cout(surfaceCapabilities);
+      }
+    }
+
+    /* VULKAN_KEY_END */
+  }
+  catch (vk::SystemError err)
+  {
+    std::cout << "vk::SystemError: " << err.what() << std::endl;
+    exit(-1);
+  }
+  catch (std::runtime_error err)
+  {
+    std::cout << "std::runtime_error: " << err.what() << std::endl;
+    exit(-1);
+  }
+  catch (...)
+  {
+    std::cout << "unknown error\n";
+    exit(-1);
+  }
+  return 0;
+}

--- a/samples/SurfaceFormats/CMakeLists.txt
+++ b/samples/SurfaceFormats/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright(c) 2019, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.2)
+
+project(SurfaceFormats)
+
+set(HEADERS
+  ../utils/utils.hpp
+)
+
+set(SOURCES
+  SurfaceFormats.cpp
+  ../utils/utils.cpp
+)
+
+source_group(headers FILES ${HEADERS})
+source_group(sources FILES ${SOURCES})
+
+add_executable(SurfaceFormats
+  ${HEADERS}
+  ${SOURCES}
+)
+
+set_target_properties(SurfaceFormats PROPERTIES FOLDER "Samples")
+target_link_libraries(SurfaceFormats PUBLIC "$ENV{VULKAN_SDK}/Lib/vulkan-1.lib"
+)

--- a/samples/SurfaceFormats/SurfaceFormats.cpp
+++ b/samples/SurfaceFormats/SurfaceFormats.cpp
@@ -1,0 +1,75 @@
+// Copyright(c) 2019, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// VulkanHpp Samples : SurfaceFormats
+//                     Get surface formats.
+
+#include "../utils/utils.hpp"
+#include "vulkan/vulkan.hpp"
+#include <iomanip>
+#include <sstream>
+#include <vector>
+
+static char const* AppName = "SurfaceFormats";
+static char const* EngineName = "Vulkan.hpp";
+
+int main(int /*argc*/, char ** /*argv*/)
+{
+  try
+  {
+    vk::UniqueInstance instance = vk::su::createInstance(AppName, EngineName, {}, vk::su::getInstanceExtensions());
+#if !defined(NDEBUG)
+    vk::UniqueDebugUtilsMessengerEXT debugUtilsMessenger = vk::su::createDebugUtilsMessenger(instance);
+#endif
+
+    // enumerate the physicalDevices
+    std::vector<vk::PhysicalDevice> physicalDevices = instance->enumeratePhysicalDevices();
+
+    vk::su::SurfaceData surfaceData(instance, AppName, AppName, vk::Extent2D(500, 500));
+
+    /* VULKAN_KEY_START */
+
+    std::cout << std::boolalpha;
+    for (size_t i=0 ; i<physicalDevices.size() ; i++)
+    {
+      std::cout << "PhysicalDevice " << i << "\n";
+      std::vector<vk::SurfaceFormatKHR> surfaceFormats = physicalDevices[i].getSurfaceFormatsKHR(*surfaceData.surface);
+      for (size_t j = 0; j < surfaceFormats.size(); j++)
+      {
+        std::cout << "\tFormat " << j << "\n";
+        std::cout << "\t\t" << "colorSpace  = " << vk::to_string(surfaceFormats[j].colorSpace) << "\n";
+        std::cout << "\t\t" << "format      = " << vk::to_string(surfaceFormats[j].format) << "\n";
+        std::cout << "\n";
+      }
+    }
+
+    /* VULKAN_KEY_END */
+  }
+  catch (vk::SystemError err)
+  {
+    std::cout << "vk::SystemError: " << err.what() << std::endl;
+    exit(-1);
+  }
+  catch (std::runtime_error err)
+  {
+    std::cout << "std::runtime_error: " << err.what() << std::endl;
+    exit(-1);
+  }
+  catch (...)
+  {
+    std::cout << "unknown error\n";
+    exit(-1);
+  }
+  return 0;
+}

--- a/samples/utils/utils.cpp
+++ b/samples/utils/utils.cpp
@@ -47,6 +47,11 @@ namespace vk
       return device->allocateMemoryUnique(vk::MemoryAllocateInfo(memoryRequirements.size, memoryTypeIndex));
     }
 
+    bool contains(std::vector<vk::ExtensionProperties> const& extensionProperties, std::string const& extensionName)
+    {
+      return std::find_if(extensionProperties.begin(), extensionProperties.end(), [&extensionName](vk::ExtensionProperties const& ep) { return extensionName == ep.extensionName; }) != extensionProperties.end();
+    }
+
     vk::UniqueCommandPool createCommandPool(vk::UniqueDevice &device, uint32_t queueFamilyIndex)
     {
       vk::CommandPoolCreateInfo commandPoolCreateInfo(vk::CommandPoolCreateFlagBits::eResetCommandBuffer, queueFamilyIndex);
@@ -195,6 +200,10 @@ namespace vk
       {
         enabledLayers.push_back("VK_LAYER_KHRONOS_validation");
       }
+      if (std::find(layers.begin(), layers.end(), "VK_LAYER_LUNARG_assistant_layer") == layers.end())
+      {
+        enabledLayers.push_back("VK_LAYER_LUNARG_assistant_layer");
+      }
 #endif
 
       std::vector<char const*> enabledExtensions;
@@ -212,8 +221,8 @@ namespace vk
 
       // create a UniqueInstance
       vk::ApplicationInfo applicationInfo(appName.c_str(), 1, engineName.c_str(), 1, apiVersion);
-      vk::UniqueInstance instance = vk::createInstanceUnique(vk::InstanceCreateInfo({}, &applicationInfo, checked_cast<uint32_t>(enabledLayers.size()), enabledLayers.data(),
-                                                                                    checked_cast<uint32_t>(enabledExtensions.size()), enabledExtensions.data()));
+      vk::InstanceCreateInfo instanceCreateInfo({}, &applicationInfo, checked_cast<uint32_t>(enabledLayers.size()), enabledLayers.data(), checked_cast<uint32_t>(enabledExtensions.size()), enabledExtensions.data());
+      vk::UniqueInstance instance = vk::createInstanceUnique(instanceCreateInfo);
 
 #if (VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1)
       // initialize function pointers for instance
@@ -807,7 +816,7 @@ namespace vk
                                                                          16.0f, false, vk::CompareOp::eNever, 0.0f, 0.0f, vk::BorderColor::eFloatOpaqueBlack));
     }
 
-    UUID::UUID(uint8_t data[VK_UUID_SIZE])
+    UUID::UUID(uint8_t const data[VK_UUID_SIZE])
     {
       memcpy(m_data, data, VK_UUID_SIZE * sizeof(uint8_t));
     }

--- a/samples/utils/utils.hpp
+++ b/samples/utils/utils.hpp
@@ -103,7 +103,9 @@ namespace vk
       SurfaceData(vk::UniqueInstance &instance, std::string const& className, std::string const& windowName, vk::Extent2D const& extent);
 
       vk::Extent2D          extent;
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
       HWND                  window;
+#endif
       vk::UniqueSurfaceKHR  surface;
     };
 
@@ -196,7 +198,7 @@ namespace vk
     struct UUID
     {
       public:
-      UUID(uint8_t data[VK_UUID_SIZE]);
+      UUID(uint8_t const data[VK_UUID_SIZE]);
 
       uint8_t m_data[VK_UUID_SIZE];
     };
@@ -263,6 +265,7 @@ namespace vk
 
     vk::UniqueDeviceMemory allocateMemory(vk::UniqueDevice const& device, vk::PhysicalDeviceMemoryProperties const& memoryProperties, vk::MemoryRequirements const& memoryRequirements,
                                           vk::MemoryPropertyFlags memoryPropertyFlags);
+    bool contains(std::vector<vk::ExtensionProperties> const& extensionProperties, std::string const& extensionName);
     vk::UniqueCommandPool createCommandPool(vk::UniqueDevice &device, uint32_t queueFamilyIndex);
     vk::UniqueDebugUtilsMessengerEXT createDebugUtilsMessenger(vk::UniqueInstance &instance);
     vk::UniqueDescriptorPool createDescriptorPool(vk::UniqueDevice &device, std::vector<vk::DescriptorPoolSize> const& poolSizes);
@@ -299,7 +302,7 @@ namespace vk
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
     HWND initializeWindow(std::string const& className, std::string const& windowName, LONG width, LONG height);
 #else
-#pragma error "unhandled platform"
+# error "unhandled platform"
 #endif
   }
 }


### PR DESCRIPTION
new:
- InstanceVersion: print out the instance version
- PhysicalDeviceExtensions: print out the device specific extensions
- PhysicalDeviceFeatures: print out the device specific features
- PhysicalDeviceGroups: print out the device groups (interesting with SLI)
- PhysicalDeviceMemoryProperties: print out the device specific memory properties
- PhysicalDeviceQueueFamilyProperties: print out the device specific queue family properties
- SurfaceCapabilities: print out the surface specific capabilities
- SurfaceFormats: print out the supported surface specific formats
improved:
- InstanceExtensionProperties: print out the instance extensions alphabetically
- InstanceLayerProperties: removed an unused local function
- RayTracing: improved fence usage