### PR TITLE
Fix std::hash specializations for null-terminated strings

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -11954,6 +11954,29 @@ std::string VulkanHppGenerator::generateStructHashSum( std::string const &      
       }
       hashSum += "    }\n";
     }
+    else if ( member.type.type == "char" && !member.len.empty() )
+    {
+      assert( member.len.size() < 3 );
+      if ( member.len.size() == 1 )
+      {
+        assert( member.len[0] == "null-terminated" );
+        hashSum += "    for ( const char* p = " + structName + "." + member.name + "; *p != '\\0'; ++p )\n";
+        hashSum += "    {\n";
+        hashSum += "      VULKAN_HPP_HASH_COMBINE( seed, *p );\n";
+        hashSum += "    }\n";
+      }
+      else
+      {
+        assert( member.len[1] == "null-terminated" );
+        hashSum += "    for ( size_t i = 0; i < " + structName + "." + member.len[0] + "; ++i )\n";
+        hashSum += "    {\n";
+        hashSum += "        for ( const char* p = " + structName + "." + member.name + "[i]; *p != '\\0'; ++p )\n";
+        hashSum += "        {\n";
+        hashSum += "          VULKAN_HPP_HASH_COMBINE( seed, *p );\n";
+        hashSum += "        }\n";
+        hashSum += "    }\n";
+      }
+    }
     else
     {
       hashSum += "    VULKAN_HPP_HASH_COMBINE( seed, " + structName + "." + member.name + " );\n";
@@ -14408,8 +14431,7 @@ void VulkanHppGenerator::readSPIRVCapabilitiesSPIRVCapabilityEnableProperty(
     }
     if ( attribute.first == "requires" )
     {
-      std::vector<std::string>
-      requires = tokenize( attribute.second, "," );
+      std::vector<std::string> requires = tokenize( attribute.second, "," );
       for ( auto const & r : requires )
       {
         check( ( m_features.find( r ) != m_features.end() ) || ( m_extensions.find( r ) != m_extensions.end() ),
@@ -14468,8 +14490,7 @@ void VulkanHppGenerator::readSPIRVCapabilitiesSPIRVCapabilityEnableStruct(
   {
     if ( attribute.first == "requires" )
     {
-      std::vector<std::string>
-      requires = tokenize( attribute.second, "," );
+      std::vector<std::string> requires = tokenize( attribute.second, "," );
       for ( auto const & r : requires )
       {
         check( ( m_features.find( r ) != m_features.end() ) || ( m_extensions.find( r ) != m_extensions.end() ),

--- a/tests/Hash/Hash.cpp
+++ b/tests/Hash/Hash.cpp
@@ -36,40 +36,68 @@ int main( int /*argc*/, char ** /*argv*/ )
 {
   try
   {
-    vk::ApplicationInfo appInfo( AppName, 1, EngineName, 1, VK_API_VERSION_1_1 );
-    vk::UniqueInstance  instance = vk::createInstanceUnique( vk::InstanceCreateInfo( {}, &appInfo ) );
+    {
+      vk::ApplicationInfo appInfo( AppName, 1, EngineName, 1, VK_API_VERSION_1_1 );
+      vk::UniqueInstance  instance = vk::createInstanceUnique( vk::InstanceCreateInfo( {}, &appInfo ) );
 
-    auto h1 = std::hash<vk::Instance>{}( *instance );
-    auto h2 = std::hash<VkInstance>{}( static_cast<VkInstance>( *instance ) );
-    assert( h1 == h2 );
+      auto h1 = std::hash<vk::Instance>{}( *instance );
+      auto h2 = std::hash<VkInstance>{}( static_cast<VkInstance>( *instance ) );
+      assert( h1 == h2 );
 
-    std::unordered_set<vk::Instance> uset;
-    uset.insert( *instance );
+      std::unordered_set<vk::Instance> uset;
+      uset.insert( *instance );
 
-    std::unordered_map<vk::Instance, size_t> umap;
-    umap[*instance] = 1;
+      std::unordered_map<vk::Instance, size_t> umap;
+      umap[*instance] = 1;
 
-    vk::FormatFeatureFlags fff;
-    auto hf = std::hash<vk::FormatFeatureFlags>{}( fff );
+      vk::FormatFeatureFlags fff;
+      auto                   hf = std::hash<vk::FormatFeatureFlags>{}( fff );
+    }
 
 #if 14 <= VULKAN_HPP_CPP_VERSION
-    vk::AabbPositionsKHR aabb0, aabb1;
-    auto                 h3 = std::hash<vk::AabbPositionsKHR>{}( aabb0 );
-    auto                 h4 = std::hash<vk::AabbPositionsKHR>{}( aabb1 );
-    assert( h3 == h4 );
+    {
+      vk::AabbPositionsKHR aabb0, aabb1;
+      auto                 h1 = std::hash<vk::AabbPositionsKHR>{}( aabb0 );
+      auto                 h2 = std::hash<vk::AabbPositionsKHR>{}( aabb1 );
+      assert( h1 == h2 );
 
-    aabb0.minX = 1.0f;
-    auto h5    = std::hash<vk::AabbPositionsKHR>{}( aabb0 );
-    assert( h3 != h5 );
+      aabb0.minX = 1.0f;
+      auto h3    = std::hash<vk::AabbPositionsKHR>{}( aabb0 );
+      assert( h1 != h3 );
 
-    std::unordered_set<vk::AabbPositionsKHR> aabbSet;
-    aabbSet.insert( aabb0 );
+      std::unordered_set<vk::AabbPositionsKHR> aabbSet;
+      aabbSet.insert( aabb0 );
 
-    std::unordered_map<vk::AabbPositionsKHR, size_t> aabbMap;
-    aabbMap[aabb0] = 1;
+      std::unordered_map<vk::AabbPositionsKHR, size_t> aabbMap;
+      aabbMap[aabb0] = 1;
 
-    vk::AccelerationStructureBuildSizesInfoKHR asbsi;
-    auto                                       h6 = std::hash<vk::AccelerationStructureBuildSizesInfoKHR>{}( asbsi );
+      vk::AccelerationStructureBuildSizesInfoKHR asbsi;
+      auto                                       h4 = std::hash<vk::AccelerationStructureBuildSizesInfoKHR>{}( asbsi );
+    }
+
+    {
+      std::string         name1 = AppName;
+      std::string         name2 = AppName;
+      vk::ApplicationInfo appInfo1( name1.c_str(), 1, EngineName, 1, VK_API_VERSION_1_1 );
+      vk::ApplicationInfo appInfo2( name2.c_str(), 1, EngineName, 1, VK_API_VERSION_1_1 );
+      auto                h1 = std::hash<vk::ApplicationInfo>{}( appInfo1 );
+      auto                h2 = std::hash<vk::ApplicationInfo>{}( appInfo2 );
+      assert( h1 == h2 );
+    }
+
+    {
+      std::vector<const char *> enabledLayers1 = { "Layer1", "Layer2", "Layer3" };
+      auto                      enabledLayers2 = enabledLayers1;
+
+      vk::ApplicationInfo    appInfo( AppName, 1, EngineName, 1, VK_API_VERSION_1_1 );
+      vk::InstanceCreateInfo info1(
+        {}, &appInfo, static_cast<uint32_t>( enabledLayers1.size() ), enabledLayers1.data() );
+      vk::InstanceCreateInfo info2(
+        {}, &appInfo, static_cast<uint32_t>( enabledLayers2.size() ), enabledLayers2.data() );
+      auto h1 = std::hash<vk::InstanceCreateInfo>{}( info1 );
+      auto h2 = std::hash<vk::InstanceCreateInfo>{}( info2 );
+      assert( h1 == h2 );
+    }
 #endif
   }
   catch ( vk::SystemError const & err )

--- a/vulkan/vulkan_hash.hpp
+++ b/vulkan/vulkan_hash.hpp
@@ -994,9 +994,15 @@ namespace std
       std::size_t seed = 0;
       VULKAN_HPP_HASH_COMBINE( seed, applicationInfo.sType );
       VULKAN_HPP_HASH_COMBINE( seed, applicationInfo.pNext );
-      VULKAN_HPP_HASH_COMBINE( seed, applicationInfo.pApplicationName );
+      for ( const char * p = applicationInfo.pApplicationName; *p != '\0'; ++p )
+      {
+        VULKAN_HPP_HASH_COMBINE( seed, *p );
+      }
       VULKAN_HPP_HASH_COMBINE( seed, applicationInfo.applicationVersion );
-      VULKAN_HPP_HASH_COMBINE( seed, applicationInfo.pEngineName );
+      for ( const char * p = applicationInfo.pEngineName; *p != '\0'; ++p )
+      {
+        VULKAN_HPP_HASH_COMBINE( seed, *p );
+      }
       VULKAN_HPP_HASH_COMBINE( seed, applicationInfo.engineVersion );
       VULKAN_HPP_HASH_COMBINE( seed, applicationInfo.apiVersion );
       return seed;
@@ -2196,7 +2202,10 @@ namespace std
       VULKAN_HPP_HASH_COMBINE( seed, pipelineShaderStageCreateInfo.flags );
       VULKAN_HPP_HASH_COMBINE( seed, pipelineShaderStageCreateInfo.stage );
       VULKAN_HPP_HASH_COMBINE( seed, pipelineShaderStageCreateInfo.module );
-      VULKAN_HPP_HASH_COMBINE( seed, pipelineShaderStageCreateInfo.pName );
+      for ( const char * p = pipelineShaderStageCreateInfo.pName; *p != '\0'; ++p )
+      {
+        VULKAN_HPP_HASH_COMBINE( seed, *p );
+      }
       VULKAN_HPP_HASH_COMBINE( seed, pipelineShaderStageCreateInfo.pSpecializationInfo );
       return seed;
     }
@@ -2421,7 +2430,10 @@ namespace std
       VULKAN_HPP_HASH_COMBINE( seed, cuFunctionCreateInfoNVX.sType );
       VULKAN_HPP_HASH_COMBINE( seed, cuFunctionCreateInfoNVX.pNext );
       VULKAN_HPP_HASH_COMBINE( seed, cuFunctionCreateInfoNVX.module );
-      VULKAN_HPP_HASH_COMBINE( seed, cuFunctionCreateInfoNVX.pName );
+      for ( const char * p = cuFunctionCreateInfoNVX.pName; *p != '\0'; ++p )
+      {
+        VULKAN_HPP_HASH_COMBINE( seed, *p );
+      }
       return seed;
     }
   };
@@ -2493,7 +2505,10 @@ namespace std
       std::size_t seed = 0;
       VULKAN_HPP_HASH_COMBINE( seed, debugMarkerMarkerInfoEXT.sType );
       VULKAN_HPP_HASH_COMBINE( seed, debugMarkerMarkerInfoEXT.pNext );
-      VULKAN_HPP_HASH_COMBINE( seed, debugMarkerMarkerInfoEXT.pMarkerName );
+      for ( const char * p = debugMarkerMarkerInfoEXT.pMarkerName; *p != '\0'; ++p )
+      {
+        VULKAN_HPP_HASH_COMBINE( seed, *p );
+      }
       for ( size_t i = 0; i < 4; ++i )
       {
         VULKAN_HPP_HASH_COMBINE( seed, debugMarkerMarkerInfoEXT.color[i] );
@@ -2513,7 +2528,10 @@ namespace std
       VULKAN_HPP_HASH_COMBINE( seed, debugMarkerObjectNameInfoEXT.pNext );
       VULKAN_HPP_HASH_COMBINE( seed, debugMarkerObjectNameInfoEXT.objectType );
       VULKAN_HPP_HASH_COMBINE( seed, debugMarkerObjectNameInfoEXT.object );
-      VULKAN_HPP_HASH_COMBINE( seed, debugMarkerObjectNameInfoEXT.pObjectName );
+      for ( const char * p = debugMarkerObjectNameInfoEXT.pObjectName; *p != '\0'; ++p )
+      {
+        VULKAN_HPP_HASH_COMBINE( seed, *p );
+      }
       return seed;
     }
   };
@@ -2561,7 +2579,10 @@ namespace std
       std::size_t seed = 0;
       VULKAN_HPP_HASH_COMBINE( seed, debugUtilsLabelEXT.sType );
       VULKAN_HPP_HASH_COMBINE( seed, debugUtilsLabelEXT.pNext );
-      VULKAN_HPP_HASH_COMBINE( seed, debugUtilsLabelEXT.pLabelName );
+      for ( const char * p = debugUtilsLabelEXT.pLabelName; *p != '\0'; ++p )
+      {
+        VULKAN_HPP_HASH_COMBINE( seed, *p );
+      }
       for ( size_t i = 0; i < 4; ++i )
       {
         VULKAN_HPP_HASH_COMBINE( seed, debugUtilsLabelEXT.color[i] );
@@ -2581,7 +2602,10 @@ namespace std
       VULKAN_HPP_HASH_COMBINE( seed, debugUtilsObjectNameInfoEXT.pNext );
       VULKAN_HPP_HASH_COMBINE( seed, debugUtilsObjectNameInfoEXT.objectType );
       VULKAN_HPP_HASH_COMBINE( seed, debugUtilsObjectNameInfoEXT.objectHandle );
-      VULKAN_HPP_HASH_COMBINE( seed, debugUtilsObjectNameInfoEXT.pObjectName );
+      for ( const char * p = debugUtilsObjectNameInfoEXT.pObjectName; *p != '\0'; ++p )
+      {
+        VULKAN_HPP_HASH_COMBINE( seed, *p );
+      }
       return seed;
     }
   };
@@ -2596,9 +2620,15 @@ namespace std
       VULKAN_HPP_HASH_COMBINE( seed, debugUtilsMessengerCallbackDataEXT.sType );
       VULKAN_HPP_HASH_COMBINE( seed, debugUtilsMessengerCallbackDataEXT.pNext );
       VULKAN_HPP_HASH_COMBINE( seed, debugUtilsMessengerCallbackDataEXT.flags );
-      VULKAN_HPP_HASH_COMBINE( seed, debugUtilsMessengerCallbackDataEXT.pMessageIdName );
+      for ( const char * p = debugUtilsMessengerCallbackDataEXT.pMessageIdName; *p != '\0'; ++p )
+      {
+        VULKAN_HPP_HASH_COMBINE( seed, *p );
+      }
       VULKAN_HPP_HASH_COMBINE( seed, debugUtilsMessengerCallbackDataEXT.messageIdNumber );
-      VULKAN_HPP_HASH_COMBINE( seed, debugUtilsMessengerCallbackDataEXT.pMessage );
+      for ( const char * p = debugUtilsMessengerCallbackDataEXT.pMessage; *p != '\0'; ++p )
+      {
+        VULKAN_HPP_HASH_COMBINE( seed, *p );
+      }
       VULKAN_HPP_HASH_COMBINE( seed, debugUtilsMessengerCallbackDataEXT.queueLabelCount );
       VULKAN_HPP_HASH_COMBINE( seed, debugUtilsMessengerCallbackDataEXT.pQueueLabels );
       VULKAN_HPP_HASH_COMBINE( seed, debugUtilsMessengerCallbackDataEXT.cmdBufLabelCount );
@@ -3089,9 +3119,21 @@ namespace std
       VULKAN_HPP_HASH_COMBINE( seed, deviceCreateInfo.queueCreateInfoCount );
       VULKAN_HPP_HASH_COMBINE( seed, deviceCreateInfo.pQueueCreateInfos );
       VULKAN_HPP_HASH_COMBINE( seed, deviceCreateInfo.enabledLayerCount );
-      VULKAN_HPP_HASH_COMBINE( seed, deviceCreateInfo.ppEnabledLayerNames );
+      for ( size_t i = 0; i < deviceCreateInfo.enabledLayerCount; ++i )
+      {
+        for ( const char * p = deviceCreateInfo.ppEnabledLayerNames[i]; *p != '\0'; ++p )
+        {
+          VULKAN_HPP_HASH_COMBINE( seed, *p );
+        }
+      }
       VULKAN_HPP_HASH_COMBINE( seed, deviceCreateInfo.enabledExtensionCount );
-      VULKAN_HPP_HASH_COMBINE( seed, deviceCreateInfo.ppEnabledExtensionNames );
+      for ( size_t i = 0; i < deviceCreateInfo.enabledExtensionCount; ++i )
+      {
+        for ( const char * p = deviceCreateInfo.ppEnabledExtensionNames[i]; *p != '\0'; ++p )
+        {
+          VULKAN_HPP_HASH_COMBINE( seed, *p );
+        }
+      }
       VULKAN_HPP_HASH_COMBINE( seed, deviceCreateInfo.pEnabledFeatures );
       return seed;
     }
@@ -3630,7 +3672,10 @@ namespace std
     {
       std::size_t seed = 0;
       VULKAN_HPP_HASH_COMBINE( seed, displayPropertiesKHR.display );
-      VULKAN_HPP_HASH_COMBINE( seed, displayPropertiesKHR.displayName );
+      for ( const char * p = displayPropertiesKHR.displayName; *p != '\0'; ++p )
+      {
+        VULKAN_HPP_HASH_COMBINE( seed, *p );
+      }
       VULKAN_HPP_HASH_COMBINE( seed, displayPropertiesKHR.physicalDimensions );
       VULKAN_HPP_HASH_COMBINE( seed, displayPropertiesKHR.physicalResolution );
       VULKAN_HPP_HASH_COMBINE( seed, displayPropertiesKHR.supportedTransforms );
@@ -5411,9 +5456,21 @@ namespace std
       VULKAN_HPP_HASH_COMBINE( seed, instanceCreateInfo.flags );
       VULKAN_HPP_HASH_COMBINE( seed, instanceCreateInfo.pApplicationInfo );
       VULKAN_HPP_HASH_COMBINE( seed, instanceCreateInfo.enabledLayerCount );
-      VULKAN_HPP_HASH_COMBINE( seed, instanceCreateInfo.ppEnabledLayerNames );
+      for ( size_t i = 0; i < instanceCreateInfo.enabledLayerCount; ++i )
+      {
+        for ( const char * p = instanceCreateInfo.ppEnabledLayerNames[i]; *p != '\0'; ++p )
+        {
+          VULKAN_HPP_HASH_COMBINE( seed, *p );
+        }
+      }
       VULKAN_HPP_HASH_COMBINE( seed, instanceCreateInfo.enabledExtensionCount );
-      VULKAN_HPP_HASH_COMBINE( seed, instanceCreateInfo.ppEnabledExtensionNames );
+      for ( size_t i = 0; i < instanceCreateInfo.enabledExtensionCount; ++i )
+      {
+        for ( const char * p = instanceCreateInfo.ppEnabledExtensionNames[i]; *p != '\0'; ++p )
+        {
+          VULKAN_HPP_HASH_COMBINE( seed, *p );
+        }
+      }
       return seed;
     }
   };


### PR DESCRIPTION
Instead of hashing the pointer, hash the string contents.

Fixes: https://github.com/KhronosGroup/Vulkan-Hpp/issues/1169
