### PR TITLE
Don't overwrite vkGetInstanceProcAddress

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -6066,6 +6066,11 @@ std::string VulkanHppGenerator::generateDispatchLoaderDynamicCommandAssignment( 
                                                                                 CommandData const & commandData,
                                                                                 std::string const & firstArg ) const
 {
+  if (commandName == "vkGetInstanceProcAddr")
+  {
+    // Don't overwite vkGetInstanceProcAddr with NULL.
+    return "";
+  }
   std::string str = "      " + commandName + " = PFN_" + commandName + "( vkGet" +
                     ( ( firstArg == "device" ) ? "Device" : "Instance" ) + "ProcAddr( " + firstArg + ", \"" +
                     commandName + "\" ) );\n";


### PR DESCRIPTION
The vk::DispatchLoaderDynamic::init(vk::VkInstance) method should note
use vkGetInstanceProcAddr to overwrite vkGetInstanceProcAddr itself.

vkGetInstanceProcAddr( a_valid_instance, "vkGetInstanceProcAddr" ) is
required to return NULL.

Fixes: #1108