### PR TITLE
Add type traits for translating between stdint types and vk::IndexType

### DIFF
--- a/VulkanHppGenerator.hpp
+++ b/VulkanHppGenerator.hpp
@@ -26,6 +26,7 @@ class VulkanHppGenerator
     VulkanHppGenerator(tinyxml2::XMLDocument const& document);
 
     void appendBaseTypes(std::string & str) const;
+    void appendIndexTypeTraits(std::string & str) const;
     void appendBitmasks(std::string & str) const;
     void appendDispatchLoaderDynamic(std::string & str); // use vkGet*ProcAddress to get function pointers
     void appendDispatchLoaderStatic(std::string & str);  // use exported symbols from loader

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -8869,6 +8869,52 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+  template<typename T>
+  struct index_type
+  {
+  };
+
+  template<IndexType value>
+  struct cpp_index_type
+  {
+  };
+
+  template <>
+  struct index_type<uint16_t>
+  {
+    static VULKAN_HPP_CONST_OR_CONSTEXPR IndexType indexType = IndexType::eUint16;
+  };
+
+  template <>
+  struct cpp_index_type<IndexType::eUint16>
+  {
+    using type = uint16_t;
+  };
+
+  template <>
+  struct index_type<uint32_t>
+  {
+    static VULKAN_HPP_CONST_OR_CONSTEXPR IndexType indexType = IndexType::eUint32;
+  };
+
+  template <>
+  struct cpp_index_type<IndexType::eUint32>
+  {
+    using type = uint32_t;
+  };
+
+  template <>
+  struct index_type<uint8_t>
+  {
+    static VULKAN_HPP_CONST_OR_CONSTEXPR IndexType indexType = IndexType::eUint8EXT;
+  };
+
+  template <>
+  struct cpp_index_type<IndexType::eUint8EXT>
+  {
+    using type = uint8_t;
+  };
+
   using AccessFlags = Flags<AccessFlagBits>;
 
   template <> struct FlagTraits<AccessFlagBits>


### PR DESCRIPTION
Adds vk::index_type and vk::cpp_index_type templates for translating between stdint.h types and vk::IndexType. This may be useful for template users needing to call bindIndexBuffer without having to write their own traits.