### PR TITLE
Add move semantics to DynamicLoader

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -1131,6 +1131,25 @@ void VulkanHppGenerator::appendDispatchLoaderDynamic(std::string & str)
 #endif
     }
 
+    DynamicLoader( DynamicLoader const& ) = delete;
+
+    DynamicLoader( DynamicLoader && other ) VULKAN_HPP_NOEXCEPT
+      : m_success(other.m_success)
+      , m_library(other.m_library)
+    {
+      other.m_library = nullptr;
+    }
+
+    DynamicLoader &operator=( DynamicLoader const& ) = delete;
+
+    DynamicLoader &operator=( DynamicLoader && other ) VULKAN_HPP_NOEXCEPT
+    {
+      m_success = other.m_success;
+      m_library = other.m_library;
+      other.m_library = nullptr;
+      return *this;
+    }
+
     ~DynamicLoader() VULKAN_HPP_NOEXCEPT
     {
       if ( m_library )

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -72471,6 +72471,25 @@ namespace VULKAN_HPP_NAMESPACE
 #endif
     }
 
+    DynamicLoader( DynamicLoader const& ) = delete;
+
+    DynamicLoader( DynamicLoader && other ) VULKAN_HPP_NOEXCEPT
+      : m_success(other.m_success)
+      , m_library(other.m_library)
+    {
+      other.m_library = nullptr;
+    }
+
+    DynamicLoader &operator=( DynamicLoader const& ) = delete;
+
+    DynamicLoader &operator=( DynamicLoader && other ) VULKAN_HPP_NOEXCEPT
+    {
+      m_success = other.m_success;
+      m_library = other.m_library;
+      other.m_library = nullptr;
+      return *this;
+    }
+
     ~DynamicLoader() VULKAN_HPP_NOEXCEPT
     {
       if ( m_library )


### PR DESCRIPTION
This avoids unintentional library closes or double-closes when handle is transferred via the default copy constructor.