### PR TITLE
Rename CMake variable for Vulkan registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,20 +55,20 @@ endif(MSVC)
 
 set(CMAKE_CXX_STANDARD 11)
 
-if (NOT DEFINED VULKAN_HPP_VULKAN_HEADERS_SRC_DIR)
-  set(VULKAN_HPP_VULKAN_HEADERS_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Vulkan-Headers")
+if (NOT DEFINED VulkanRegistry_DIR)
+  set(VulkanRegistry_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Vulkan-Headers/registry")
 endif()
-file(TO_NATIVE_PATH ${VULKAN_HPP_VULKAN_HEADERS_SRC_DIR}/registry/vk.xml vk_spec)
+file(TO_NATIVE_PATH ${VulkanRegistry_DIR}/vk.xml vk_spec)
 string(REPLACE "\\" "\\\\" vk_spec ${vk_spec})
 add_definitions(-DVK_SPEC="${vk_spec}")
 
-if (NOT DEFINED VULKAN_HPP_PATH)
-  set(VULKAN_HPP_PATH "${CMAKE_CURRENT_SOURCE_DIR}/vulkan")
+if (NOT DEFINED VulkanHeaders_INCLUDE_DIR)
+  set(VulkanHeaders_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
-file(TO_NATIVE_PATH ${VULKAN_HPP_PATH}/vulkan.hpp vulkan_hpp)
+file(TO_NATIVE_PATH ${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan.hpp vulkan_hpp)
 string(REPLACE "\\" "\\\\" vulkan_hpp ${vulkan_hpp})
 add_definitions(-DVULKAN_HPP_FILE="${vulkan_hpp}")
-include_directories(${VULKAN_HPP_PATH})
+include_directories(${VulkanHeaders_INCLUDE_DIR})
 
 
 set(HEADERS


### PR DESCRIPTION
This is change is part of my effort to make Vulkan github projects work better as CMake subprojects using git submodules.

`VulkanRegistry_DIR` and `VulkanHeaders_INCLUDE_DIRS` is what `Vulkan-Tools/cmake/FindVulkanHeaders.cmake` uses.

```
# This module is intended to be used by projects that build Vulkan
# "system" components such as the loader and layers.
```

As a side note, it seems like Vulkan-Hpp should also use `FindVulkanHeaders.cmake` like Vulkan-Tools does. I do this in my CMake parent project, which is what makes these variables `VulkanRegistry_DIR` and `VulkanHeaders_INCLUDE_DIRS` work here for me.