### PR TITLE
[linux][warnings] Fix -Werror=unused-but-set-variable on GCC 10.2, Linux

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -4091,11 +4091,10 @@ std::string
 {
   assert( commandData.returnType == "VkResult" );
 
-  auto firstVectorParamIt = vectorParamIndices.begin();
-
   assert( commandData.params[0].type.type == commandData.handle );
 
 #if !defined( NDEBUG )
+  auto firstVectorParamIt = vectorParamIndices.begin();
   auto secondVectorParamIt = std::next( firstVectorParamIt );
   assert( firstVectorParamIt->second == secondVectorParamIt->second );
 #endif


### PR DESCRIPTION
Variable definition moved into a block where it is conditionally used.

Fixes #854.