### PR TITLE
Introduce default constructors for ObjectDestroy, ObjectFree, and UniqueHandle.

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -4589,7 +4589,13 @@ int main( int argc, char **argv )
   class ObjectDestroy
   {
     public:
-      ObjectDestroy( OwnerType owner = OwnerType(), Optional<const AllocationCallbacks> allocationCallbacks = nullptr, Dispatch const &dispatch = VULKAN_HPP_DEFAULT_DISPATCHER ) VULKAN_HPP_NOEXCEPT
+      ObjectDestroy()
+        : m_owner()
+        , m_allocationCallbacks( nullptr )
+        , m_dispatch( nullptr )
+      {}
+
+      ObjectDestroy( OwnerType owner, Optional<const AllocationCallbacks> allocationCallbacks, Dispatch const &dispatch ) VULKAN_HPP_NOEXCEPT
         : m_owner( owner )
         , m_allocationCallbacks( allocationCallbacks )
         , m_dispatch( &dispatch )
@@ -4602,6 +4608,7 @@ int main( int argc, char **argv )
       template <typename T>
       void destroy(T t) VULKAN_HPP_NOEXCEPT
       {
+        assert( m_owner && m_dispatch );
         m_owner.destroy( t, m_allocationCallbacks, *m_dispatch );
       }
 
@@ -4617,6 +4624,11 @@ int main( int argc, char **argv )
   class ObjectDestroy<NoParent,Dispatch>
   {
     public:
+      ObjectDestroy()
+        : m_allocationCallbacks( nullptr )
+        , m_dispatch( nullptr )
+      {}
+
       ObjectDestroy( Optional<const AllocationCallbacks> allocationCallbacks = nullptr, Dispatch const &dispatch = VULKAN_HPP_DEFAULT_DISPATCHER ) VULKAN_HPP_NOEXCEPT
         : m_allocationCallbacks( allocationCallbacks )
         , m_dispatch( &dispatch )
@@ -4628,6 +4640,7 @@ int main( int argc, char **argv )
       template <typename T>
       void destroy(T t) VULKAN_HPP_NOEXCEPT
       {
+        assert( m_dispatch );
         t.destroy( m_allocationCallbacks, *m_dispatch );
       }
 
@@ -4642,7 +4655,13 @@ int main( int argc, char **argv )
   class ObjectFree
   {
     public:
-      ObjectFree( OwnerType owner = OwnerType(), Optional<const AllocationCallbacks> allocationCallbacks = nullptr, Dispatch const &dispatch = VULKAN_HPP_DEFAULT_DISPATCHER ) VULKAN_HPP_NOEXCEPT
+      ObjectFree()
+        : m_owner()
+        , m_allocationCallbacks( nullptr )
+        , m_dispatch( nullptr )
+      {}
+
+      ObjectFree( OwnerType owner, Optional<const AllocationCallbacks> allocationCallbacks, Dispatch const &dispatch ) VULKAN_HPP_NOEXCEPT
         : m_owner( owner )
         , m_allocationCallbacks( allocationCallbacks )
         , m_dispatch( &dispatch )
@@ -4655,6 +4674,7 @@ int main( int argc, char **argv )
       template <typename T>
       void destroy(T t) VULKAN_HPP_NOEXCEPT
       {
+        assert( m_owner && m_dispatch );
         m_owner.free( t, m_allocationCallbacks, *m_dispatch );
       }
 
@@ -4853,7 +4873,12 @@ int main( int argc, char **argv )
   public:
     using element_type = Type;
 
-    explicit UniqueHandle( Type const& value = Type(), Deleter const& deleter = Deleter() ) VULKAN_HPP_NOEXCEPT
+    UniqueHandle()
+      : Deleter()
+      , m_value()
+    {}
+
+    explicit UniqueHandle( Type const& value, Deleter const& deleter = Deleter() ) VULKAN_HPP_NOEXCEPT
       : Deleter( deleter)
       , m_value( value )
     {}

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -543,7 +543,12 @@ namespace VULKAN_HPP_NAMESPACE
   public:
     using element_type = Type;
 
-    explicit UniqueHandle( Type const& value = Type(), Deleter const& deleter = Deleter() ) VULKAN_HPP_NOEXCEPT
+    UniqueHandle()
+      : Deleter()
+      , m_value()
+    {}
+
+    explicit UniqueHandle( Type const& value, Deleter const& deleter = Deleter() ) VULKAN_HPP_NOEXCEPT
       : Deleter( deleter)
       , m_value( value )
     {}
@@ -2595,7 +2600,13 @@ namespace VULKAN_HPP_NAMESPACE
   class ObjectDestroy
   {
     public:
-      ObjectDestroy( OwnerType owner = OwnerType(), Optional<const AllocationCallbacks> allocationCallbacks = nullptr, Dispatch const &dispatch = VULKAN_HPP_DEFAULT_DISPATCHER ) VULKAN_HPP_NOEXCEPT
+      ObjectDestroy()
+        : m_owner()
+        , m_allocationCallbacks( nullptr )
+        , m_dispatch( nullptr )
+      {}
+
+      ObjectDestroy( OwnerType owner, Optional<const AllocationCallbacks> allocationCallbacks, Dispatch const &dispatch ) VULKAN_HPP_NOEXCEPT
         : m_owner( owner )
         , m_allocationCallbacks( allocationCallbacks )
         , m_dispatch( &dispatch )
@@ -2608,6 +2619,7 @@ namespace VULKAN_HPP_NAMESPACE
       template <typename T>
       void destroy(T t) VULKAN_HPP_NOEXCEPT
       {
+        assert( m_owner && m_dispatch );
         m_owner.destroy( t, m_allocationCallbacks, *m_dispatch );
       }
 
@@ -2623,6 +2635,11 @@ namespace VULKAN_HPP_NAMESPACE
   class ObjectDestroy<NoParent,Dispatch>
   {
     public:
+      ObjectDestroy()
+        : m_allocationCallbacks( nullptr )
+        , m_dispatch( nullptr )
+      {}
+
       ObjectDestroy( Optional<const AllocationCallbacks> allocationCallbacks = nullptr, Dispatch const &dispatch = VULKAN_HPP_DEFAULT_DISPATCHER ) VULKAN_HPP_NOEXCEPT
         : m_allocationCallbacks( allocationCallbacks )
         , m_dispatch( &dispatch )
@@ -2634,6 +2651,7 @@ namespace VULKAN_HPP_NAMESPACE
       template <typename T>
       void destroy(T t) VULKAN_HPP_NOEXCEPT
       {
+        assert( m_dispatch );
         t.destroy( m_allocationCallbacks, *m_dispatch );
       }
 
@@ -2646,7 +2664,13 @@ namespace VULKAN_HPP_NAMESPACE
   class ObjectFree
   {
     public:
-      ObjectFree( OwnerType owner = OwnerType(), Optional<const AllocationCallbacks> allocationCallbacks = nullptr, Dispatch const &dispatch = VULKAN_HPP_DEFAULT_DISPATCHER ) VULKAN_HPP_NOEXCEPT
+      ObjectFree()
+        : m_owner()
+        , m_allocationCallbacks( nullptr )
+        , m_dispatch( nullptr )
+      {}
+
+      ObjectFree( OwnerType owner, Optional<const AllocationCallbacks> allocationCallbacks, Dispatch const &dispatch ) VULKAN_HPP_NOEXCEPT
         : m_owner( owner )
         , m_allocationCallbacks( allocationCallbacks )
         , m_dispatch( &dispatch )
@@ -2659,6 +2683,7 @@ namespace VULKAN_HPP_NAMESPACE
       template <typename T>
       void destroy(T t) VULKAN_HPP_NOEXCEPT
       {
+        assert( m_owner && m_dispatch );
         m_owner.free( t, m_allocationCallbacks, *m_dispatch );
       }
 


### PR DESCRIPTION
Resolves #443