### PR TITLE
Add VULKAN_HPP_ASSERT_ON_RESULT

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,9 @@ std::vector<LayerProperties, MyStatefulCustomAllocator> properties = physicalDev
 
 ### Custom assertions
 
-All over vulkan.hpp, there are a couple of calls to an assert function. By defining VULKAN_HPP_ASSERT, you can specifiy your own custom assert function to be called instead.
+All over vulkan.hpp, there are a couple of calls to an assert function. By defining `VULKAN_HPP_ASSERT`, you can specifiy your own custom assert function to be called instead.
+
+By default, `VULKAN_HPP_ASSERT_ON_RESULT` will be used for checking results when `VULKAN_HPP_NO_EXCEPTIONS` is defined. If you want to handle errors by yourself, you can disable/customize it just like `VULKAN_HPP_ASSERT`.
 
 ### Extensions / Per Device function pointers
 

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -7947,6 +7947,10 @@ static_assert( false, "vulkan.hpp needs at least c++ standard version 11" );
 # define VULKAN_HPP_ASSERT   assert
 #endif
 
+#if !defined(VULKAN_HPP_ASSERT_ON_RESULT)
+# define VULKAN_HPP_ASSERT_ON_RESULT VULKAN_HPP_ASSERT
+#endif
+
 #if !defined(VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL)
 # define VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL 1
 #endif

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -8089,7 +8089,7 @@ namespace std
   {
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
     ignore(message);
-    VULKAN_HPP_ASSERT( result == Result::eSuccess );
+    VULKAN_HPP_ASSERT_ON_RESULT( result == Result::eSuccess );
     return result;
 #else
     if ( result != Result::eSuccess )
@@ -8104,7 +8104,7 @@ namespace std
   {
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
     ignore(message);
-    VULKAN_HPP_ASSERT( result == Result::eSuccess );
+    VULKAN_HPP_ASSERT_ON_RESULT( result == Result::eSuccess );
     return ResultValue<T>( result, std::move( data ) );
 #else
     if ( result != Result::eSuccess )
@@ -8119,7 +8119,7 @@ namespace std
   {
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
     ignore(message);
-    VULKAN_HPP_ASSERT( std::find( successCodes.begin(), successCodes.end(), result ) != successCodes.end() );
+    VULKAN_HPP_ASSERT_ON_RESULT( std::find( successCodes.begin(), successCodes.end(), result ) != successCodes.end() );
 #else
     if ( std::find( successCodes.begin(), successCodes.end(), result ) == successCodes.end() )
     {
@@ -8134,7 +8134,7 @@ namespace std
   {
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
     ignore(message);
-    VULKAN_HPP_ASSERT( std::find( successCodes.begin(), successCodes.end(), result ) != successCodes.end() );
+    VULKAN_HPP_ASSERT_ON_RESULT( std::find( successCodes.begin(), successCodes.end(), result ) != successCodes.end() );
 #else
     if ( std::find( successCodes.begin(), successCodes.end(), result ) == successCodes.end() )
     {
@@ -8150,7 +8150,7 @@ namespace std
   {
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
     ignore(message);
-    VULKAN_HPP_ASSERT( result == Result::eSuccess );
+    VULKAN_HPP_ASSERT_ON_RESULT( result == Result::eSuccess );
     return ResultValue<UniqueHandle<T,D>>( result, UniqueHandle<T,D>(data, deleter) );
 #else
     if ( result != Result::eSuccess )
@@ -8166,7 +8166,7 @@ namespace std
   {
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
     ignore(message);
-    VULKAN_HPP_ASSERT( std::find( successCodes.begin(), successCodes.end(), result ) != successCodes.end() );
+    VULKAN_HPP_ASSERT_ON_RESULT( std::find( successCodes.begin(), successCodes.end(), result ) != successCodes.end() );
     return ResultValue<UniqueHandle<T,D>>( result, UniqueHandle<T,D>(data, deleter) );
 #else
     if ( std::find( successCodes.begin(), successCodes.end(), result ) == successCodes.end() )


### PR DESCRIPTION
This PR adds `VULKAN_HPP_ASSERT_ON_RESULT` discussed in #644 

* [x] Add `VULKAN_HPP_ASSERT_ON_RESULT` macro
* [x] Use new assertion macros in `createResult` functions
* [x] Add docs?