### PR TITLE
Check for "VK_API_VERSION_m_n" or "VK_VERSION_m_n" in SPIRVCapabilities and SPIRVExtensions

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -13338,11 +13338,14 @@ void VulkanHppGenerator::readSPIRVCapabilitiesSPIRVCapabilityEnableVersion(
   for ( auto const & attribute : attributes )
   {
     assert( attribute.first == "version" );
-    check( beginsWith( attribute.second, "VK_API_VERSION_" ),
+    std::string feature = attribute.second;
+    if ( beginsWith( feature, "VK_API_" ) )
+    {
+      feature.erase( 3, 4 );  // remove "API_" from the version -> VK_VERSION_x_y
+    }
+    check( beginsWith( feature, "VK_VERSION_" ),
            xmlLine,
            "unknown version <" + attribute.second + "> specified for SPIR-V capability" );
-    std::string feature = attribute.second;
-    feature.erase( 3, 4 );  // remove "API_" from the version -> VK_VERSION_x_y
     check( m_features.find( feature ) != m_features.end(),
            xmlLine,
            "unknown version <" + attribute.second + "> specified for SPIR-V capability" );
@@ -13398,11 +13401,14 @@ void VulkanHppGenerator::readSPIRVExtensionsExtensionEnable( tinyxml2::XMLElemen
     else
     {
       assert( attribute.first == "version" );
-      check( beginsWith( attribute.second, "VK_API_VERSION_" ),
+      std::string feature = attribute.second;
+      if ( beginsWith( feature, "VK_API_" ) )
+      {
+        feature.erase( 3, 4 );  // remove "API_" from the version -> VK_VERSION_x_y
+      }
+      check( beginsWith( feature, "VK_VERSION_" ),
              line,
              "unknown version <" + attribute.second + "> specified for SPIR-V extension" );
-      std::string feature = attribute.second;
-      feature.erase( 3, 4 );  // remove "API_" from the version -> VK_VERSION_x_y
       check( m_features.find( feature ) != m_features.end(),
              line,
              "unknown version <" + attribute.second + "> specified for SPIR-V extension" );


### PR DESCRIPTION
Resolves #1126.