### PR TITLE
Remove the 'allFlags' from the general FlagTraits struct to catch unintentional usage with something different than a supported FlagBitsType.

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -16791,12 +16791,7 @@ int main( int argc, char ** argv )
   static const std::string classFlags = R"(
   template <typename FlagBitsType>
   struct FlagTraits
-  {
-    enum
-    {
-      allFlags = 0
-    };
-  };
+  {};
 
   template <typename BitType>
   class Flags

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -640,12 +640,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   template <typename FlagBitsType>
   struct FlagTraits
-  {
-    enum
-    {
-      allFlags = 0
-    };
-  };
+  {};
 
   template <typename BitType>
   class Flags


### PR DESCRIPTION
Resolves #1192.