### PR TITLE
Generalize command generation for a specific type of commands

### DIFF
--- a/VulkanHppGenerator.hpp
+++ b/VulkanHppGenerator.hpp
@@ -383,6 +383,8 @@ private:
   std::string addTitleAndProtection( std::string const & title,
                                      std::string const & strIf,
                                      std::string const & strElse = {} ) const;
+  bool        allVectorSizesSupported( std::vector<ParamData> const & params,
+                                       std::map<size_t, size_t> const & vectorParams ) const;
   void        appendDispatchLoaderDynamicCommands( std::vector<RequireData> const & requireData,
                                                    std::set<std::string> &          listedCommands,
                                                    std::string const &              title,
@@ -540,11 +542,6 @@ private:
                                                         bool                             definition,
                                                         std::vector<size_t> const &      returnParamIndices,
                                                         std::map<size_t, size_t> const & vectorParamIndices ) const;
-  std::string generateCommandResultGetTwoVectors( std::string const &              name,
-                                                  CommandData const &              commandData,
-                                                  size_t                           initialSkipCount,
-                                                  bool                             definition,
-                                                  std::map<size_t, size_t> const & vectorParamIndices ) const;
   std::string generateCommandResultGetValue( std::string const & name,
                                              CommandData const & commandData,
                                              size_t              initialSkipCount,
@@ -615,6 +612,12 @@ private:
                                                                   CommandData const & commandData,
                                                                   size_t              initialSkipCount,
                                                                   bool                definition ) const;
+  std::string
+              generateCommandResultMultiSuccessWithErrors0ReturnNVector( std::string const &              name,
+                                                                         CommandData const &              commandData,
+                                                                         size_t                           initialSkipCount,
+                                                                         bool                             definition,
+                                                                         std::map<size_t, size_t> const & vectorParams ) const;
   std::string generateCommandResultMultiSuccessWithErrors1Return( std::string const & name,
                                                                   CommandData const & commandData,
                                                                   size_t              initialSkipCount,

--- a/vulkan/vulkan_funcs.hpp
+++ b/vulkan/vulkan_funcs.hpp
@@ -13875,11 +13875,11 @@ namespace VULKAN_HPP_NAMESPACE
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
   template <typename Dispatch>
-  VULKAN_HPP_INLINE Result Device::buildAccelerationStructuresKHR(
+  VULKAN_HPP_NODISCARD VULKAN_HPP_INLINE Result Device::buildAccelerationStructuresKHR(
     VULKAN_HPP_NAMESPACE::DeferredOperationKHR                                                     deferredOperation,
     ArrayProxy<const VULKAN_HPP_NAMESPACE::AccelerationStructureBuildGeometryInfoKHR> const &      infos,
     ArrayProxy<const VULKAN_HPP_NAMESPACE::AccelerationStructureBuildRangeInfoKHR * const> const & pBuildRangeInfos,
-    Dispatch const & d ) const VULKAN_HPP_NOEXCEPT_WHEN_NO_EXCEPTIONS
+    Dispatch const &                                                                               d ) const
   {
     VULKAN_HPP_ASSERT( d.getVkHeaderVersion() == VK_HEADER_VERSION );
 #  ifdef VULKAN_HPP_NO_EXCEPTIONS

--- a/vulkan/vulkan_handles.hpp
+++ b/vulkan/vulkan_handles.hpp
@@ -10515,11 +10515,11 @@ namespace VULKAN_HPP_NAMESPACE
       Dispatch const & d VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) const VULKAN_HPP_NOEXCEPT;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
     template <typename Dispatch = VULKAN_HPP_DEFAULT_DISPATCHER_TYPE>
-    Result buildAccelerationStructuresKHR(
+    VULKAN_HPP_NODISCARD Result buildAccelerationStructuresKHR(
       VULKAN_HPP_NAMESPACE::DeferredOperationKHR                                                     deferredOperation,
       ArrayProxy<const VULKAN_HPP_NAMESPACE::AccelerationStructureBuildGeometryInfoKHR> const &      infos,
       ArrayProxy<const VULKAN_HPP_NAMESPACE::AccelerationStructureBuildRangeInfoKHR * const> const & pBuildRangeInfos,
-      Dispatch const & d VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) const VULKAN_HPP_NOEXCEPT_WHEN_NO_EXCEPTIONS;
+      Dispatch const & d VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) const;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
     template <typename Dispatch = VULKAN_HPP_DEFAULT_DISPATCHER_TYPE>


### PR DESCRIPTION
Commands returning a VkResult, with multiple success codes and at least one error code, that get no non-const pointers and zero or more input vectors are generalized into one function.