### PR TITLE
Disable implicit move constructors for wrapper structs

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -3192,6 +3192,8 @@ ${enter}  class ${className}
       : m_${memberName}(VK_NULL_HANDLE)
     {}
 
+    VULKAN_HPP_CONSTEXPR ${className}( const ${className}& ) VULKAN_HPP_NOEXCEPT = default;
+
     VULKAN_HPP_CONSTEXPR ${className}( std::nullptr_t ) VULKAN_HPP_NOEXCEPT
       : m_${memberName}(VK_NULL_HANDLE)
     {}

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -3192,7 +3192,7 @@ ${enter}  class ${className}
       : m_${memberName}(VK_NULL_HANDLE)
     {}
 
-    VULKAN_HPP_CONSTEXPR ${className}( const ${className}& ) VULKAN_HPP_NOEXCEPT = default;
+    VULKAN_HPP_CONSTEXPR ${className}( ${className} const & ) VULKAN_HPP_NOEXCEPT = default;
 
     VULKAN_HPP_CONSTEXPR ${className}( std::nullptr_t ) VULKAN_HPP_NOEXCEPT
       : m_${memberName}(VK_NULL_HANDLE)

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -3595,6 +3595,8 @@ ${prefix}${constexpr}${structName}(${arguments}) VULKAN_HPP_NOEXCEPT
 ${prefix}${initializers}
 ${prefix}{}
 
+${prefix}${constexpr}${structName}( ${structName} const & ) VULKAN_HPP_NOEXCEPT = default;
+
 ${prefix}${structName}( Vk${structName} const & rhs ) VULKAN_HPP_NOEXCEPT
 ${prefix}{
 ${prefix}  *this = rhs;

--- a/tests/ResultValue/ResultValue.cpp
+++ b/tests/ResultValue/ResultValue.cpp
@@ -35,33 +35,51 @@ int main( int /*argc*/, char ** /*argv*/ )
   static_assert( false, "Conversions not enabled" );
 #endif
 
-  using result = vk::ResultValue<int>;
+  {
+    using result = vk::ResultValue<int>;
 
-  auto       val  = result{ vk::Result{}, 42 };
-  const auto cval = result{ vk::Result{}, 42 };
+    auto       val  = result{ vk::Result{}, 42 };
+    const auto cval = result{ vk::Result{}, 42 };
 
-  as_value( val );
-  as_value( cval );
+    as_value( val );
+    as_value( cval );
 
-  as_ref( val );
-  // as_ref(cval); // should fail
-  as_cref( val );
-  as_cref( cval );
+    as_ref( val );
+    // as_ref(cval); // should fail
+    as_cref( val );
+    as_cref( cval );
 
-  as_rvref( std::move( val ) );
-  // as_rvref(std::move(cval)); // should fail
-  as_crvref( std::move( val ) );
-  as_crvref( std::move( cval ) );
+    as_rvref( std::move( val ) );
+    // as_rvref(std::move(cval)); // should fail
+    as_crvref( std::move( val ) );
+    as_crvref( std::move( cval ) );
+  }
 
-  vk::Pipeline       pipe( VkPipeline( 0x8 ) );  // fake a Pipeline here, to have something different from zero
-  vk::UniquePipeline pipeline( pipe );
-  vk::ResultValue<vk::UniquePipeline> rv( {}, std::move( pipeline ) );
+  {
+    vk::Pipeline       pipe( VkPipeline( 0x8 ) );  // fake a Pipeline here, to have something different from zero
+    vk::UniquePipeline pipeline( pipe );
+    vk::ResultValue<vk::UniquePipeline> rv( {}, std::move( pipeline ) );
 
-  as_cref( rv );  // does not move out handle
-  assert( rv.value );
+    as_cref( rv );  // does not move out handle
+    assert( rv.value );
 
-  auto p = std::move( rv.value );
-  p.release();  // release the faked Pipeline, to prevent error on trying to destroy it
+    auto p = std::move( rv.value );
+    p.release();  // release the faked Pipeline, to prevent error on trying to destroy it
+  }
+
+  // test for issue #659
+  if (false) {
+    vk::ResultValue<vk::Pipeline> pipe {{}, {}};
+    vk::ResultValue<vk::UniquePipeline> upipe( {}, {});
+    // init
+    vk::UniquePipeline up1 = std::move(upipe);
+    vk::Pipeline p1 = pipe;
+    vk::Pipeline p2 = std::move(pipe);
+    // assign
+    up1 = std::move(upipe);
+    p1 = pipe;
+    p2 = std::move(pipe);
+  }
 
   return 0;
 }

--- a/tests/ResultValue/ResultValue.cpp
+++ b/tests/ResultValue/ResultValue.cpp
@@ -68,14 +68,25 @@ int main( int /*argc*/, char ** /*argv*/ )
   }
 
   // test for issue #659
-  if (false) {
-    vk::ResultValue<vk::Pipeline> pipe {{}, {}};
+  if ( false )
+  {
+    // types from VulkanHppGenerator::appendHandle
+    vk::ResultValue<vk::Pipeline> pipe{ {}, {} };
     // init
     vk::Pipeline p1 = pipe;
-    vk::Pipeline p2 = std::move(pipe);
+    vk::Pipeline p2 = std::move( pipe );
     // assign
     p1 = pipe;
-    p2 = std::move(pipe);
+    p2 = std::move( pipe );
+
+    // types from VulkanHppGenerator::appendStructure
+    vk::ResultValue<vk::DisplayPlaneCapabilitiesKHR> cap{ {}, {} };
+    // init
+    vk::DisplayPlaneCapabilitiesKHR c1 = cap;
+    vk::DisplayPlaneCapabilitiesKHR c2 = std::move( cap );
+    // assign
+    c1 = cap;
+    c2 = std::move( cap );
   }
 
   return 0;

--- a/tests/ResultValue/ResultValue.cpp
+++ b/tests/ResultValue/ResultValue.cpp
@@ -70,13 +70,10 @@ int main( int /*argc*/, char ** /*argv*/ )
   // test for issue #659
   if (false) {
     vk::ResultValue<vk::Pipeline> pipe {{}, {}};
-    vk::ResultValue<vk::UniquePipeline> upipe( {}, {});
     // init
-    vk::UniquePipeline up1 = std::move(upipe);
     vk::Pipeline p1 = pipe;
     vk::Pipeline p2 = std::move(pipe);
     // assign
-    up1 = std::move(upipe);
     p1 = pipe;
     p2 = std::move(pipe);
   }


### PR DESCRIPTION
This PR disables implicitly generated move constructors for handles and structs.
Should fix #659.