### PR TITLE
[HPP][ResultValue] Add missing ref-qualifier to conversion operators

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -7882,6 +7882,11 @@ namespace std
       return value;
     }
 
+    operator T const&& () const && VULKAN_HPP_NOEXCEPT
+    {
+      return std::move( value );
+    }
+
     operator T&& () && VULKAN_HPP_NOEXCEPT
     {
       return std::move( value );

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -7872,12 +7872,12 @@ namespace std
     operator std::tuple<Result&, T&>() VULKAN_HPP_NOEXCEPT { return std::tuple<Result&, T&>(result, value); }
 
 #if !defined(VULKAN_HPP_DISABLE_IMPLICIT_RESULT_VALUE_CAST)
-    operator T const& () const VULKAN_HPP_NOEXCEPT
+    operator T const& () const & VULKAN_HPP_NOEXCEPT
     {
       return value;
     }
 
-    operator T& () VULKAN_HPP_NOEXCEPT
+    operator T& () & VULKAN_HPP_NOEXCEPT
     {
       return value;
     }

--- a/tests/ResultValue/CMakeLists.txt
+++ b/tests/ResultValue/CMakeLists.txt
@@ -14,25 +14,25 @@
 
 cmake_minimum_required(VERSION 3.2)
 
-project(ResultValueRValue)
+project(ResultValue)
 
 set(HEADERS
 )
 
 set(SOURCES
-  ResultValueRValue.cpp
+  ResultValue.cpp
 )
 
 source_group(headers FILES ${HEADERS})
 source_group(sources FILES ${SOURCES})
 
-add_library(ResultValueRValue
+add_library(ResultValue
   ${HEADERS}
   ${SOURCES}
 )
 
 if (UNIX)
-  target_link_libraries(ResultValueRValue "-ldl")
+  target_link_libraries(ResultValue "-ldl")
 endif()
 
-set_target_properties(ResultValueRValue PROPERTIES FOLDER "Tests")
+set_target_properties(ResultValue PROPERTIES FOLDER "Tests")

--- a/tests/ResultValue/ResultValue.cpp
+++ b/tests/ResultValue/ResultValue.cpp
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// VulkanHpp Test: Compile only test for issue 589.
+// VulkanHpp Tests : ResultValue
+//                   Compile-test for ResultValue
 
 #define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
 
@@ -20,18 +21,19 @@
 
 VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 
+// Compile only test for issue 589.
+void test_conversion()
+{
 #if defined(VULKAN_DISABLE_IMPLICIT_RESULT_VALUE_CAST)
   static_assert(false, "Conversions not enabled");
 #endif
 
-void as_value(int)  {}
-void as_ref(int&) {}
-void as_cref(const int&) {}
-void as_rvref(int&&)  {}
-void as_crvref(const int&&)  {}
+  void as_value(int);
+  void as_ref(int&);
+  void as_cref(const int&);
+  void as_rvref(int&&);
+  void as_crvref(const int&&);
 
-void test()
-{
   using result = vk::ResultValue<int>;
 
   auto val        = result {vk::Result{}, 42};

--- a/tests/ResultValueRValue/ResultValueRValue.cpp
+++ b/tests/ResultValueRValue/ResultValueRValue.cpp
@@ -24,21 +24,29 @@ VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
   static_assert(false, "Conversions not enabled");
 #endif
 
-template <class T> void as_value(T)  {}
-template <class T> void as_cref(const T&) {}
-template <class T> void as_rvref(T&&)  {}
+void as_value(int)  {}
+void as_ref(int&) {}
+void as_cref(const int&) {}
+void as_rvref(int&&)  {}
+void as_crvref(const int&&)  {}
 
 void test()
 {
-  auto device = vk::Device{};
+  using result = vk::ResultValue<int>;
 
-  // just example: non-result values (vk::Image)
-  as_value<vk::Image>(device.createImage({}));
-  as_cref<vk::Image>(device.createImage({}));
-  as_rvref<vk::Image>(device.createImage({}));
+  auto val        = result {vk::Result{}, 42};
+  const auto cval = result {vk::Result{}, 42}; 
 
-  // vk::ResultValue<vk::Pipeline> should also work
-  as_value<vk::Pipeline>(device.createGraphicsPipeline(nullptr, {}));
-  as_cref<vk::Pipeline>(device.createGraphicsPipeline(nullptr, {}));
-  as_rvref<vk::Pipeline>(device.createGraphicsPipeline(nullptr,{}));
+  as_value(val);
+  as_value(cval);
+
+  as_ref(val);
+  //as_ref(cval); // should fail
+  as_cref(val);
+  as_cref(cval);
+
+  as_rvref(std::move(val));
+  //as_rvref(std::move(cval)); // should fail
+  as_crvref(std::move(val));
+  as_crvref(std::move(cval));
 }

--- a/tests/ResultValueRValue/ResultValueRValue.cpp
+++ b/tests/ResultValueRValue/ResultValueRValue.cpp
@@ -20,19 +20,25 @@
 
 VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 
-template <typename T>
-struct Wrapper
-{
-  Wrapper( T && raw ) : raw{ raw } {}
+#if defined(VULKAN_DISABLE_IMPLICIT_RESULT_VALUE_CAST)
+  static_assert(false, "Conversions not enabled");
+#endif
 
-  T raw;
-};
+template <class T> void as_value(T)  {}
+template <class T> void as_cref(const T&) {}
+template <class T> void as_rvref(T&&)  {}
 
 void test()
 {
   auto device = vk::Device{};
-  // We should be able to move created vk objects, regardless of the
-  // result type they were returned in.
-  Wrapper<vk::Image>{ device.createImage( {} ) };
-  Wrapper<vk::Pipeline>{ device.createGraphicsPipeline( {}, {} ) };
+
+  // just example: non-result values (vk::Image)
+  as_value<vk::Image>(device.createImage({}));
+  as_cref<vk::Image>(device.createImage({}));
+  as_rvref<vk::Image>(device.createImage({}));
+
+  // vk::ResultValue<vk::Pipeline> should also work
+  as_value<vk::Pipeline>(device.createGraphicsPipeline(nullptr, {}));
+  as_cref<vk::Pipeline>(device.createGraphicsPipeline(nullptr, {}));
+  as_rvref<vk::Pipeline>(device.createGraphicsPipeline(nullptr,{}));
 }


### PR DESCRIPTION
This PR adds missing ref-qualifiers to complete #590 , also adds sore more test cases.
Should fix #616 

- [x] Add ref-qualifier to existing conversion operators
- [x] Add some tests
- [x] Add `operator T cons&&() const &&` for consistency?
- [x] Better tests
- [x] Change test target name to more general one