### PR TITLE
Make struct copy constructors explicit

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -3635,6 +3635,8 @@ ${prefix}${constexpr}${structName}(${arguments}) VULKAN_HPP_NOEXCEPT
 ${prefix}${initializers}
 ${prefix}{}
 
+${prefix}${constexpr}${structName}( ${structName} const & ) VULKAN_HPP_NOEXCEPT = default;
+
 ${prefix}${structName}( Vk${structName} const & rhs ) VULKAN_HPP_NOEXCEPT
 ${prefix}{
 ${prefix}  *this = rhs;


### PR DESCRIPTION
This removes compiler warnings about implicit copy constructors being deprecated.