### PR TITLE
fix(ci): filter out publications of Vulkan SC on header update

### DIFF
--- a/.github/workflows/update-header-pr.yml
+++ b/.github/workflows/update-header-pr.yml
@@ -24,7 +24,8 @@ jobs:
       run: |
         git submodule update --init --recursive
         cd Vulkan-Headers
-        VK_HEADER_GIT_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+        VK_HEADER_GIT_TAG=$(git describe --tags $(git rev-list --tags | grep 'v\d\.' | head -n1))
+        echo "New revision of Vulkan-Headers: $VK_HEADER_GIT_TAG"
         git checkout $VK_HEADER_GIT_TAG
         echo "VK_HEADER_GIT_TAG=$VK_HEADER_GIT_TAG" >> $GITHUB_ENV
 


### PR DESCRIPTION
The publication of Vulkan SC (https://www.khronos.org/news/press/khronos-releases-vulkan-safety-critical-1.0-specification-to-deliver-safety-critical-graphics-compute)
confused the update job since it was the most recent tag.

Preliminary solution: only accept tags that match `v1\.`.