### PR TITLE
Guard definition of VULKAN_HPP_STORAGE_API by an if !defined(); extend internal support to gcc and clang.

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,11 @@ By defining ```VULKAN_HPP_NO_SMART_HANDLE``` before including vulkan.hpp, the he
 
 With C++20, the so-called spaceship-operator ```<=>``` is introduced. If that operator is supported, all the structs and classes in vulkan.hpp use the default implementation of it. As currently some implementations of this operator are very slow, and others seem to be incomplete, by defining ```VULKAN_HPP_NO_SPACESHIP_OPERATOR``` before including vulkan.hpp you can remove that operator from those structs and classes.
 
+#### VULKAN_HPP_STORAGE_API
+
+With this define you can specify whether the ```DispatchLoaderDynamic``` is imported or exported. If ```VULKAN_HPP_STORAGE_API``` is not defined externally, and ```VULKAN_HPP_STORAGE_SHARED``` is defined, depending on the ```VULKAN_HPP_STORAGE_SHARED_EXPORT``` being defined, ```VULKAN_HPP_STORAGE_API``` is either set to ```__declspec( dllexport )``` (for MSVC) / ```__attribute__( ( visibility( "default" ) ) )``` (for gcc or clang) or ```__declspec( dllimport )``` (for MSVC), respectively. For other compilers, you might specify the corresponding storage by defining ```VULKAN_HPP_STORAGE_API``` on your own.
+
+
 #### VULKAN_HPP_TYPESAFE_CONVERSION
 
 32-bit vulkan is not typesafe for handles, so we don't allow copy constructors on this platform by default. To enable this feature on 32-bit platforms define ```VULKAN_HPP_TYPESAFE_CONVERSION```.

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -2044,14 +2044,27 @@ void VulkanHppGenerator::appendDispatchLoaderDefault( std::string & str )
 # endif
 #endif
 
-#if defined(_WIN32) && defined(VULKAN_HPP_STORAGE_SHARED)
-#  ifdef VULKAN_HPP_STORAGE_SHARED_EXPORT
-#    define VULKAN_HPP_STORAGE_API __declspec( dllexport )
+#if !defined( VULKAN_HPP_STORAGE_API )
+#  if defined( VULKAN_HPP_STORAGE_SHARED )
+#    if defined( _MSC_VER )
+#      if defined( VULKAN_HPP_STORAGE_SHARED_EXPORT )
+#        define VULKAN_HPP_STORAGE_API __declspec( dllexport )
+#      else
+#        define VULKAN_HPP_STORAGE_API __declspec( dllimport )
+#      endif
+#    elif defined( __clang__ ) || defined( __GNUC__ )
+#      if defined( VULKAN_HPP_STORAGE_SHARED_EXPORT )
+#        define VULKAN_HPP_STORAGE_API __attribute__( ( visibility( "default" ) ) )
+#      else
+#        define VULKAN_HPP_STORAGE_API
+#      endif
+#    else
+#      define VULKAN_HPP_STORAGE_API
+#      pragma warning Unknown import / export semantics
+#    endif
 #  else
-#    define VULKAN_HPP_STORAGE_API __declspec( dllimport )
+#    define VULKAN_HPP_STORAGE_API
 #  endif
-#else
-#  define VULKAN_HPP_STORAGE_API
 #endif
 
 #if !defined(VULKAN_HPP_DEFAULT_DISPATCHER)


### PR DESCRIPTION
+ mention that define in the README.md

Resolves #849.