### PR TITLE
Fix release build of samples: suppress warnings about unused variables

### DIFF
--- a/RAII_Samples/11_InitShaders/11_InitShaders.cpp
+++ b/RAII_Samples/11_InitShaders/11_InitShaders.cpp
@@ -45,14 +45,20 @@ int main( int /*argc*/, char ** /*argv*/ )
     glslang::InitializeProcess();
 
     std::vector<unsigned int> vertexShaderSPV;
-    bool ok = vk::su::GLSLtoSPV( vk::ShaderStageFlagBits::eVertex, vertexShaderText_PC_C, vertexShaderSPV );
+#if !defined( NDEBUG )
+    bool ok = 
+  #endif
+      vk::su::GLSLtoSPV( vk::ShaderStageFlagBits::eVertex, vertexShaderText_PC_C, vertexShaderSPV );
     assert( ok );
 
     vk::ShaderModuleCreateInfo vertexShaderModuleCreateInfo( {}, vertexShaderSPV );
     vk::raii::ShaderModule     vertexShaderModule( device, vertexShaderModuleCreateInfo );
 
     std::vector<unsigned int> fragmentShaderSPV;
-    ok = vk::su::GLSLtoSPV( vk::ShaderStageFlagBits::eFragment, fragmentShaderText_C_C, fragmentShaderSPV );
+#if !defined( NDEBUG )
+    ok =
+#endif
+      vk::su::GLSLtoSPV( vk::ShaderStageFlagBits::eFragment, fragmentShaderText_C_C, fragmentShaderSPV );
     assert( ok );
 
     vk::ShaderModuleCreateInfo fragmentShaderModuleCreateInfo( {}, fragmentShaderSPV );

--- a/RAII_Samples/CopyBlitImage/CopyBlitImage.cpp
+++ b/RAII_Samples/CopyBlitImage/CopyBlitImage.cpp
@@ -67,10 +67,11 @@ int main( int /*argc*/, char ** /*argv*/ )
                                                graphicsAndPresentQueueFamilyIndex.second );
 
     /* VULKAN_KEY_START */
-
+#if !defined( NDEBUG )
     vk::FormatProperties formatProperties = physicalDevice.getFormatProperties( swapChainData.colorFormat );
     assert( ( formatProperties.linearTilingFeatures & vk::FormatFeatureFlagBits::eBlitSrc ) &&
             "Format cannot be used as transfer source" );
+#endif
 
     vk::raii::Semaphore imageAcquiredSemaphore( device, vk::SemaphoreCreateInfo() );
 

--- a/samples/11_InitShaders/11_InitShaders.cpp
+++ b/samples/11_InitShaders/11_InitShaders.cpp
@@ -46,14 +46,20 @@ int main( int /*argc*/, char ** /*argv*/ )
     glslang::InitializeProcess();
 
     std::vector<unsigned int> vertexShaderSPV;
-    bool ok = vk::su::GLSLtoSPV( vk::ShaderStageFlagBits::eVertex, vertexShaderText_PC_C, vertexShaderSPV );
+#if !defined( NDEBUG )
+    bool ok = 
+#endif
+      vk::su::GLSLtoSPV( vk::ShaderStageFlagBits::eVertex, vertexShaderText_PC_C, vertexShaderSPV );
     assert( ok );
 
     vk::ShaderModuleCreateInfo vertexShaderModuleCreateInfo( vk::ShaderModuleCreateFlags(), vertexShaderSPV );
     vk::ShaderModule           vertexShaderModule = device.createShaderModule( vertexShaderModuleCreateInfo );
 
     std::vector<unsigned int> fragmentShaderSPV;
-    ok = vk::su::GLSLtoSPV( vk::ShaderStageFlagBits::eFragment, fragmentShaderText_C_C, fragmentShaderSPV );
+#if !defined( NDEBUG )
+    ok = 
+#endif
+      vk::su::GLSLtoSPV( vk::ShaderStageFlagBits::eFragment, fragmentShaderText_C_C, fragmentShaderSPV );
     assert( ok );
 
     vk::ShaderModuleCreateInfo fragmentShaderModuleCreateInfo( vk::ShaderModuleCreateFlags(), fragmentShaderSPV );

--- a/samples/CopyBlitImage/CopyBlitImage.cpp
+++ b/samples/CopyBlitImage/CopyBlitImage.cpp
@@ -68,10 +68,11 @@ int main( int /*argc*/, char ** /*argv*/ )
                                          graphicsAndPresentQueueFamilyIndex.second );
 
     /* VULKAN_KEY_START */
-
+#if !defined( NDEBUG )
     vk::FormatProperties formatProperties = physicalDevice.getFormatProperties( swapChainData.colorFormat );
     assert( ( formatProperties.linearTilingFeatures & vk::FormatFeatureFlagBits::eBlitSrc ) &&
             "Format cannot be used as transfer source" );
+#endif
 
     vk::Semaphore imageAcquiredSemaphore = device.createSemaphore( vk::SemaphoreCreateInfo() );
 

--- a/samples/CreateDebugUtilsMessenger/CreateDebugUtilsMessenger.cpp
+++ b/samples/CreateDebugUtilsMessenger/CreateDebugUtilsMessenger.cpp
@@ -153,9 +153,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::DebugUtilsMessengerEXT            debugUtilsMessenger = instance.createDebugUtilsMessengerEXT(
       vk::DebugUtilsMessengerCreateInfoEXT( {}, severityFlags, messageTypeFlags, &debugMessageFunc ) );
 
-#if !defined( NDEBUG )
     instance.destroyDebugUtilsMessengerEXT( debugUtilsMessenger );
-#endif
     instance.destroy();
 
     /* VULKAN_KEY_END */


### PR DESCRIPTION
Due to `-Werror` I can only build the samples in debug mode. In release mode (clang-14), the warning about unused variables cause the build to fail.

Is there any preference how a warning about a unused variable should be suppressed?