### PR TITLE
Update EnableValidationWithCallback.cpp

### DIFF
--- a/samples/EnableValidationWithCallback/EnableValidationWithCallback.cpp
+++ b/samples/EnableValidationWithCallback/EnableValidationWithCallback.cpp
@@ -82,7 +82,7 @@ VkBool32 debugMessageFunc(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity
 #ifdef _WIN32
   MessageBox(NULL, message.c_str(), "Alert", MB_OK);
 #else
-  std::cout << message.str() << std::endl;
+  std::cout << message << std::endl;
 #endif
 
   return false;


### PR DESCRIPTION
Quick patch that fixes the `EnableValidationWithCallback` sample:
 -  There's no `str()` method here, should use `c_str()`;  
 -  *but* also, you can print the std::string directly to `std::cout`.

Patches remove `.str()` from printing line when WIN32 is not defined.