### PR TITLE
Turn Conformance Mode on for Visual Studio builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ else()
 endif()
 
 if(MSVC)
-  add_compile_options(/W4)
+  add_compile_options(/W4 /permissive-)
 else(MSVC)
   add_compile_options(-Wall)
 endif(MSVC)


### PR DESCRIPTION
+ reorganize library loading and still keep windows.h out.

Resolves #600
Resolves #629