### PR TITLE
Update Vookoo introduction article link

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,7 +596,7 @@ All those elements will be removed around November 2021.
 Feel free to submit a PR to add to this list.
 
 - [Examples](https://github.com/jherico/vulkan) A port of Sascha Willems [examples](https://github.com/SaschaWillems/Vulkan) to Vulkan-Hpp 
-- [Vookoo](https://github.com/andy-thomason/Vookoo/) Stateful helper classes for Vulkan-Hpp, [Introduction Article](https://accu.org/index.php/journals/2380).
+- [Vookoo](https://github.com/andy-thomason/Vookoo/) Stateful helper classes for Vulkan-Hpp, [Introduction Article](https://accu.org/journals/overload/25/139/overload139.pdf#page=14).
 
 ## License
 


### PR DESCRIPTION
The previous is unable. I updated the link to point to the PDF which is readily available