### PR TITLE
Use std::swap for DynamicLibrary move assign

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -1145,8 +1145,7 @@ void VulkanHppGenerator::appendDispatchLoaderDynamic(std::string & str)
     DynamicLoader &operator=( DynamicLoader && other ) VULKAN_HPP_NOEXCEPT
     {
       m_success = other.m_success;
-      m_library = other.m_library;
-      other.m_library = nullptr;
+      std::swap(m_library, other.m_library);
       return *this;
     }
 

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -72528,8 +72528,7 @@ namespace VULKAN_HPP_NAMESPACE
     DynamicLoader &operator=( DynamicLoader && other ) VULKAN_HPP_NOEXCEPT
     {
       m_success = other.m_success;
-      m_library = other.m_library;
-      other.m_library = nullptr;
+      std::swap(m_library, other.m_library);
       return *this;
     }
 


### PR DESCRIPTION
Continuation of #508.

In case of move assign over already-opened DynamicLibrary, swapping the handle ensures the existing handle is closed.