### PR TITLE
Fixed vertexBindingDescription scope.

### DIFF
--- a/samples/utils/utils.cpp
+++ b/samples/utils/utils.cpp
@@ -122,9 +122,10 @@ namespace vk
 
       std::vector<vk::VertexInputAttributeDescription> vertexInputAttributeDescriptions;
       vk::PipelineVertexInputStateCreateInfo pipelineVertexInputStateCreateInfo;
+      vk::VertexInputBindingDescription vertexInputBindingDescription(0, vertexStride);
+      
       if (0 < vertexStride)
       {
-        vk::VertexInputBindingDescription vertexInputBindingDescription(0, vertexStride);
         vertexInputAttributeDescriptions.reserve(vertexInputAttributeFormatOffset.size());
         for (uint32_t i=0 ; i<vertexInputAttributeFormatOffset.size() ; i++)
         {


### PR DESCRIPTION
vk::PipelineVertexInputStateCreateInfo::pVertexBindingDescriptions used to run out of scope before being used in the Device::createGraphicsPipelineUnique resulting in undefined behavior. 