### PR TITLE
Generalize ArrayProxy and ArrayProxyNoTemporaries constructors

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -15647,83 +15647,23 @@ int main( int argc, char ** argv )
 #    pragma GCC diagnostic pop
 #  endif
 
-    template <size_t N>
-    ArrayProxy( std::array<T, N> const & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( N )
-      , m_ptr( data.data() )
+    // Any type with a .data() return type implicitly convertible to T*, and a
+    // .size() return type implicitly convertible to size_t. The const version
+    // can capture temporaries, with lifetime ending at end of statement.
+    template<typename V, typename std::enable_if<
+                             std::is_convertible<decltype(std::declval<V>().data()), T*>::value
+                             && std::is_convertible<decltype(std::declval<V>().size()), std::size_t>::value>::type* = nullptr>
+    ArrayProxy( const V & v ) VULKAN_HPP_NOEXCEPT
+        : m_count( static_cast<uint32_t>( v.size() ) ),
+          m_ptr( v.data() )
     {}
-
-    template <size_t N, typename B = T, typename std::enable_if<std::is_const<B>::value, int>::type = 0>
-    ArrayProxy( std::array<typename std::remove_const<T>::type, N> const & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( N )
-      , m_ptr( data.data() )
+    template<typename V, typename std::enable_if<
+                             std::is_convertible<decltype(std::declval<V>().data()), T*>::value
+                             && std::is_convertible<decltype(std::declval<V>().size()), std::size_t>::value>::type* = nullptr>
+    ArrayProxy( V & v ) VULKAN_HPP_NOEXCEPT
+        : m_count( static_cast<uint32_t>( v.size() ) ),
+          m_ptr( v.data() )
     {}
-
-    template <size_t N>
-    ArrayProxy( std::array<T, N> & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( N )
-      , m_ptr( data.data() )
-    {}
-
-    template <size_t N, typename B = T, typename std::enable_if<std::is_const<B>::value, int>::type = 0>
-    ArrayProxy( std::array<typename std::remove_const<T>::type, N> & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( N )
-      , m_ptr( data.data() )
-    {}
-
-    template <class Allocator = std::allocator<typename std::remove_const<T>::type>>
-    ArrayProxy( std::vector<T, Allocator> const & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( static_cast<uint32_t>( data.size() ) )
-      , m_ptr( data.data() )
-    {}
-
-    template <class Allocator = std::allocator<typename std::remove_const<T>::type>,
-              typename B      = T,
-              typename std::enable_if<std::is_const<B>::value, int>::type = 0>
-    ArrayProxy( std::vector<typename std::remove_const<T>::type, Allocator> const & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( static_cast<uint32_t>( data.size() ) )
-      , m_ptr( data.data() )
-    {}
-
-    template <class Allocator = std::allocator<typename std::remove_const<T>::type>>
-    ArrayProxy( std::vector<T, Allocator> & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( static_cast<uint32_t>( data.size() ) )
-      , m_ptr( data.data() )
-    {}
-
-    template <class Allocator = std::allocator<typename std::remove_const<T>::type>,
-              typename B      = T,
-              typename std::enable_if<std::is_const<B>::value, int>::type = 0>
-    ArrayProxy( std::vector<typename std::remove_const<T>::type, Allocator> & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( static_cast<uint32_t>( data.size() ) )
-      , m_ptr( data.data() )
-    {}
-
-#if defined( VULKAN_HPP_SUPPORT_SPAN )
-    template <size_t N = std::dynamic_extent>
-    ArrayProxy( std::span<T, N> const & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( static_cast<uint32_t>( data.size() ) )
-      , m_ptr( data.data() )
-    {}
-
-    template <size_t N = std::dynamic_extent, typename B = T, typename std::enable_if<std::is_const<B>::value, int>::type = 0>
-    ArrayProxy( std::span<typename std::remove_const<T>::type, N> const & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( static_cast<uint32_t>( data.size() ) )
-      , m_ptr( data.data() )
-    {}
-
-    template <size_t N = std::dynamic_extent>
-    ArrayProxy( std::span<T, N> & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( static_cast<uint32_t>( data.size() ) )
-      , m_ptr( data.data() )
-    {}
-
-    template <size_t N = std::dynamic_extent, typename B = T, typename std::enable_if<std::is_const<B>::value, int>::type = 0>
-    ArrayProxy( std::span<typename std::remove_const<T>::type, N> & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( static_cast<uint32_t>( data.size() ) )
-      , m_ptr( data.data() )
-    {}
-#endif
 
     const T * begin() const VULKAN_HPP_NOEXCEPT
     {
@@ -15786,7 +15726,8 @@ int main( int argc, char ** argv )
       , m_ptr( &value )
     {}
 
-    ArrayProxyNoTemporaries( T && value ) = delete;
+    template<typename V>
+    ArrayProxyNoTemporaries( V && value ) = delete;
 
     template <typename B = T, typename std::enable_if<std::is_const<B>::value, int>::type = 0>
     ArrayProxyNoTemporaries( typename std::remove_const<T>::type & value ) VULKAN_HPP_NOEXCEPT
@@ -15841,112 +15782,15 @@ int main( int argc, char ** argv )
     template <typename B = T, typename std::enable_if<std::is_const<B>::value, int>::type = 0>
     ArrayProxyNoTemporaries( std::initializer_list<typename std::remove_const<T>::type> && list ) = delete;
 
-    template <size_t N>
-    ArrayProxyNoTemporaries( std::array<T, N> const & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( N )
-      , m_ptr( data.data() )
+    // Any type with a .data() return type implicitly convertible to T*, and a
+    // .size() return type implicitly convertible to size_t.
+    template<typename V, typename std::enable_if<
+                             std::is_convertible<decltype(std::declval<V>().data()), T*>::value
+                             && std::is_convertible<decltype(std::declval<V>().size()), std::size_t>::value>::type* = nullptr>
+    ArrayProxyNoTemporaries( V & v ) VULKAN_HPP_NOEXCEPT
+        : m_count( static_cast<uint32_t>( v.size() ) ),
+          m_ptr( v.data() )
     {}
-
-    template <size_t N>
-    ArrayProxyNoTemporaries( std::array<T, N> const && data ) = delete;
-
-    template <size_t N, typename B = T, typename std::enable_if<std::is_const<B>::value, int>::type = 0>
-    ArrayProxyNoTemporaries( std::array<typename std::remove_const<T>::type, N> const & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( N )
-      , m_ptr( data.data() )
-    {}
-
-    template <size_t N, typename B = T, typename std::enable_if<std::is_const<B>::value, int>::type = 0>
-    ArrayProxyNoTemporaries( std::array<typename std::remove_const<T>::type, N> const && data ) = delete;
-
-    template <size_t N>
-    ArrayProxyNoTemporaries( std::array<T, N> & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( N )
-      , m_ptr( data.data() )
-    {}
-
-    template <size_t N>
-    ArrayProxyNoTemporaries( std::array<T, N> && data ) = delete;
-
-    template <size_t N, typename B = T, typename std::enable_if<std::is_const<B>::value, int>::type = 0>
-    ArrayProxyNoTemporaries( std::array<typename std::remove_const<T>::type, N> & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( N )
-      , m_ptr( data.data() )
-    {}
-
-    template <size_t N, typename B = T, typename std::enable_if<std::is_const<B>::value, int>::type = 0>
-    ArrayProxyNoTemporaries( std::array<typename std::remove_const<T>::type, N> && data ) = delete;
-
-    template <class Allocator = std::allocator<typename std::remove_const<T>::type>>
-    ArrayProxyNoTemporaries( std::vector<T, Allocator> const & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( static_cast<uint32_t>( data.size() ) )
-      , m_ptr( data.data() )
-    {}
-
-    template <class Allocator = std::allocator<typename std::remove_const<T>::type>>
-    ArrayProxyNoTemporaries( std::vector<T, Allocator> const && data ) = delete;
-
-    template <class Allocator = std::allocator<typename std::remove_const<T>::type>,
-              typename B      = T,
-              typename std::enable_if<std::is_const<B>::value, int>::type = 0>
-    ArrayProxyNoTemporaries( std::vector<typename std::remove_const<T>::type, Allocator> const & data )
-      VULKAN_HPP_NOEXCEPT
-      : m_count( static_cast<uint32_t>( data.size() ) )
-      , m_ptr( data.data() )
-    {}
-
-    template <class Allocator = std::allocator<typename std::remove_const<T>::type>,
-              typename B      = T,
-              typename std::enable_if<std::is_const<B>::value, int>::type = 0>
-    ArrayProxyNoTemporaries( std::vector<typename std::remove_const<T>::type, Allocator> const && data ) = delete;
-
-    template <class Allocator = std::allocator<typename std::remove_const<T>::type>>
-    ArrayProxyNoTemporaries( std::vector<T, Allocator> & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( static_cast<uint32_t>( data.size() ) )
-      , m_ptr( data.data() )
-    {}
-
-    template <class Allocator = std::allocator<typename std::remove_const<T>::type>>
-    ArrayProxyNoTemporaries( std::vector<T, Allocator> && data ) = delete;
-
-    template <class Allocator = std::allocator<typename std::remove_const<T>::type>,
-              typename B      = T,
-              typename std::enable_if<std::is_const<B>::value, int>::type = 0>
-    ArrayProxyNoTemporaries( std::vector<typename std::remove_const<T>::type, Allocator> & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( static_cast<uint32_t>( data.size() ) )
-      , m_ptr( data.data() )
-    {}
-
-    template <class Allocator = std::allocator<typename std::remove_const<T>::type>,
-              typename B      = T,
-              typename std::enable_if<std::is_const<B>::value, int>::type = 0>
-    ArrayProxyNoTemporaries( std::vector<typename std::remove_const<T>::type, Allocator> && data ) = delete;
-
-#if defined( VULKAN_HPP_SUPPORT_SPAN )
-    template <size_t N = std::dynamic_extent>
-    ArrayProxyNoTemporaries( std::span<T, N> const & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( static_cast<uint32_t>( data.size() ) )
-      , m_ptr( data.data() )
-    {}
-
-    template <size_t N = std::dynamic_extent, typename B = T, typename std::enable_if<std::is_const<B>::value, int>::type = 0>
-    ArrayProxyNoTemporaries( std::span<typename std::remove_const<T>::type, N> const & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( static_cast<uint32_t>( data.size() ) )
-      , m_ptr( data.data() )
-    {}
-
-    template <size_t N = std::dynamic_extent>
-    ArrayProxyNoTemporaries( std::span<T, N> & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( static_cast<uint32_t>( data.size() ) )
-      , m_ptr( data.data() )
-    {}
-
-    template <size_t N = std::dynamic_extent, typename B = T, typename std::enable_if<std::is_const<B>::value, int>::type = 0>
-    ArrayProxyNoTemporaries( std::span<typename std::remove_const<T>::type, N> & data ) VULKAN_HPP_NOEXCEPT
-      : m_count( static_cast<uint32_t>( data.size() ) )
-      , m_ptr( data.data() )
-    {}
-#endif
 
     const T * begin() const VULKAN_HPP_NOEXCEPT
     {


### PR DESCRIPTION
Add new constructors that accept any vector-like type (with
compatible .data() and .size() methods). Replaces the more specific
constructors accepting std::array, std::vector and std::span.