### PR TITLE
Add checks on member sType of structs:

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -6339,12 +6339,6 @@ void VulkanHppGenerator::readStructMember( tinyxml2::XMLElement const * element,
   members.push_back( MemberData( line ) );
   MemberData & memberData = members.back();
 
-  auto valuesIt = attributes.find( "values" );
-  if ( valuesIt != attributes.end() )
-  {
-    memberData.values = valuesIt->second;
-  }
-
   for ( auto child : children )
   {
     std::string value = child->Value();
@@ -6360,6 +6354,18 @@ void VulkanHppGenerator::readStructMember( tinyxml2::XMLElement const * element,
     {
       readStructMemberType( child, memberData );
     }
+  }
+
+  auto valuesIt = attributes.find( "values" );
+  if ( valuesIt != attributes.end() )
+  {
+    check( memberData.name == "sType",
+           line,
+           "Structure member named differently than <sType> with attribute <values> encountered: " );
+    check( m_sTypeValues.insert( valuesIt->second ).second,
+           line,
+           "<" + valuesIt->second + "> already encountered as values for the sType member of a struct" );
+    memberData.values = valuesIt->second;
   }
 }
 

--- a/VulkanHppGenerator.hpp
+++ b/VulkanHppGenerator.hpp
@@ -592,6 +592,7 @@ private:
   std::map<std::string, std::string>     m_platforms;
   std::map<std::string, std::string>     m_structureAliases;
   std::map<std::string, StructureData>   m_structures;
+  std::set<std::string>                  m_sTypeValues;
   std::set<std::string>                  m_tags;
   std::map<std::string, TypeCategory>    m_types;
   std::string                            m_typesafeCheck;


### PR DESCRIPTION
- only members named <sType> are supposed to have a <values> attribute
- no <values> attribute is allowed to occur more than once.