### PR TITLE
Fix regression in ObjectDestroy default argument

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -4811,7 +4811,7 @@ int main(int argc, char **argv)
         , m_dispatch( nullptr )
       {}
 
-      ObjectDestroy( OwnerType owner, Optional<const AllocationCallbacks> allocationCallbacks = nullptr, Dispatch const &dispatch = Dispatch() ) VULKAN_HPP_NOEXCEPT
+      ObjectDestroy( OwnerType owner, Optional<const AllocationCallbacks> allocationCallbacks = nullptr, Dispatch const &dispatch = VULKAN_HPP_DEFAULT_DISPATCHER ) VULKAN_HPP_NOEXCEPT
         : m_owner( owner )
         , m_allocationCallbacks( allocationCallbacks )
         , m_dispatch( &dispatch )

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -2749,7 +2749,7 @@ namespace VULKAN_HPP_NAMESPACE
         , m_dispatch( nullptr )
       {}
 
-      ObjectDestroy( OwnerType owner, Optional<const AllocationCallbacks> allocationCallbacks = nullptr, Dispatch const &dispatch = Dispatch() ) VULKAN_HPP_NOEXCEPT
+      ObjectDestroy( OwnerType owner, Optional<const AllocationCallbacks> allocationCallbacks = nullptr, Dispatch const &dispatch = VULKAN_HPP_DEFAULT_DISPATCHER ) VULKAN_HPP_NOEXCEPT
         : m_owner( owner )
         , m_allocationCallbacks( allocationCallbacks )
         , m_dispatch( &dispatch )


### PR DESCRIPTION
It seems like the default `dispatch` argument should be `VULKAN_HPP_DEFAULT_DISPATCHER` rather than default constructing a new dispatcher.

Default constructing a new dispatcher probably works fine when using static dispatch, but fails with dynamic dispatch since the dynamic dispatcher uses a `VkInstance` (and a `VkDevice`) which the newly default constructed dispatcher lacks.