### PR TITLE
Enable samples on AppVeyor builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,40 +1,32 @@
-os:
+image:
+  - Visual Studio 2015 
   - Visual Studio 2017
-
-build:
-  verbosity: detailed
+  - Visual Studio 2019
 
 configuration:
   - Debug
 
+build:
+  verbosity: detailed
+
 environment:
   matrix:
-    - GENERATOR: Visual Studio 14 2015
-      GENERATOR_ARCH: Win32
-      RAW_PLATFORM: x86
-    - GENERATOR: Visual Studio 14 2015
-      GENERATOR_ARCH: x64
-      RAW_PLATFORM: amd64
-    - GENERATOR: Visual Studio 15 2017
-      GENERATOR_ARCH: Win32
-      RAW_PLATFORM: x86
-    - GENERATOR: Visual Studio 15 2017
-      GENERATOR_ARCH: x64
-      RAW_PLATFORM: amd64
+    - GENERATOR_ARCH: Win32
+    - GENERATOR_ARCH: x64
 
 install:
   - git submodule update --init --recursive
 
-
-before_build:
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %RAW_PLATFORM%
-  - cd C:\projects\Vulkan-Hpp
-
-
 build_script:
-  - mkdir appveyor-build
-  - cd appveyor-build
-  - cmake ..\tests -G "%GENERATOR%" -A %GENERATOR_ARCH% -DTESTS_BUILD_WITH_LOCAL_VULKAN_HPP=1 -DTESTS_BUILD_ONLY_DYNAMIC=1
-
-test_script:
+  - mkdir build
+  - cd build
+  - cmake --version
+  - cmake .. 
+    -A %GENERATOR_ARCH% 
+    -DSAMPLES_BUILD=ON 
+    -DTESTS_BUILD=ON
+    -DSAMPLES_BUILD_ONLY_DYNAMIC=ON 
+    -DSAMPLES_BUILD_WITH_LOCAL_VULKAN_HPP=ON 
+    -DTESTS_BUILD_ONLY_DYNAMIC=ON 
+    -DTESTS_BUILD_WITH_LOCAL_VULKAN_HPP=ON
   - cmake --build . --config %CONFIGURATION%

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,15 +106,20 @@ endif()
 
 option (SAMPLES_BUILD "Build samples" OFF)
 if (SAMPLES_BUILD)
+  # external libraries
+  add_subdirectory(glm)
+  set(GLFW_BUILD_EXAMPLES OFF)
+  set(GLFW_BUILD_TESTS OFF)
   add_subdirectory(glfw)
   add_subdirectory(glslang)
+  # samples
   add_subdirectory(samples)
-endif (SAMPLES_BUILD)
+endif ()
 
 option (TESTS_BUILD "Build tests" OFF)
 if (TESTS_BUILD)
   add_subdirectory(tests)
-endif (TESTS_BUILD)
+endif ()
 
 if (${VULKAN_HPP_INSTALL})
   install(FILES ${vulkan_hpp} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vulkan)

--- a/samples/05_InitSwapchain/05_InitSwapchain.cpp
+++ b/samples/05_InitSwapchain/05_InitSwapchain.cpp
@@ -44,9 +44,9 @@ int main(int /*argc*/, char ** /*argv*/)
     vk::UniqueSurfaceKHR surface;
     {
       VkSurfaceKHR _surface;
-      glfwCreateWindowSurface(instance.get(), window.handle, nullptr, &_surface);
+      glfwCreateWindowSurface(VkInstance(instance.get()), window.handle, nullptr, &_surface);
       vk::ObjectDestroy<vk::Instance, VULKAN_HPP_DEFAULT_DISPATCHER_TYPE> _deleter(instance.get());
-      surface = vk::UniqueSurfaceKHR(_surface, _deleter);
+      surface = vk::UniqueSurfaceKHR(vk::SurfaceKHR(_surface), _deleter);
     }
 
     // determine a queueFamilyIndex that suports present

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -40,8 +40,6 @@ else()
   include_directories("${Vulkan_INCLUDE_DIRS}")
 endif()
 
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../glm")
-
 FOREACH( linkunit ${linkunits} )
   if( IS_DIRECTORY ${linkunit} )
     if( EXISTS ${linkunit}/CMakeLists.txt )

--- a/samples/CreateDebugUtilsMessenger/CreateDebugUtilsMessenger.cpp
+++ b/samples/CreateDebugUtilsMessenger/CreateDebugUtilsMessenger.cpp
@@ -36,8 +36,8 @@ VKAPI_ATTR void VKAPI_CALL vkDestroyDebugUtilsMessengerEXT(VkInstance instance, 
 }
 
 
-VkBool32 debugMessageFunc(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageTypes,
-                          VkDebugUtilsMessengerCallbackDataEXT const * pCallbackData, void * /*pUserData*/)
+VKAPI_ATTR VkBool32 VKAPI_CALL debugMessageFunc(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageTypes,
+                                                VkDebugUtilsMessengerCallbackDataEXT const * pCallbackData, void * /*pUserData*/)
 {
   std::ostringstream message;
 

--- a/samples/EnableValidationWithCallback/EnableValidationWithCallback.cpp
+++ b/samples/EnableValidationWithCallback/EnableValidationWithCallback.cpp
@@ -38,8 +38,8 @@ VKAPI_ATTR void VKAPI_CALL vkDestroyDebugUtilsMessengerEXT(VkInstance instance, 
 }
 
 
-VkBool32 debugMessageFunc(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageTypes,
-  VkDebugUtilsMessengerCallbackDataEXT const * pCallbackData, void * /*pUserData*/)
+VKAPI_ATTR VkBool32 VKAPI_CALL debugMessageFunc(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageTypes,
+                                                VkDebugUtilsMessengerCallbackDataEXT const * pCallbackData, void * /*pUserData*/)
 {
   std::string message;
 

--- a/samples/PhysicalDeviceGroups/PhysicalDeviceGroups.cpp
+++ b/samples/PhysicalDeviceGroups/PhysicalDeviceGroups.cpp
@@ -43,7 +43,7 @@ int main(int /*argc*/, char ** /*argv*/)
       std::cout << "\t" << "physicalDevices:\n";
       for (size_t j = 0; j < groupProperties[i].physicalDeviceCount; j++)
       {
-        std::cout << "\t\t" << j << " : " << groupProperties[i].physicalDevices[j] << "\n";
+        std::cout << "\t\t" << j << " : " << groupProperties[i].physicalDevices[j].getProperties().deviceName << "\n";
       }
       std::cout << "\t" << "subsetAllocation    = " << static_cast<bool>(groupProperties[i].subsetAllocation) << "\n";
       std::cout << "\n";

--- a/samples/RayTracing/RayTracing.cpp
+++ b/samples/RayTracing/RayTracing.cpp
@@ -656,7 +656,7 @@ int main(int /*argc*/, char** /*argv*/)
 
     // Create Window Surface (using glfw)
     vk::SurfaceKHR surface;
-    VkResult err = glfwCreateWindowSurface(*instance, window, nullptr, reinterpret_cast<VkSurfaceKHR*>(&surface));
+    VkResult err = glfwCreateWindowSurface(VkInstance(*instance), window, nullptr, reinterpret_cast<VkSurfaceKHR*>(&surface));
     check_vk_result(err);
 
     std::pair<uint32_t, uint32_t> graphicsAndPresentQueueFamilyIndex = vk::su::findGraphicsAndPresentQueueFamilyIndex(physicalDevice, surface);
@@ -1063,7 +1063,7 @@ int main(int /*argc*/, char** /*argv*/)
     // Cleanup
     device->waitIdle();
     swapChainData.swapChain.reset();    // need to reset swapChain before destroying the surface !
-    VULKAN_HPP_DEFAULT_DISPATCHER.vkDestroySurfaceKHR(*instance, surface, nullptr);
+    VULKAN_HPP_DEFAULT_DISPATCHER.vkDestroySurfaceKHR(VkInstance(*instance), VkSurfaceKHR(surface), nullptr);
     glfwDestroyWindow(window);
     glfwTerminate();
   }

--- a/samples/utils/CMakeLists.txt
+++ b/samples/utils/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(utils
   ${HEADERS}
 )
 
+target_link_libraries(utils PUBLIC glm)
 target_link_libraries(utils PUBLIC glfw)
 target_link_libraries(utils PUBLIC glslang)
 target_link_libraries(utils PUBLIC glslang-default-resource-limits)

--- a/samples/utils/utils.cpp
+++ b/samples/utils/utils.cpp
@@ -263,7 +263,7 @@ namespace vk
                                                                      &subpassDescription));
     }
 
-    VkBool32 debugUtilsMessengerCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageTypes,
+    VKAPI_ATTR VkBool32 VKAPI_CALL debugUtilsMessengerCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageTypes,
                                          VkDebugUtilsMessengerCallbackDataEXT const * pCallbackData, void * /*pUserData*/)
     {
       std::cerr << vk::to_string(static_cast<vk::DebugUtilsMessageSeverityFlagBitsEXT>(messageSeverity)) << ": " << vk::to_string(static_cast<vk::DebugUtilsMessageTypeFlagsEXT>(messageTypes)) << ":\n";

--- a/samples/utils/utils.cpp
+++ b/samples/utils/utils.cpp
@@ -671,11 +671,11 @@ namespace vk
       , window(vk::su::createWindow(windowName, extent))
     {
       VkSurfaceKHR _surface;
-      VkResult err = glfwCreateWindowSurface(instance.get(), window.handle, nullptr, &_surface);
+      VkResult err = glfwCreateWindowSurface(VkInstance(instance.get()), window.handle, nullptr, &_surface);
       if (err != VK_SUCCESS)
         throw std::runtime_error("Failed to create window!");
       vk::ObjectDestroy<vk::Instance, VULKAN_HPP_DEFAULT_DISPATCHER_TYPE> _deleter(instance.get());
-      surface = vk::UniqueSurfaceKHR(_surface, _deleter);
+      surface = vk::UniqueSurfaceKHR(vk::SurfaceKHR(_surface), _deleter);
     }
 
     SwapChainData::SwapChainData(vk::PhysicalDevice const& physicalDevice, vk::UniqueDevice const& device, vk::SurfaceKHR const& surface, vk::Extent2D const& extent, vk::ImageUsageFlags usage,

--- a/samples/utils/utils.hpp
+++ b/samples/utils/utils.hpp
@@ -299,7 +299,7 @@ namespace vk
     vk::UniqueInstance createInstance(std::string const& appName, std::string const& engineName, std::vector<std::string> const& layers = {}, std::vector<std::string> const& extensions = {},
                                       uint32_t apiVersion = VK_API_VERSION_1_0);
     vk::UniqueRenderPass createRenderPass(vk::UniqueDevice &device, vk::Format colorFormat, vk::Format depthFormat, vk::AttachmentLoadOp loadOp = vk::AttachmentLoadOp::eClear, vk::ImageLayout colorFinalLayout = vk::ImageLayout::ePresentSrcKHR);
-    VkBool32 debugUtilsMessengerCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageTypes, VkDebugUtilsMessengerCallbackDataEXT const * pCallbackData, void * /*pUserData*/);
+    VKAPI_ATTR VkBool32 VKAPI_CALL debugUtilsMessengerCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity, VkDebugUtilsMessageTypeFlagsEXT messageTypes, VkDebugUtilsMessengerCallbackDataEXT const * pCallbackData, void * /*pUserData*/);
     uint32_t findGraphicsQueueFamilyIndex(std::vector<vk::QueueFamilyProperties> const& queueFamilyProperties);
     std::pair<uint32_t, uint32_t> findGraphicsAndPresentQueueFamilyIndex(vk::PhysicalDevice physicalDevice, vk::SurfaceKHR const& surface);
     uint32_t findMemoryType(vk::PhysicalDeviceMemoryProperties const& memoryProperties, uint32_t typeBits, vk::MemoryPropertyFlags requirementsMask);


### PR DESCRIPTION
This PR enables samples on AppVeyor builds.
Following configurations are included:
- Visual Studio images
  + `Visual Studio 2015`
  + `Visual Studio 2017`
  + `Visual Studio 2019`
- Arch options:
  + `Win32`
  + `x64`  

All builds are compiled with `Debug`.

