### PR TITLE
Fix missing <utility> import for std::exchange

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -16421,6 +16421,7 @@ int main( int argc, char ** argv )
 #include <string>
 #include <system_error>
 #include <tuple>
+#include <utility>
 #include <type_traits>
 #include <vulkan/vulkan.h>
 #if 17 <= VULKAN_HPP_CPP_VERSION


### PR DESCRIPTION
In GCC 12, std::exchange is no longer implicitly included in many header files, and so must be explicitly included by including `utility`.