### PR TITLE
Add is_error_code_enum only if VULKAN_HPP_NO_EXCEPTIONS is not defined.

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -5212,12 +5212,14 @@ static const std::string constExpressionArrayCopy = R"(
 )";
 
   static const std::string is_error_code_enum = R"(
+#ifndef VULKAN_HPP_NO_EXCEPTIONS
 namespace std
 {
   template <>
   struct is_error_code_enum<VULKAN_HPP_NAMESPACE::Result> : public true_type
   {};
 }
+#endif
 )";
 
   static const std::string structResultValue = R"(

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -11964,12 +11964,14 @@ namespace VULKAN_HPP_NAMESPACE
 #endif /*VK_USE_PLATFORM_XLIB_KHR*/
 } // namespace VULKAN_HPP_NAMESPACE
 
+#ifndef VULKAN_HPP_NO_EXCEPTIONS
 namespace std
 {
   template <>
   struct is_error_code_enum<VULKAN_HPP_NAMESPACE::Result> : public true_type
   {};
 }
+#endif
 
 namespace VULKAN_HPP_NAMESPACE
 {


### PR DESCRIPTION
Resolves #458.