### PR TITLE
Introduce getDispatchLoaderStatic() to prevent dangling pointers in debug builds.

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -16343,23 +16343,32 @@ int main( int argc, char ** argv )
 #  endif
 #endif
 
-#if !defined(VULKAN_HPP_DEFAULT_DISPATCHER)
-# if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
-#  define VULKAN_HPP_DEFAULT_DISPATCHER ::VULKAN_HPP_NAMESPACE::defaultDispatchLoaderDynamic
-#  define VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE namespace VULKAN_HPP_NAMESPACE { VULKAN_HPP_STORAGE_API DispatchLoaderDynamic defaultDispatchLoaderDynamic; }
+#if !defined( VULKAN_HPP_DEFAULT_DISPATCHER )
+#  if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
+#    define VULKAN_HPP_DEFAULT_DISPATCHER ::VULKAN_HPP_NAMESPACE::defaultDispatchLoaderDynamic
+#    define VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE                     \
+      namespace VULKAN_HPP_NAMESPACE                                               \
+      {                                                                            \
+        VULKAN_HPP_STORAGE_API DispatchLoaderDynamic defaultDispatchLoaderDynamic; \
+      }
   extern VULKAN_HPP_STORAGE_API DispatchLoaderDynamic defaultDispatchLoaderDynamic;
-# else
-#  define VULKAN_HPP_DEFAULT_DISPATCHER ::VULKAN_HPP_NAMESPACE::DispatchLoaderStatic()
-#  define VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
-# endif
+#  else
+  static ::VULKAN_HPP_NAMESPACE::DispatchLoaderStatic & getDispatchLoaderStatic()
+  {
+    static ::VULKAN_HPP_NAMESPACE::DispatchLoaderStatic dls;
+    return dls;
+  }
+#    define VULKAN_HPP_DEFAULT_DISPATCHER ::VULKAN_HPP_NAMESPACE::getDispatchLoaderStatic()
+#    define VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
+#  endif
 #endif
 
-#if !defined(VULKAN_HPP_DEFAULT_DISPATCHER_TYPE)
-# if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
-  #define VULKAN_HPP_DEFAULT_DISPATCHER_TYPE ::VULKAN_HPP_NAMESPACE::DispatchLoaderDynamic
-# else
-#  define VULKAN_HPP_DEFAULT_DISPATCHER_TYPE ::VULKAN_HPP_NAMESPACE::DispatchLoaderStatic
-# endif
+#if !defined( VULKAN_HPP_DEFAULT_DISPATCHER_TYPE )
+#  if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
+#    define VULKAN_HPP_DEFAULT_DISPATCHER_TYPE ::VULKAN_HPP_NAMESPACE::DispatchLoaderDynamic
+#  else
+#    define VULKAN_HPP_DEFAULT_DISPATCHER_TYPE ::VULKAN_HPP_NAMESPACE::DispatchLoaderStatic
+#  endif
 #endif
 
 #if defined( VULKAN_HPP_NO_DEFAULT_DISPATCHER )

--- a/tests/ArrayProxy/ArrayProxy.cpp
+++ b/tests/ArrayProxy/ArrayProxy.cpp
@@ -30,6 +30,9 @@ int main( int /*argc*/, char ** /*argv*/ )
 {
   try
   {
+    // to prevent a warning on unreferenced function vk::getDispatchLoaderStatic, use just one arbitrary vk-function
+    vk::enumerateInstanceVersion();
+
     // nullptr_t
     fct( nullptr );
     fctc( nullptr );

--- a/tests/ArrayProxyNoTemporaries/ArrayProxyNoTemporaries.cpp
+++ b/tests/ArrayProxyNoTemporaries/ArrayProxyNoTemporaries.cpp
@@ -66,6 +66,9 @@ int main( int /*argc*/, char ** /*argv*/ )
 {
   try
   {
+    // to prevent a warning on unreferenced function vk::getDispatchLoaderStatic, use just one arbitrary vk-function
+    vk::enumerateInstanceVersion();
+
     // nullptr_t
     fct(nullptr);
     fctc(nullptr);

--- a/tests/DesignatedInitializers/DesignatedInitializers.cpp
+++ b/tests/DesignatedInitializers/DesignatedInitializers.cpp
@@ -50,6 +50,9 @@ MyVulkanTest::MyVulkanTest()
 
 int main( int /*argc*/, char ** /*argv*/ )
 {
+  // to prevent a warning on unreferenced function vk::getDispatchLoaderStatic, use just one arbitrary vk-function
+  vk::enumerateInstanceVersion();
+
   char const * appName       = "DesignatedInitializers";
   uint32_t     appVersion    = 1;
   char const * engineName    = "Vulkan.hpp";

--- a/tests/DispatchLoaderStatic/CMakeLists.txt
+++ b/tests/DispatchLoaderStatic/CMakeLists.txt
@@ -1,0 +1,44 @@
+# Copyright(c) 2018, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.2)
+
+if (NOT TESTS_BUILD_ONLY_DYNAMIC)
+
+  project(DispatchLoaderStatic)
+
+  set(HEADERS
+  )
+
+  set(SOURCES
+    DispatchLoaderStatic.cpp
+  )
+
+  source_group(headers FILES ${HEADERS})
+  source_group(sources FILES ${SOURCES})
+
+  add_executable(DispatchLoaderStatic
+    ${HEADERS}
+    ${SOURCES}
+    )
+
+  if (UNIX)
+    target_link_libraries(DispatchLoaderStatic "-ldl")
+  endif()
+
+  target_link_libraries(DispatchLoaderStatic "${Vulkan_LIBRARIES}")
+
+  set_target_properties(DispatchLoaderStatic PROPERTIES FOLDER "Tests")
+
+endif()

--- a/tests/DispatchLoaderStatic/DispatchLoaderStatic.cpp
+++ b/tests/DispatchLoaderStatic/DispatchLoaderStatic.cpp
@@ -1,0 +1,49 @@
+// Copyright(c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// VulkanHpp Samples : DispatchLoaderStatic
+//                     Compile test on DispatchLoaderStatic functions
+
+#include "vulkan/vulkan.hpp"
+
+#include <iostream>
+#include <map>
+
+int main( int /*argc*/, char ** /*argv*/ )
+{
+  try
+  {
+    vk::Instance instance = vk::createInstance( {} );
+
+    std::vector<vk::PhysicalDevice> physicalDevices = instance.enumeratePhysicalDevices();
+    assert( !physicalDevices.empty() );
+
+    vk::Device device = physicalDevices[0].createDevice( {} );
+
+    device.destroy();
+    instance.destroy();
+  }
+  catch ( vk::SystemError const & err )
+  {
+    std::cout << "vk::SystemError: " << err.what() << std::endl;
+    exit( -1 );
+  }
+  catch ( ... )
+  {
+    std::cout << "unknown error\n";
+    exit( -1 );
+  }
+
+  return 0;
+}

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -5634,7 +5634,12 @@ namespace VULKAN_HPP_NAMESPACE
       }
   extern VULKAN_HPP_STORAGE_API DispatchLoaderDynamic defaultDispatchLoaderDynamic;
 #  else
-#    define VULKAN_HPP_DEFAULT_DISPATCHER ::VULKAN_HPP_NAMESPACE::DispatchLoaderStatic()
+  static ::VULKAN_HPP_NAMESPACE::DispatchLoaderStatic & getDispatchLoaderStatic()
+  {
+    static ::VULKAN_HPP_NAMESPACE::DispatchLoaderStatic dls;
+    return dls;
+  }
+#    define VULKAN_HPP_DEFAULT_DISPATCHER ::VULKAN_HPP_NAMESPACE::getDispatchLoaderStatic()
 #    define VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 #  endif
 #endif


### PR DESCRIPTION
Resolves #1065.