### PR TITLE
Implement support for unicode Windows projects using `vk::DynamicLoader`.

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -1055,7 +1055,7 @@ void VulkanHppGenerator::appendDispatchLoaderDynamic(std::string & str)
 #elif defined(__APPLE__)
       m_library = dlopen( "libvulkan.dylib", RTLD_NOW | RTLD_LOCAL );
 #elif defined(_WIN32)
-      m_library = LoadLibrary( "vulkan-1.dll" );
+      m_library = LoadLibrary( TEXT( "vulkan-1.dll" ) );
 #else
       assert( false && "unsupported platform" );
 #endif

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -73811,7 +73811,7 @@ namespace VULKAN_HPP_NAMESPACE
 #elif defined(__APPLE__)
       m_library = dlopen( "libvulkan.dylib", RTLD_NOW | RTLD_LOCAL );
 #elif defined(_WIN32)
-      m_library = LoadLibrary( "vulkan-1.dll" );
+      m_library = LoadLibrary( TEXT( "vulkan-1.dll" ) );
 #else
       assert( false && "unsupported platform" );
 #endif


### PR DESCRIPTION
I wasn't really sure what to do with this. Windows is just annoying to work with, and I just hit this on a test project at work.

The other solution is to just force calling `LoadLibraryA`. Both works, but I don't know which one is better, if any.

This macro is defined by `winnt.h`, so I don't see it getting removed anytime soon.