### PR TITLE
Provide rvalue cast operator for ResultValue

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -7859,6 +7859,11 @@ namespace std
     {
       return value;
     }
+
+    operator T&& () && VULKAN_HPP_NOEXCEPT
+    {
+      return std::move( value );
+    }
 #endif
   };
 

--- a/tests/ResultValueRValue/CMakeLists.txt
+++ b/tests/ResultValueRValue/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright(c) 2020, Collabora Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.2)
+
+project(ResultValueRValue)
+
+set(HEADERS
+)
+
+set(SOURCES
+  ResultValueRValue.cpp
+)
+
+source_group(headers FILES ${HEADERS})
+source_group(sources FILES ${SOURCES})
+
+add_library(ResultValueRValue
+  ${HEADERS}
+  ${SOURCES}
+)
+
+if (UNIX)
+  target_link_libraries(ResultValueRValue "-ldl")
+endif()
+
+set_target_properties(ResultValueRValue PROPERTIES FOLDER "Tests")

--- a/tests/ResultValueRValue/ResultValueRValue.cpp
+++ b/tests/ResultValueRValue/ResultValueRValue.cpp
@@ -1,0 +1,38 @@
+// Copyright(c) 2020, Collabora Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// VulkanHpp Test: Compile only test for issue 589.
+
+#define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
+
+#include "vulkan/vulkan.hpp"
+
+VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
+
+template <typename T>
+struct Wrapper
+{
+  Wrapper( T && raw ) : raw{ raw } {}
+
+  T raw;
+};
+
+void test()
+{
+  auto device = vk::Device{};
+  // We should be able to move created vk objects, regardless of the
+  // result type they were returned in.
+  Wrapper<vk::Image>{ device.createImage( {} ) };
+  Wrapper<vk::Pipeline>{ device.createGraphicsPipeline( {}, {} ) };
+}


### PR DESCRIPTION
Allows objects returned as ResultValue (instead of ResultValueType::type) to be moved without requiring additional casting or explicit use of ResultValue::value.

Resolves #589