### PR TITLE
Small fix for ArrayWrapper1D's conversion operators

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -6943,14 +6943,14 @@ int main( int argc, char ** argv )
     }
 
     template <typename B = T, typename std::enable_if<std::is_same<B, char>::value, int>::type = 0>
-    operator std::string const () const VULKAN_HPP_NOEXCEPT
+    operator std::string() const
     {
       return std::string( this->data() );
     }
 
 #if 17 <= VULKAN_HPP_CPP_VERSION
     template <typename B = T, typename std::enable_if<std::is_same<B, char>::value, int>::type = 0>
-    operator std::string_view const () const VULKAN_HPP_NOEXCEPT
+    operator std::string_view() const
     {
       return std::string_view( this->data() );
     }

--- a/samples/InstanceLayerExtensionProperties/InstanceLayerExtensionProperties.cpp
+++ b/samples/InstanceLayerExtensionProperties/InstanceLayerExtensionProperties.cpp
@@ -49,7 +49,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     for ( auto const & layerProperty : layerProperties )
     {
       std::vector<vk::ExtensionProperties> extensionProperties =
-        vk::enumerateInstanceExtensionProperties( std::string( layerProperty.layerName ) );
+        vk::enumerateInstanceExtensionProperties( vk::Optional<const std::string>( layerProperty.layerName ) );
       propertyData.push_back( PropertyData( layerProperty, extensionProperties ) );
     }
 


### PR DESCRIPTION
This PR removes `const` on return type and `VULKAN_HPP_NOEXCEPT` from string conversion operators of `Array1DWrapper`.
Not sure this is intended, but it seems `const` and `VULKAN_HPP_NOEXCEPT` on these operators are not necessary, considering `const` prevents move semantics and both `std::string` and `std::string_view` can possibly throw on construction.