### PR TITLE
Extend template argument list for functions returning a std::vector<Stuff> to help compilers detecting the correct function.

### DIFF
--- a/VulkanHppGenerator.hpp
+++ b/VulkanHppGenerator.hpp
@@ -116,7 +116,7 @@ private:
   struct EnumValueData
   {
     EnumValueData( int line, std::string const & vulkan, std::string const & vk, bool singleBit_ )
-      : vulkanValue( vulkan ), vkValue( vk ), singleBit( singleBit_ ), xmlLine(line)
+      : vulkanValue( vulkan ), vkValue( vk ), singleBit( singleBit_ ), xmlLine( line )
     {}
 
     std::string vulkanValue;
@@ -312,7 +312,7 @@ private:
                               bool                             singular,
                               bool                             unique,
                               bool                             isStructureChain,
-                              bool                             withAllocator ) const;
+                              bool                             withAllocatorArgument ) const;
   void        appendFunctionBodyEnhanced( std::string &                    str,
                                           std::string const &              indentation,
                                           std::string const &              name,
@@ -466,11 +466,10 @@ private:
                                      bool                singular,
                                      bool                unique,
                                      bool                withDefault,
-                                     bool                isStructureChain ) const;
-  void appendHandle( std::string &                              str,
-                     std::pair<std::string, HandleData> const & handle );
-  void appendStruct( std::string &                                 str,
-                     std::pair<std::string, StructureData> const & structure );
+                                     bool                isStructureChain,
+                                     bool                withAllocatorArgument ) const;
+  void appendHandle( std::string & str, std::pair<std::string, HandleData> const & handle );
+  void appendStruct( std::string & str, std::pair<std::string, StructureData> const & structure );
   void appendStructAssignmentOperators( std::string &                                 str,
                                         std::pair<std::string, StructureData> const & structure,
                                         std::string const &                           prefix ) const;

--- a/tests/DeviceFunctions/DeviceFunctions.cpp
+++ b/tests/DeviceFunctions/DeviceFunctions.cpp
@@ -30,6 +30,9 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::UniqueInstance  instance       = vk::createInstanceUnique( vk::InstanceCreateInfo( {}, &appInfo ) );
     vk::PhysicalDevice  physicalDevice = instance->enumeratePhysicalDevices().front();
 
+    uint32_t propertyCount;
+    physicalDevice.getQueueFamilyProperties( &propertyCount, nullptr );
+
     // get the QueueFamilyProperties of the first PhysicalDevice
     std::vector<vk::QueueFamilyProperties> queueFamilyProperties = physicalDevice.getQueueFamilyProperties();
 


### PR DESCRIPTION
+ change the order of Allocator and Dispatch template arguments for functions returning a std::vector<UniqueStuff>, as the Allocator needs to use the Dispatch in those cases!