### PR TITLE
Add flag adder/remover methods

### DIFF
--- a/tests/FlagSetters/CMakeLists.txt
+++ b/tests/FlagSetters/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Copyright(c) 2018, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.2)
+
+project(FlagSetters)
+
+set(HEADERS
+)
+
+set(SOURCES
+	FlagSetters.cpp
+)
+
+source_group(headers FILES ${HEADERS})
+source_group(sources FILES ${SOURCES})
+
+add_executable(FlagSetters
+	${HEADERS}
+	${SOURCES}
+)
+
+set_target_properties(FlagSetters PROPERTIES FOLDER "Tests")
+target_link_libraries(FlagSetters "${Vulkan_LIBRARIES}")

--- a/tests/FlagSetters/FlagSetters.cpp
+++ b/tests/FlagSetters/FlagSetters.cpp
@@ -1,0 +1,48 @@
+// Copyright(c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// VulkanHpp Samples : FlagSetters
+//                     Compile test on using flag setting functions on structs
+
+#include <vulkan/vulkan.hpp>
+
+int main( int /*argc*/, char ** /*argv*/ )
+{
+  auto bufferCreateInfo = vk::BufferCreateInfo();
+  bufferCreateInfo.setUsage(vk::BufferUsageFlagBits::eStorageBuffer);
+  assert( bufferCreateInfo.usage == vk::BufferUsageFlagBits::eStorageBuffer );
+  bufferCreateInfo.addUsage(vk::BufferUsageFlagBits::eStorageTexelBuffer);
+  assert( bufferCreateInfo.usage == (vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eStorageTexelBuffer) );
+  bufferCreateInfo.addUsage(vk::BufferUsageFlagBits::eStorageTexelBuffer);
+  assert( bufferCreateInfo.usage == (vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eStorageTexelBuffer) );
+  bufferCreateInfo.removeUsage(vk::BufferUsageFlagBits::eStorageBuffer);
+  assert( bufferCreateInfo.usage == vk::BufferUsageFlagBits::eStorageTexelBuffer );
+  bufferCreateInfo.removeUsage(vk::BufferUsageFlagBits::eStorageBuffer);
+  assert( bufferCreateInfo.usage == vk::BufferUsageFlagBits::eStorageTexelBuffer );
+
+
+  auto accStructInst = vk::AccelerationStructureInstanceKHR();
+  accStructInst.setFlags(vk::GeometryInstanceFlagBitsKHR::eForceOpaque);
+  assert( accStructInst.flags ==  VK_GEOMETRY_INSTANCE_FORCE_OPAQUE_BIT_KHR );
+  accStructInst.addFlags(vk::GeometryInstanceFlagBitsKHR::eTriangleFlipFacing);
+  assert( accStructInst.flags == (VK_GEOMETRY_INSTANCE_FORCE_OPAQUE_BIT_KHR | VK_GEOMETRY_INSTANCE_TRIANGLE_FLIP_FACING_BIT_KHR) );
+  accStructInst.addFlags(vk::GeometryInstanceFlagBitsKHR::eTriangleFlipFacing);
+  assert( accStructInst.flags == (VK_GEOMETRY_INSTANCE_FORCE_OPAQUE_BIT_KHR | VK_GEOMETRY_INSTANCE_TRIANGLE_FLIP_FACING_BIT_KHR) );
+  accStructInst.removeFlags(vk::GeometryInstanceFlagBitsKHR::eForceOpaque);
+  assert( accStructInst.flags == VK_GEOMETRY_INSTANCE_TRIANGLE_FLIP_FACING_BIT_KHR );
+  accStructInst.removeFlags(vk::GeometryInstanceFlagBitsKHR::eForceOpaque);
+  assert( accStructInst.flags == VK_GEOMETRY_INSTANCE_TRIANGLE_FLIP_FACING_BIT_KHR );
+
+  return 0;
+}

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -695,6 +695,10 @@ namespace VULKAN_HPP_NAMESPACE
   template <typename FlagBitsType>
   struct FlagTraits
   {
+    enum : typename std::underlying_type<FlagBitsType>::type
+    {
+      allFlags = typename std::underlying_type<FlagBitsType>::type()
+    };
   };
 
   template <typename BitType>


### PR DESCRIPTION
When building the contents of a struct by chaining `.setXY()` calls, I think it would be useful if the various flag-like variables could be modified in-place, instead of simply being overwritten.

For this purpose, I added a `addXY()` and `removeXY()` method to the structs for all fields that are bitmasks.
The functions simply set the specified bits, or unset the specified, leaving the other bits in the bitmask alone.

As it is right now I see one potential issue:
We now need the `FlagTraits<FlagBitsType>::allFlags`, even for enums that are empty.
To make the compiler happy, I added a default implementation that sets `FlagTraits<FlagBitsType>::allFlags` to the default-initialized underlying type, since there are no flags anyways, this should be consistent.
The problem is that this way, the `FlagTraits` are specified for _any_ type, so if one forgets to specify the `FlagTraits` for a non-empty enum, the `FlagTraits<FlagBitsType>::allFlags` would be incorrect and the compiler would not complain.
Of cource, when an existing non-empty enum is modified in the future, the same problem exists anyways (so maybe this is a non-issue?).
Alternatively the FlagTraits could also be specialized for all empty bitmasks, but I think this would unneccessarily bloat the code.
