### PR TITLE
Resolve warning/error on discarded return value in ArrayProxyNoTemporaries test.

### DIFF
--- a/tests/ArrayProxyNoTemporaries/ArrayProxyNoTemporaries.cpp
+++ b/tests/ArrayProxyNoTemporaries/ArrayProxyNoTemporaries.cpp
@@ -84,9 +84,6 @@ int main( int /*argc*/, char ** /*argv*/ )
 {
   try
   {
-    // to prevent a warning on unreferenced function vk::getDispatchLoaderStatic, use just one arbitrary vk-function
-    vk::enumerateInstanceVersion();
-
     // nullptr_t
     fct( nullptr );
     fctc( nullptr );


### PR DESCRIPTION
Resolves #1359.