### PR TITLE
Introduce VULKAN_HPP_NO_DEFAULT_DISPATCHER to not have a default argument for the last argument of each function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,15 @@ The goal of the Vulkan-Hpp is to provide header only C++ bindings for the Vulkan
 
 Vulkan-Hpp is part of the LunarG Vulkan SDK since version 1.0.24. Just `#include <vulkan/vulkan.hpp>` and you're ready to use the C++ bindings. If you're using a Vulkan version not yet supported by the Vulkan SDK you can find the latest version of the header [here](https://github.com/KhronosGroup/Vulkan-Hpp/blob/master/vulkan/vulkan.hpp).
 
+### Minimum Requirements
+
+Vulkan-Hpp requires a C++11 capable compiler to compile. The following compilers are known to work:
+* Visual Studio >=2015
+* GCC >= 4.8.2 (earlier version might work, but are untested)
+* Clang >= 3.3
+
 ### Building Vulkan-Hpp, Samples, and Tests
+
 To build the local samples and tests you'll have to clone this repository and run CMake to generate the required build files
 
 0.) Ensure that you have CMake and git installed and accessible from a shell. Ensure that you have installed the Vulkan SDK. Optionally install clang-format >= 10.0 to get a nicely formatted Vulkan-Hpp header.
@@ -24,13 +32,6 @@ For a full list of generators execute ```cmake -G```.
 5.) Either open the generated project with an IDE, e.g. Visual Studio or launch the build process with ```cmake --build .```.
 
 optional) To update the Vulkan-Hpp and its submodules execute ```git pull --recurse-submodules```.
-
-### Minimum Requirements
-
-Vulkan-Hpp requires a C++11 capable compiler to compile. The following compilers are known to work:
-* Visual Studio >=2015
-* GCC >= 4.8.2 (earlier version might work, but are untested)
-* Clang >= 3.3
 
 ### Optional Features
 
@@ -467,6 +468,8 @@ Creating a full featured ```DispatchLoaderDynamic``` is a two- to three-step pro
 After the second step above, the dispatcher is fully functional. Adding the third step can potentially result in more efficient code.
 
 In some cases the storage for the DispatchLoaderDynamic should be embedded in a DLL. For those cases you need to define ```VULKAN_HPP_STORAGE_SHARED``` to tell Vulkan-Hpp that the storage resides in a DLL. When compiling the DLL with the storage it is also required to define ```VULKAN_HPP_STORAGE_SHARED_EXPORT``` to export the required symbols.
+
+For all functions, that VULKAN_HPP_DEFAULT_DISPATCHER is the default for the last argument to that function. In case you want to explicitly provide the dispatcher for each and every function call (when you have multiple dispatchers for different devices, for example) and you want to make sure, that you don't accidentally miss any function call, you can define VULKAN_HPP_NO_DEFAULT_DISPATCHER before you include vulkan.hpp to remove that default argument.
 
 
 ### Samples and Tests

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -1777,6 +1777,16 @@ void VulkanHppGenerator::appendDispatchLoaderDefault( std::string & str )
 #  define VULKAN_HPP_DEFAULT_DISPATCHER_TYPE ::VULKAN_HPP_NAMESPACE::DispatchLoaderStatic
 # endif
 #endif
+
+#if defined( VULKAN_HPP_NO_DEFAULT_DISPATCHER )
+#  define VULKAN_HPP_DEFAULT_ARGUMENT_ASSIGNMENT
+#  define VULKAN_HPP_DEFAULT_ARGUMENT_NULLPTR_ASSIGNMENT
+#  define VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT
+#else
+#  define VULKAN_HPP_DEFAULT_ARGUMENT_ASSIGNMENT = {}
+#  define VULKAN_HPP_DEFAULT_ARGUMENT_NULLPTR_ASSIGNMENT = nullptr
+#  define VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT = VULKAN_HPP_DEFAULT_DISPATCHER
+#endif
 )";
 }
 
@@ -2728,7 +2738,8 @@ void VulkanHppGenerator::appendFunctionHeaderArgumentEnhancedPointer( std::strin
            stripPrefix( param.type.type, "Vk" ) + "> " + strippedParameterName;
     if ( withDefaults && !withAllocator )
     {
-      str += " = nullptr";
+      assert( param.type.type == "VkAllocationCallbacks" );
+      str += " VULKAN_HPP_DEFAULT_ARGUMENT_NULLPTR_ASSIGNMENT";
     }
   }
   else if ( param.type.type == "void" )
@@ -2768,7 +2779,7 @@ void VulkanHppGenerator::appendFunctionHeaderArgumentEnhancedSimple(
       if ( ( enumIt == m_enums.end() ) || ( enumIt->second.values.empty() ) )
       {
         // there are no bits in this flag -> provide the default
-        str += " = " + stripPrefix( param.type.type, "Vk" ) + "()";
+        str += " VULKAN_HPP_DEFAULT_ARGUMENT_ASSIGNMENT";
       }
     }
   }
@@ -2798,7 +2809,7 @@ void VulkanHppGenerator::appendFunctionHeaderArgumentEnhancedVector( std::string
     str += optionalBegin + "const std::string" + optionalEnd + strippedParameterName;
     if ( optional && withDefaults && !withAllocator )
     {
-      str += " = nullptr";
+      str += " VULKAN_HPP_DEFAULT_ARGUMENT_NULLPTR_ASSIGNMENT";
     }
   }
   else if ( singular )
@@ -2905,7 +2916,7 @@ void VulkanHppGenerator::appendFunctionHeaderArgumentsEnhanced( std::string &   
   str += "Dispatch const &d";
   if ( withDefaults && !withAllocator )
   {
-    str += " = VULKAN_HPP_DEFAULT_DISPATCHER";
+    str += " VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT";
   }
   str += " ";
 }
@@ -2932,7 +2943,7 @@ void VulkanHppGenerator::appendFunctionHeaderArgumentsStandard( std::string &   
   str += "Dispatch const &d";
   if ( withDefaults )
   {
-    str += " = VULKAN_HPP_DEFAULT_DISPATCHER ";
+    str += " VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT";
   }
 }
 
@@ -2959,7 +2970,7 @@ bool VulkanHppGenerator::appendFunctionHeaderArgumentStandard(
       if ( ( enumIt == m_enums.end() ) || ( enumIt->second.values.empty() ) )
       {
         // there are no bits in this flag -> provide the default
-        str += " = " + stripPrefix( param.type.type, "Vk" ) + "()";
+        str += " VULKAN_HPP_DEFAULT_ARGUMENT_ASSIGNMENT";
       }
     }
   }
@@ -7916,7 +7927,7 @@ int main( int argc, char ** argv )
         , m_dispatch( nullptr )
       {}
 
-      ObjectDestroy( OwnerType owner, Optional<const AllocationCallbacks> allocationCallbacks = nullptr, Dispatch const &dispatch = VULKAN_HPP_DEFAULT_DISPATCHER ) VULKAN_HPP_NOEXCEPT
+      ObjectDestroy( OwnerType owner, Optional<const AllocationCallbacks> allocationCallbacks VULKAN_HPP_DEFAULT_ARGUMENT_NULLPTR_ASSIGNMENT, Dispatch const &dispatch VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) VULKAN_HPP_NOEXCEPT
         : m_owner( owner )
         , m_allocationCallbacks( allocationCallbacks )
         , m_dispatch( &dispatch )
@@ -7950,7 +7961,7 @@ int main( int argc, char ** argv )
         , m_dispatch( nullptr )
       {}
 
-      ObjectDestroy( Optional<const AllocationCallbacks> allocationCallbacks, Dispatch const &dispatch = VULKAN_HPP_DEFAULT_DISPATCHER ) VULKAN_HPP_NOEXCEPT
+      ObjectDestroy( Optional<const AllocationCallbacks> allocationCallbacks, Dispatch const &dispatch VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) VULKAN_HPP_NOEXCEPT
         : m_allocationCallbacks( allocationCallbacks )
         , m_dispatch( &dispatch )
       {}
@@ -7979,8 +7990,8 @@ int main( int argc, char ** argv )
     ObjectFree() : m_owner(), m_allocationCallbacks( nullptr ), m_dispatch( nullptr ) {}
 
     ObjectFree( OwnerType                           owner,
-                Optional<const AllocationCallbacks> allocationCallbacks = nullptr,
-                Dispatch const &                    dispatch = VULKAN_HPP_DEFAULT_DISPATCHER ) VULKAN_HPP_NOEXCEPT
+                Optional<const AllocationCallbacks> allocationCallbacks VULKAN_HPP_DEFAULT_ARGUMENT_NULLPTR_ASSIGNMENT,
+                Dispatch const &                    dispatch VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) VULKAN_HPP_NOEXCEPT
       : m_owner( owner )
       , m_allocationCallbacks( allocationCallbacks )
       , m_dispatch( &dispatch )
@@ -8034,7 +8045,9 @@ int main( int argc, char ** argv )
   class PoolFree
   {
     public:
-      PoolFree( OwnerType owner = OwnerType(), PoolType pool = PoolType(), Dispatch const &dispatch = VULKAN_HPP_DEFAULT_DISPATCHER ) VULKAN_HPP_NOEXCEPT
+      PoolFree() = default;
+
+      PoolFree( OwnerType owner, PoolType pool, Dispatch const &dispatch ) VULKAN_HPP_NOEXCEPT
         : m_owner( owner )
         , m_pool( pool )
         , m_dispatch( &dispatch )
@@ -8051,9 +8064,9 @@ int main( int argc, char ** argv )
       }
 
     private:
-      OwnerType m_owner;
-      PoolType m_pool;
-      Dispatch const* m_dispatch;
+      OwnerType m_owner = OwnerType();
+      PoolType m_pool   = PoolType();
+      Dispatch const* m_dispatch = &VULKAN_HPP_DEFAULT_DISPATCHER;
   };
 )";
 


### PR DESCRIPTION
Resolves #707.