### PR TITLE
Fix T & ArrayWrapper1D::operator[](int index)

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -10250,7 +10250,7 @@ int main( int argc, char ** argv )
       return std::array<T, N>::operator[](index);
     }
 
-    VULKAN_HPP_CONSTEXPR T & operator[](int index) VULKAN_HPP_NOEXCEPT
+    T & operator[](int index) VULKAN_HPP_NOEXCEPT
     {
       return std::array<T, N>::operator[](index);
     }


### PR DESCRIPTION
With MinGW I get the following error, because constexpr clashes with const:
vulkan.hpp:544:30: error: ‘constexpr T& vk::ArrayWrapper1D<T, N>::operator const’
cannot be overloaded with ‘constexpr const T& vk::ArrayWrapper1D<T, N>::operator const’
544 | VULKAN_HPP_CONSTEXPR T & operator[](int index) VULKAN_HPP_NOEXCEPT