### PR TITLE
Add vkGetDrmDisplayEXT to the list of function deleted by ObjectRelease

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -5035,7 +5035,7 @@ std::string VulkanHppGenerator::constructCommandResultGetHandleUnique( std::stri
     if ( ( name.find( "Acquire" ) != std::string::npos ) || ( name.find( "Get" ) != std::string::npos ) )
     {
       if ( ( name == "vkAcquirePerformanceConfigurationINTEL" ) || ( name == "vkGetRandROutputDisplayEXT" ) ||
-           ( name == "vkGetWinrtDisplayNV" ) )
+           ( name == "vkGetWinrtDisplayNV" ) || ( name == "vkGetDrmDisplayEXT" ))
       {
         objectDeleter = "ObjectRelease";
       }


### PR DESCRIPTION
CI is blocked for https://github.com/KhronosGroup/Vulkan-Docs/pull/1529 because the function not recognized by the generator yet.