### PR TITLE
ci: Add .github/workflows/update-header-pr.yml

### DIFF
--- a/.github/workflows/set-version-tag.yml
+++ b/.github/workflows/set-version-tag.yml
@@ -1,0 +1,28 @@
+name: Set Version Tag
+
+on:
+  push:
+    branches: ["master"]
+
+jobs:
+  set-version-tag:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Update Submodules
+      run: |
+        git submodule update --init --recursive
+        cd Vulkan-Headers
+        VK_HEADER_GIT_TAG=$(git tag --points-at HEAD | head -n1)
+        git checkout $VK_HEADER_GIT_TAG
+        echo "VK_HEADER_GIT_TAG=$VK_HEADER_GIT_TAG" >> $GITHUB_ENV
+
+    - name: Set Tag
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+        git tag $VK_HEADER_GIT_TAG || echo "Failed to set tag. Already existing?"
+        git push -u origin $VK_HEADER_GIT_TAG || echo "Failed to push tag. Already existing?"

--- a/.github/workflows/update-header-pr.yml
+++ b/.github/workflows/update-header-pr.yml
@@ -1,4 +1,4 @@
-name: CI Ubuntu
+name: Update Vulkan-Headers PR
 
 on:
   schedule:
@@ -56,4 +56,4 @@ jobs:
         branch: update-vulkan-headers-pr
         base: ${{ github.head_ref }}
         body: |
-          Please close and open this PR to trigger the CI!
+          Please close and reopen this PR to trigger the CI!

--- a/.github/workflows/update-header-pr.yml
+++ b/.github/workflows/update-header-pr.yml
@@ -1,0 +1,59 @@
+name: CI Ubuntu
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # every day at midnight
+
+jobs:
+  update-vulkan-headers:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        build_type: [Debug]
+        cxx_compiler: [g++-9]
+        cxx_standard: [11]
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Install libraries
+      run: sudo apt install clang-format-12
+
+    - name: Update Submodules
+      run: |
+        git submodule update --init --recursive
+        cd Vulkan-Headers
+        VK_HEADER_GIT_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+        git checkout $VK_HEADER_GIT_TAG
+        echo "VK_HEADER_GIT_TAG=$VK_HEADER_GIT_TAG" >> $GITHUB_ENV
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build
+            -DSAMPLES_BUILD=OFF
+            -DTESTS_BUILD=OFF
+            -DVULKAN_HPP_RUN_GENERATOR=ON
+            -DCMAKE_CXX_COMPILER=${{matrix.cxx_compiler}}
+            -DCMAKE_CXX_STANDARD=${{matrix.cxx_standard}}
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}}
+
+    - name: Commit changes
+      run: |
+        git config user.name "GitHub"
+        git config user.email "noreply@github.com"
+        git add Vulkan-Headers vulkan
+        rm -rf build
+        git commit -m "Update Vulkan-Headers to $VK_HEADER_GIT_TAG" || echo 'No commit necessary!'
+        git clean -xf
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        commit-message: Update Vulkan-Headers to ${{ env.VK_HEADER_GIT_TAG }}
+        title: Update Vulkan-Headers to ${{ env.VK_HEADER_GIT_TAG }}
+        branch: update-vulkan-headers-pr
+        base: ${{ github.head_ref }}
+        body: |
+          Please close and open this PR to trigger the CI!


### PR DESCRIPTION
Generates PRs like theHamsta#2

As I said, Github will usually not automatically run the CI when commits are created via Github Action Bot. The CI can be triggered manually by closing and the opening the respective PR again.