### PR TITLE
chore(warnings): fix warnings about unused variables in Release mode

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -9102,7 +9102,9 @@ std::string
     if ( !handle.second.secondLevelCommands.empty() )
     {
       assert( !handle.second.constructorIts.empty() );
+#if !defined( NDEBUG )
       auto constructorCommandIt = m_commands.find( handle.second.constructorIts.front()->first );
+#endif
       assert( ( constructorCommandIt != m_commands.end() ) && ( 1 < constructorCommandIt->second.params.size() ) );
       assert( std::next( constructorCommandIt->second.params.begin() )->type.type == "Vk" + parentType );
 
@@ -9729,7 +9731,9 @@ std::tuple<std::string, std::string, std::string, std::string, std::string, std:
       assert( !handle.second.constructorIts.front()->second.params.empty() );
       auto const & frontType = handle.second.constructorIts.front()->second.params.front().type.type;
       assert( isHandleType( frontType ) );
+#if !defined( NDEBUG )
       auto handleIt = m_handles.find( "Vk" + parentType );
+#endif
       assert( handleIt != m_handles.end() );
       assert( handleIt->second.parent == frontType );
       std::string frontName = handle.second.constructorIts.front()->second.params.front().name;


### PR DESCRIPTION
Compiler: clang++-15
```
/home/stephan/projects/Vulkan-Hpp/VulkanHppGenerator.cpp:9105:12: error: unused variable 'constructorCommandIt' [-Werror,-Wunused-variable]
      auto constructorCommandIt = m_commands.find( handle.second.constructorIts.front()->first );
           ^
/home/stephan/projects/Vulkan-Hpp/VulkanHppGenerator.cpp:9732:12: error: unused variable 'handleIt' [-Werror,-Wunused-variable]
      auto handleIt = m_handles.find( "Vk" + parentType );
```