### PR TITLE
Introduce VULKAN_HPP_NO_SPACESHIP_OPERATOR to disable operator<=>() for all structs and classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,10 @@ With C++17, all ```vk```-functions returning something are declared with the att
 
 By defining ```VULKAN_HPP_NO_SMART_HANDLE``` before including vulkan.hpp, the helper class ```UniqueHandle``` and all the unique handle types are not available.
 
+### VULKAN_HPP_NO_SPACESHIP_OPERATOR
+
+With C++20, the so-called spaceship-operator ```<=>``` is introduced. If that operator is supported, all the structs and classes in vulkan.hpp use the default implementation of it. As currently some implementations of this operator are very slow, and others seem to be incomplete, by defining ```VULKAN_HPP_NO_SPACESHIP_OPERATOR``` before including vulkan.hpp you can remove that operator from those structs and classes.
+
 #### VULKAN_HPP_TYPESAFE_CONVERSION
 
 32-bit vulkan is not typesafe for handles, so we don't allow copy constructors on this platform by default. To enable this feature on 32-bit platforms define ```VULKAN_HPP_TYPESAFE_CONVERSION```.

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -11040,7 +11040,7 @@ extern "C" __declspec( dllimport ) FARPROC __stdcall GetProcAddress( HINSTANCE h
 # define __has_include(x) false
 #endif
 
-#if ( 201711 <= __cpp_impl_three_way_comparison ) && __has_include( <compare> )
+#if ( 201711 <= __cpp_impl_three_way_comparison ) && __has_include( <compare> ) && !defined( VULKAN_HPP_NO_SPACESHIP_OPERATOR )
 # define VULKAN_HPP_HAS_SPACESHIP_OPERATOR
 #endif
 #if defined(VULKAN_HPP_HAS_SPACESHIP_OPERATOR)


### PR DESCRIPTION
Resolves #827.