### PR TITLE
Introduce helper function ResultValue<UniqueHandle<Type, Dispatch>>::asTuple()

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -9436,8 +9436,10 @@ namespace std
       , value(std::move(v))
     {}
 
-    Result                        result;
-    UniqueHandle<Type, Dispatch>  value;
+    std::tuple<Result, UniqueHandle<Type, Dispatch>> asTuple()
+    {
+      return std::make_tuple( result, std::move( value ) );
+    }
 
 #  if !defined(VULKAN_HPP_DISABLE_IMPLICIT_RESULT_VALUE_CAST)
     VULKAN_HPP_DEPRECATED("Implicit-cast operators on vk::ResultValue are deprecated. Explicitly access the value as member of ResultValue.")
@@ -9452,6 +9454,9 @@ namespace std
       return std::move(value);
     }
 #  endif
+
+    Result                        result;
+    UniqueHandle<Type, Dispatch>  value;
   };
 
   template <typename Type, typename Dispatch>

--- a/samples/14_InitPipeline/14_InitPipeline.cpp
+++ b/samples/14_InitPipeline/14_InitPipeline.cpp
@@ -161,9 +161,11 @@ int main( int /*argc*/, char ** /*argv*/ )
       renderPass.get()                        // renderPass
     );
 
-    vk::ResultValue<vk::UniquePipeline> pipeline =
-      device->createGraphicsPipelineUnique( nullptr, graphicsPipelineCreateInfo );
-    switch ( pipeline.result )
+    vk::Result         result;
+    vk::UniquePipeline pipeline;
+    std::tie( result, pipeline ) =
+      device->createGraphicsPipelineUnique( nullptr, graphicsPipelineCreateInfo ).asTuple();
+    switch ( result )
     {
       case vk::Result::eSuccess: break;
       case vk::Result::ePipelineCompileRequiredEXT:


### PR DESCRIPTION
Allows coding like this:

    vk::Result         result;
    vk::UniquePipeline pipeline;
    std::tie( result, pipeline ) =
      device->createGraphicsPipelineUnique( nullptr, graphicsPipelineCreateInfo ).asTuple();

Resolves #714