### PR TITLE
correct enhanced version of vkGetQueryPoolResults

### DIFF
--- a/VulkanHppGenerator.hpp
+++ b/VulkanHppGenerator.hpp
@@ -311,10 +311,11 @@ private:
                              std::string const & name,
                              CommandData const & commandData,
                              bool                definition ) const;
-  void        appendCommandFixedSizeVector( std::string &       str,
-                                            std::string const & name,
-                                            CommandData const & commandData,
-                                            bool                definition ) const;
+  void        appendCommandFixedSizeVector( std::string &                    str,
+                                            std::string const &              name,
+                                            CommandData const &              commandData,
+                                            std::map<size_t, size_t> const & vectorParamIndices,
+                                            bool                             definition ) const;
   void        appendDispatchLoaderDynamicCommand( std::string &       str,
                                                   std::string &       emptyFunctions,
                                                   std::string &       deviceFunctions,

--- a/samples/OcclusionQuery/OcclusionQuery.cpp
+++ b/samples/OcclusionQuery/OcclusionQuery.cpp
@@ -202,14 +202,14 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     graphicsQueue.waitIdle();
 
-    uint64_t   samplesPassed[2];
-    vk::Result result = device->getQueryPoolResults( queryPool.get(),
-                                                     0,
-                                                     2,
-                                                     vk::ArrayProxy<uint64_t>( 4, samplesPassed ),
-                                                     sizeof( uint64_t ),
-                                                     vk::QueryResultFlagBits::e64 | vk::QueryResultFlagBits::eWait );
-    switch ( result )
+    vk::ResultValue<std::vector<uint64_t>> rv =
+      device->getQueryPoolResults<uint64_t>( *queryPool,
+                                   0,
+                                   2,
+                                   2 * sizeof( uint64_t ),
+                                   sizeof( uint64_t ),
+                                   vk::QueryResultFlagBits::e64 | vk::QueryResultFlagBits::eWait );
+   switch ( rv.result )
     {
       case vk::Result::eSuccess: break;
       case vk::Result::eNotReady: std::cout << "vk::Device::getQueryPoolResults returned vk::Result::eNotReady !\n";
@@ -217,8 +217,8 @@ int main( int /*argc*/, char ** /*argv*/ )
     }
 
     std::cout << "vkGetQueryPoolResults data\n";
-    std::cout << "samples_passed[0] = " << samplesPassed[0] << "\n";
-    std::cout << "samples_passed[1] = " << samplesPassed[1] << "\n";
+    std::cout << "samples_passed[0] = " << rv.value[0] << "\n";
+    std::cout << "samples_passed[1] = " << rv.value[1] << "\n";
 
     /* Read back query result from buffer */
     uint64_t * samplesPassedPtr = static_cast<uint64_t *>(
@@ -233,7 +233,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     while ( vk::Result::eTimeout == device->waitForFences( drawFence.get(), VK_TRUE, vk::su::FenceTimeout ) )
       ;
 
-    result = presentQueue.presentKHR( vk::PresentInfoKHR( {}, *swapChainData.swapChain, currentBuffer.value ) );
+    vk::Result result = presentQueue.presentKHR( vk::PresentInfoKHR( {}, *swapChainData.swapChain, currentBuffer.value ) );
     switch ( result )
     {
       case vk::Result::eSuccess: break;


### PR DESCRIPTION
- mark wrong version as deprecated (C++14)
- introduce new version returning ResultValue<vector<T,Allocator>>
- introduce new singular version returning ResultValue<T>