### PR TITLE
Restrict reflect() on structures to non-GCC and GCC version above 7.5.

### DIFF
--- a/VulkanHppGenerator.hpp
+++ b/VulkanHppGenerator.hpp
@@ -1214,6 +1214,7 @@ private:
   std::string generateStruct( std::pair<std::string, StructureData> const & structure,
                               std::set<std::string> &                       listedStructs ) const;
   std::string generateStructAssignmentOperators( std::pair<std::string, StructureData> const & structure ) const;
+  std::string generateStructCompareOperators( std::pair<std::string, StructureData> const & structure ) const;
   std::string generateStructConstructors( std::pair<std::string, StructureData> const & structData ) const;
   std::string generateStructConstructorsEnhanced( std::pair<std::string, StructureData> const & structData ) const;
   std::string


### PR DESCRIPTION
Resolves #1167 