### PR TITLE
ci: only create a header update PR if tag does not yet exist

### DIFF
--- a/.github/workflows/update-header-pr.yml
+++ b/.github/workflows/update-header-pr.yml
@@ -46,7 +46,15 @@ jobs:
         git config user.email "noreply@github.com"
         git add Vulkan-Headers vulkan
         rm -rf build
-        git commit -m "Update Vulkan-Headers to $VK_HEADER_GIT_TAG" || echo 'No commit necessary!'
+        git fetch --all --tags
+        if [ -z $(git tag | grep $VK_HEADER_GIT_TAG) ]
+        then
+          echo "Creating commit for new tag: $VK_HEADER_GIT_TAG"
+          git commit -m "Update Vulkan-Headers to $VK_HEADER_GIT_TAG" || echo 'No commit necessary!'
+        else
+          echo "Tag already exists: $VK_HEADER_GIT_TAG"
+        fi
+        git stash
         git clean -xf
 
     - name: Create Pull Request


### PR DESCRIPTION
Run when tag does not yet exist: https://github.com/theHamsta/Vulkan-Hpp/runs/5461820621?check_suite_focus=true (it actually should exist but I haven't run `git fetch --all --tags` in that revision to actually have any tags locally)
Run when tag already exists: https://github.com/theHamsta/Vulkan-Hpp/runs/5462719659?check_suite_focus=true