### PR TITLE
Fix a typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ switch (result.result)
 	case vk::Result::eTimeout:
 	case vk::Result::eNotReady:
 	case vk::Result::eSuboptimalKHR:
-		// do something meaningfull
+		// do something meaningful
 		break;
 	default:
 		// should not happen, as other return codes are considered to be an error and throw an exception


### PR DESCRIPTION
Fixed a code comment typo on code samples in README.md:
meaningfull -> meaningful