### PR TITLE
Adding configuration option to disable struct/union setters and union constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ vk::Image image = device.createImage({{}, vk::ImageType::e2D, vk::Format::eR8G8B
 
 ### Designated Initializers
 
-Beginning with C++20, C++ supports designated initializers. As that feature requires to not have any user-declared or inherited constructors, you have to `#define VULKAN_HPP_NO_STRUCT_CONSTRUCTORS`, which removes all the structure constructors from vulkan.hpp. Instead you can then use aggregate initialization. The first few vk-lines in your source might then look like
+Beginning with C++20, C++ supports designated initializers. As that feature requires to not have any user-declared or inherited constructors, you have to `#define VULKAN_HPP_NO_CONSTRUCTORS`, which removes all the structure and union constructors from vulkan.hpp. Instead you can then use aggregate initialization. The first few vk-lines in your source might then look like
 ```c++
 // initialize the vk::ApplicationInfo structure
 vk::ApplicationInfo applicationInfo{ .pApplicationName   = AppName,
@@ -549,6 +549,10 @@ This is set to be the compiler-dependent attribute used to mark functions as inl
 
 By default, the namespace used with vulkan.hpp is ```vk```. By defining ```VULKAN_HPP_NAMESPACE``` before including vulkan.hpp, you can adjust this.
 
+#### VULKAN_HPP_NO_CONSTRUCTORS
+
+With C++20, designated initializers are available. Their use requires the absence of any user-defined constructors. Define ```VULKAN_HPP_NO_CONSTRUCTORS``` to remove constructors from structs and unions.
+
 #### VULKAN_HPP_NO_EXCEPTIONS
 
 When a vulkan function returns an error code that is not specified to be a success code, an exception is thrown unless ```VULKAN_HPP_NO_EXCEPTIONS``` is defined before including vulkan.hpp.
@@ -557,11 +561,15 @@ When a vulkan function returns an error code that is not specified to be a succe
 
 With C++17, all ```vk```-functions returning something are declared with the attribute ```[[nodiscard]]```. This can be removed by defining ```VULKAN_HPP_NO_NODISCARD_WARNINGS``` before including vulkan.hpp.
 
+#### VULKAN_HPP_NO_SETTERS
+
+By defining ```VULKAN_HPP_NO_SETTERS```before including vulkan.hpp, setter member functions will not be available within structs and unions. Modifying their data members will then only be possible via direct assignment.
+
 #### VULKAN_HPP_NO_SMART_HANDLE
 
 By defining ```VULKAN_HPP_NO_SMART_HANDLE``` before including vulkan.hpp, the helper class ```UniqueHandle``` and all the unique handle types are not available.
 
-### VULKAN_HPP_NO_SPACESHIP_OPERATOR
+#### VULKAN_HPP_NO_SPACESHIP_OPERATOR
 
 With C++20, the so-called spaceship-operator ```<=>``` is introduced. If that operator is supported, all the structs and classes in vulkan.hpp use the default implementation of it. As currently some implementations of this operator are very slow, and others seem to be incomplete, by defining ```VULKAN_HPP_NO_SPACESHIP_OPERATOR``` before including vulkan.hpp you can remove that operator from those structs and classes.
 

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -9190,10 +9190,12 @@ void VulkanHppGenerator::appendStructure( std::string &                         
   if ( !structure.second.returnedOnly )
   {
     // only structs that are not returnedOnly get setters!
+    constructorAndSetters += "\n#if !defined( VULKAN_HPP_NO_STRUCT_SETTERS )";
     for ( size_t i = 0; i < structure.second.members.size(); i++ )
     {
       appendStructSetter( constructorAndSetters, stripPrefix( structure.first, "Vk" ), structure.second.members, i );
     }
+    constructorAndSetters += "#endif /*VULKAN_HPP_NO_STRUCT_SETTERS*/\n";
   }
 
   // operator==() and operator!=()
@@ -9427,8 +9429,8 @@ void VulkanHppGenerator::appendUnion( std::string & str, std::pair<std::string, 
   str += "  union " + unionName +
          "\n"
          "  {\n"
-         "    " +
-         unionName + "( VULKAN_HPP_NAMESPACE::" + unionName +
+         "#if !defined( VULKAN_HPP_NO_UNION_CONSTRUCTORS )\n"
+         "    " + unionName + "( VULKAN_HPP_NAMESPACE::" + unionName +
          " const & rhs ) VULKAN_HPP_NOEXCEPT\n"
          "    {\n"
          "      memcpy( static_cast<void*>( this ), &rhs, sizeof( VULKAN_HPP_NAMESPACE::" +
@@ -9470,12 +9472,15 @@ void VulkanHppGenerator::appendUnion( std::string & str, std::pair<std::string, 
                              { "unionName", stripPrefix( structure.first, "Vk" ) } } );
     firstMember = false;
   }
+  str += "#endif /*VULKAN_HPP_NO_UNION_CONSTRUCTORS*/\n";
 
+  str += "\n#if !defined( VULKAN_HPP_NO_UNION_SETTERS )";
   // one setter per union element
   for ( size_t i = 0; i < structure.second.members.size(); i++ )
   {
     appendStructSetter( str, stripPrefix( structure.first, "Vk" ), structure.second.members, i );
   }
+  str += "#endif /*VULKAN_HPP_NO_UNION_SETTERS*/\n";
 
   // assignment operator
   static const std::string operatorsTemplate = R"(
@@ -16277,6 +16282,24 @@ int main( int argc, char ** argv )
 #else
 #  include <memory>
 #  include <vector>
+#endif
+
+#if defined( VULKAN_HPP_NO_CONSTRUCTORS )
+#  if !defined( VULKAN_HPP_NO_STRUCT_CONSTRUCTORS )
+#    define VULKAN_HPP_NO_STRUCT_CONSTRUCTORS
+#  endif
+#  if !defined( VULKAN_HPP_NO_UNION_CONSTRUCTORS )
+#    define VULKAN_HPP_NO_UNION_CONSTRUCTORS
+#  endif
+#endif
+
+#if defined( VULKAN_HPP_NO_SETTERS )
+#  if !defined( VULKAN_HPP_NO_STRUCT_SETTERS )
+#    define VULKAN_HPP_NO_STRUCT_SETTERS
+#  endif
+#  if !defined( VULKAN_HPP_NO_UNION_SETTERS )
+#    define VULKAN_HPP_NO_UNION_SETTERS
+#  endif
 #endif
 
 #if !defined( VULKAN_HPP_ASSERT )


### PR DESCRIPTION
Hello maintainers,

this PR extends Vulkan-HPP's customization capabilities. In my case, since I prefer using designated initializers for Vulkan, having the setter methods around clutters up my IDE's dropdowns. I added a #define option that allows people to remove the setter methods on structs and unions respectively via `VULKAN_HPP_NO_STRUCT_SETTERS` / `VULKAN_HPP_NO_UNION_SETTERS` and also in general via `VULKAN_HPP_NO_SETTERS`.

Also since unions can also be used with designated initializers, I added `VULKAN_HPP_NO_UNION_CONSTRUCTORS` to allow for this when desired. Both that define and `VULKAN_HPP_NO_STRUCT_CONSTRUCTORS` are defined when `VULKAN_HPP_NO_CONSTRUCTORS` is defined.

I also amended the README.md to account for these config options. I think these additions could be useful for a number of users.