### PR TITLE
Introduce VULKAN_HPP_NO_TO_STRING to optionally remove the various vk::to_string functions.

### DIFF
--- a/RAII_Samples/CreateDebugUtilsMessenger/CreateDebugUtilsMessenger.cpp
+++ b/RAII_Samples/CreateDebugUtilsMessenger/CreateDebugUtilsMessenger.cpp
@@ -23,6 +23,157 @@
 static char const * AppName    = "CreateDebugReportMessenger";
 static char const * EngineName = "Vulkan.hpp";
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::DebugUtilsMessageSeverityFlagBitsEXT value )
+  {
+    switch ( value )
+    {
+      case vk::DebugUtilsMessageSeverityFlagBitsEXT::eVerbose: return "Verbose";
+      case vk::DebugUtilsMessageSeverityFlagBitsEXT::eInfo: return "Info";
+      case vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning: return "Warning";
+      case vk::DebugUtilsMessageSeverityFlagBitsEXT::eError: return "Error";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+
+  std::string to_string( vk::DebugUtilsMessageTypeFlagsEXT value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::DebugUtilsMessageTypeFlagBitsEXT::eGeneral )
+      result += "General | ";
+    if ( value & vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation )
+      result += "Validation | ";
+    if ( value & vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance )
+      result += "Performance | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::ObjectType value )
+  {
+    switch ( value )
+    {
+      case vk::ObjectType::eUnknown: return "Unknown";
+      case vk::ObjectType::eInstance: return "Instance";
+      case vk::ObjectType::ePhysicalDevice: return "PhysicalDevice";
+      case vk::ObjectType::eDevice: return "Device";
+      case vk::ObjectType::eQueue: return "Queue";
+      case vk::ObjectType::eSemaphore: return "Semaphore";
+      case vk::ObjectType::eCommandBuffer: return "CommandBuffer";
+      case vk::ObjectType::eFence: return "Fence";
+      case vk::ObjectType::eDeviceMemory: return "DeviceMemory";
+      case vk::ObjectType::eBuffer: return "Buffer";
+      case vk::ObjectType::eImage: return "Image";
+      case vk::ObjectType::eEvent: return "Event";
+      case vk::ObjectType::eQueryPool: return "QueryPool";
+      case vk::ObjectType::eBufferView: return "BufferView";
+      case vk::ObjectType::eImageView: return "ImageView";
+      case vk::ObjectType::eShaderModule: return "ShaderModule";
+      case vk::ObjectType::ePipelineCache: return "PipelineCache";
+      case vk::ObjectType::ePipelineLayout: return "PipelineLayout";
+      case vk::ObjectType::eRenderPass: return "RenderPass";
+      case vk::ObjectType::ePipeline: return "Pipeline";
+      case vk::ObjectType::eDescriptorSetLayout: return "DescriptorSetLayout";
+      case vk::ObjectType::eSampler: return "Sampler";
+      case vk::ObjectType::eDescriptorPool: return "DescriptorPool";
+      case vk::ObjectType::eDescriptorSet: return "DescriptorSet";
+      case vk::ObjectType::eFramebuffer: return "Framebuffer";
+      case vk::ObjectType::eCommandPool: return "CommandPool";
+      case vk::ObjectType::eSamplerYcbcrConversion: return "SamplerYcbcrConversion";
+      case vk::ObjectType::eDescriptorUpdateTemplate: return "DescriptorUpdateTemplate";
+      case vk::ObjectType::ePrivateDataSlot: return "PrivateDataSlot";
+      case vk::ObjectType::eSurfaceKHR: return "SurfaceKHR";
+      case vk::ObjectType::eSwapchainKHR: return "SwapchainKHR";
+      case vk::ObjectType::eDisplayKHR: return "DisplayKHR";
+      case vk::ObjectType::eDisplayModeKHR: return "DisplayModeKHR";
+      case vk::ObjectType::eDebugReportCallbackEXT: return "DebugReportCallbackEXT";
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
+      case vk::ObjectType::eVideoSessionKHR: return "VideoSessionKHR";
+      case vk::ObjectType::eVideoSessionParametersKHR: return "VideoSessionParametersKHR";
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
+      case vk::ObjectType::eCuModuleNVX: return "CuModuleNVX";
+      case vk::ObjectType::eCuFunctionNVX: return "CuFunctionNVX";
+      case vk::ObjectType::eDebugUtilsMessengerEXT: return "DebugUtilsMessengerEXT";
+      case vk::ObjectType::eAccelerationStructureKHR: return "AccelerationStructureKHR";
+      case vk::ObjectType::eValidationCacheEXT: return "ValidationCacheEXT";
+      case vk::ObjectType::eAccelerationStructureNV: return "AccelerationStructureNV";
+      case vk::ObjectType::ePerformanceConfigurationINTEL: return "PerformanceConfigurationINTEL";
+      case vk::ObjectType::eDeferredOperationKHR: return "DeferredOperationKHR";
+      case vk::ObjectType::eIndirectCommandsLayoutNV: return "IndirectCommandsLayoutNV";
+#  if defined( VK_USE_PLATFORM_FUCHSIA )
+      case vk::ObjectType::eBufferCollectionFUCHSIA: return "BufferCollectionFUCHSIA";
+#  endif /*VK_USE_PLATFORM_FUCHSIA*/
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+
+  std::string to_string( vk::Result value )
+  {
+    switch ( value )
+    {
+      case vk::Result::eSuccess: return "Success";
+      case vk::Result::eNotReady: return "NotReady";
+      case vk::Result::eTimeout: return "Timeout";
+      case vk::Result::eEventSet: return "EventSet";
+      case vk::Result::eEventReset: return "EventReset";
+      case vk::Result::eIncomplete: return "Incomplete";
+      case vk::Result::eErrorOutOfHostMemory: return "ErrorOutOfHostMemory";
+      case vk::Result::eErrorOutOfDeviceMemory: return "ErrorOutOfDeviceMemory";
+      case vk::Result::eErrorInitializationFailed: return "ErrorInitializationFailed";
+      case vk::Result::eErrorDeviceLost: return "ErrorDeviceLost";
+      case vk::Result::eErrorMemoryMapFailed: return "ErrorMemoryMapFailed";
+      case vk::Result::eErrorLayerNotPresent: return "ErrorLayerNotPresent";
+      case vk::Result::eErrorExtensionNotPresent: return "ErrorExtensionNotPresent";
+      case vk::Result::eErrorFeatureNotPresent: return "ErrorFeatureNotPresent";
+      case vk::Result::eErrorIncompatibleDriver: return "ErrorIncompatibleDriver";
+      case vk::Result::eErrorTooManyObjects: return "ErrorTooManyObjects";
+      case vk::Result::eErrorFormatNotSupported: return "ErrorFormatNotSupported";
+      case vk::Result::eErrorFragmentedPool: return "ErrorFragmentedPool";
+      case vk::Result::eErrorUnknown: return "ErrorUnknown";
+      case vk::Result::eErrorOutOfPoolMemory: return "ErrorOutOfPoolMemory";
+      case vk::Result::eErrorInvalidExternalHandle: return "ErrorInvalidExternalHandle";
+      case vk::Result::eErrorFragmentation: return "ErrorFragmentation";
+      case vk::Result::eErrorInvalidOpaqueCaptureAddress: return "ErrorInvalidOpaqueCaptureAddress";
+      case vk::Result::ePipelineCompileRequired: return "PipelineCompileRequired";
+      case vk::Result::eErrorSurfaceLostKHR: return "ErrorSurfaceLostKHR";
+      case vk::Result::eErrorNativeWindowInUseKHR: return "ErrorNativeWindowInUseKHR";
+      case vk::Result::eSuboptimalKHR: return "SuboptimalKHR";
+      case vk::Result::eErrorOutOfDateKHR: return "ErrorOutOfDateKHR";
+      case vk::Result::eErrorIncompatibleDisplayKHR: return "ErrorIncompatibleDisplayKHR";
+      case vk::Result::eErrorValidationFailedEXT: return "ErrorValidationFailedEXT";
+      case vk::Result::eErrorInvalidShaderNV: return "ErrorInvalidShaderNV";
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
+      case vk::Result::eErrorImageUsageNotSupportedKHR: return "ErrorImageUsageNotSupportedKHR";
+      case vk::Result::eErrorVideoPictureLayoutNotSupportedKHR: return "ErrorVideoPictureLayoutNotSupportedKHR";
+      case vk::Result::eErrorVideoProfileOperationNotSupportedKHR: return "ErrorVideoProfileOperationNotSupportedKHR";
+      case vk::Result::eErrorVideoProfileFormatNotSupportedKHR: return "ErrorVideoProfileFormatNotSupportedKHR";
+      case vk::Result::eErrorVideoProfileCodecNotSupportedKHR: return "ErrorVideoProfileCodecNotSupportedKHR";
+      case vk::Result::eErrorVideoStdVersionNotSupportedKHR: return "ErrorVideoStdVersionNotSupportedKHR";
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
+      case vk::Result::eErrorInvalidDrmFormatModifierPlaneLayoutEXT: return "ErrorInvalidDrmFormatModifierPlaneLayoutEXT";
+      case vk::Result::eErrorNotPermittedKHR: return "ErrorNotPermittedKHR";
+#  if defined( VK_USE_PLATFORM_WIN32_KHR )
+      case vk::Result::eErrorFullScreenExclusiveModeLostEXT: return "ErrorFullScreenExclusiveModeLostEXT";
+#  endif /*VK_USE_PLATFORM_WIN32_KHR*/
+      case vk::Result::eThreadIdleKHR: return "ThreadIdleKHR";
+      case vk::Result::eThreadDoneKHR: return "ThreadDoneKHR";
+      case vk::Result::eOperationDeferredKHR: return "OperationDeferredKHR";
+      case vk::Result::eOperationNotDeferredKHR: return "OperationNotDeferredKHR";
+      case vk::Result::eErrorCompressionExhaustedEXT: return "ErrorCompressionExhaustedEXT";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
 VKAPI_ATTR VkBool32 VKAPI_CALL debugMessageFunc( VkDebugUtilsMessageSeverityFlagBitsEXT       messageSeverity,
                                                  VkDebugUtilsMessageTypeFlagsEXT              messageTypes,
                                                  VkDebugUtilsMessengerCallbackDataEXT const * pCallbackData,
@@ -30,50 +181,38 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debugMessageFunc( VkDebugUtilsMessageSeverityFlag
 {
   std::ostringstream message;
 
-  message << vk::to_string( static_cast<vk::DebugUtilsMessageSeverityFlagBitsEXT>( messageSeverity ) ) << ": "
-          << vk::to_string( static_cast<vk::DebugUtilsMessageTypeFlagsEXT>( messageTypes ) ) << ":\n";
-  message << "\t"
-          << "messageIDName   = <" << pCallbackData->pMessageIdName << ">\n";
-  message << "\t"
-          << "messageIdNumber = " << pCallbackData->messageIdNumber << "\n";
-  message << "\t"
-          << "message         = <" << pCallbackData->pMessage << ">\n";
+  message << to_string( static_cast<vk::DebugUtilsMessageSeverityFlagBitsEXT>( messageSeverity ) ) << ": "
+          << to_string( static_cast<vk::DebugUtilsMessageTypeFlagsEXT>( messageTypes ) ) << ":\n";
+  message << std::string( "\t" ) << "messageIDName   = <" << pCallbackData->pMessageIdName << ">\n";
+  message << std::string( "\t" ) << "messageIdNumber = " << pCallbackData->messageIdNumber << "\n";
+  message << std::string( "\t" ) << "message         = <" << pCallbackData->pMessage << ">\n";
   if ( 0 < pCallbackData->queueLabelCount )
   {
-    message << "\t"
-            << "Queue Labels:\n";
+    message << std::string( "\t" ) << "Queue Labels:\n";
     for ( uint32_t i = 0; i < pCallbackData->queueLabelCount; i++ )
     {
-      message << "\t\t"
-              << "labelName = <" << pCallbackData->pQueueLabels[i].pLabelName << ">\n";
+      message << std::string( "\t\t" ) << "labelName = <" << pCallbackData->pQueueLabels[i].pLabelName << ">\n";
     }
   }
   if ( 0 < pCallbackData->cmdBufLabelCount )
   {
-    message << "\t"
-            << "CommandBuffer Labels:\n";
+    message << std::string( "\t" ) << "CommandBuffer Labels:\n";
     for ( uint32_t i = 0; i < pCallbackData->cmdBufLabelCount; i++ )
     {
-      message << "\t\t"
-              << "labelName = <" << pCallbackData->pCmdBufLabels[i].pLabelName << ">\n";
+      message << std::string( "\t\t" ) << "labelName = <" << pCallbackData->pCmdBufLabels[i].pLabelName << ">\n";
     }
   }
   if ( 0 < pCallbackData->objectCount )
   {
-    message << "\t"
-            << "Objects:\n";
+    message << std::string( "\t" ) << "Objects:\n";
     for ( uint32_t i = 0; i < pCallbackData->objectCount; i++ )
     {
-      message << "\t\t"
-              << "Object " << i << "\n";
-      message << "\t\t\t"
-              << "objectType   = " << vk::to_string( static_cast<vk::ObjectType>( pCallbackData->pObjects[i].objectType ) ) << "\n";
-      message << "\t\t\t"
-              << "objectHandle = " << pCallbackData->pObjects[i].objectHandle << "\n";
+      message << std::string( "\t\t" ) << "Object " << i << "\n";
+      message << std::string( "\t\t\t" ) << "objectType   = " << to_string( static_cast<vk::ObjectType>( pCallbackData->pObjects[i].objectType ) ) << "\n";
+      message << std::string( "\t\t\t" ) << "objectHandle = " << pCallbackData->pObjects[i].objectHandle << "\n";
       if ( pCallbackData->pObjects[i].pObjectName )
       {
-        message << "\t\t\t"
-                << "objectName   = <" << pCallbackData->pObjects[i].pObjectName << ">\n";
+        message << std::string( "\t\t\t" ) << "objectName   = <" << pCallbackData->pObjects[i].pObjectName << ">\n";
       }
     }
   }

--- a/RAII_Samples/EnableValidationWithCallback/EnableValidationWithCallback.cpp
+++ b/RAII_Samples/EnableValidationWithCallback/EnableValidationWithCallback.cpp
@@ -38,6 +38,100 @@ static char const * EngineName = "Vulkan.hpp";
 PFN_vkCreateDebugUtilsMessengerEXT  pfnVkCreateDebugUtilsMessengerEXT;
 PFN_vkDestroyDebugUtilsMessengerEXT pfnVkDestroyDebugUtilsMessengerEXT;
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::DebugUtilsMessageSeverityFlagBitsEXT value )
+  {
+    switch ( value )
+    {
+      case vk::DebugUtilsMessageSeverityFlagBitsEXT::eVerbose: return "Verbose";
+      case vk::DebugUtilsMessageSeverityFlagBitsEXT::eInfo: return "Info";
+      case vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning: return "Warning";
+      case vk::DebugUtilsMessageSeverityFlagBitsEXT::eError: return "Error";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+
+  std::string to_string( vk::DebugUtilsMessageTypeFlagsEXT value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::DebugUtilsMessageTypeFlagBitsEXT::eGeneral )
+      result += "General | ";
+    if ( value & vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation )
+      result += "Validation | ";
+    if ( value & vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance )
+      result += "Performance | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::ObjectType value )
+  {
+    switch ( value )
+    {
+      case vk::ObjectType::eUnknown: return "Unknown";
+      case vk::ObjectType::eInstance: return "Instance";
+      case vk::ObjectType::ePhysicalDevice: return "PhysicalDevice";
+      case vk::ObjectType::eDevice: return "Device";
+      case vk::ObjectType::eQueue: return "Queue";
+      case vk::ObjectType::eSemaphore: return "Semaphore";
+      case vk::ObjectType::eCommandBuffer: return "CommandBuffer";
+      case vk::ObjectType::eFence: return "Fence";
+      case vk::ObjectType::eDeviceMemory: return "DeviceMemory";
+      case vk::ObjectType::eBuffer: return "Buffer";
+      case vk::ObjectType::eImage: return "Image";
+      case vk::ObjectType::eEvent: return "Event";
+      case vk::ObjectType::eQueryPool: return "QueryPool";
+      case vk::ObjectType::eBufferView: return "BufferView";
+      case vk::ObjectType::eImageView: return "ImageView";
+      case vk::ObjectType::eShaderModule: return "ShaderModule";
+      case vk::ObjectType::ePipelineCache: return "PipelineCache";
+      case vk::ObjectType::ePipelineLayout: return "PipelineLayout";
+      case vk::ObjectType::eRenderPass: return "RenderPass";
+      case vk::ObjectType::ePipeline: return "Pipeline";
+      case vk::ObjectType::eDescriptorSetLayout: return "DescriptorSetLayout";
+      case vk::ObjectType::eSampler: return "Sampler";
+      case vk::ObjectType::eDescriptorPool: return "DescriptorPool";
+      case vk::ObjectType::eDescriptorSet: return "DescriptorSet";
+      case vk::ObjectType::eFramebuffer: return "Framebuffer";
+      case vk::ObjectType::eCommandPool: return "CommandPool";
+      case vk::ObjectType::eSamplerYcbcrConversion: return "SamplerYcbcrConversion";
+      case vk::ObjectType::eDescriptorUpdateTemplate: return "DescriptorUpdateTemplate";
+      case vk::ObjectType::ePrivateDataSlot: return "PrivateDataSlot";
+      case vk::ObjectType::eSurfaceKHR: return "SurfaceKHR";
+      case vk::ObjectType::eSwapchainKHR: return "SwapchainKHR";
+      case vk::ObjectType::eDisplayKHR: return "DisplayKHR";
+      case vk::ObjectType::eDisplayModeKHR: return "DisplayModeKHR";
+      case vk::ObjectType::eDebugReportCallbackEXT: return "DebugReportCallbackEXT";
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
+      case vk::ObjectType::eVideoSessionKHR: return "VideoSessionKHR";
+      case vk::ObjectType::eVideoSessionParametersKHR: return "VideoSessionParametersKHR";
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
+      case vk::ObjectType::eCuModuleNVX: return "CuModuleNVX";
+      case vk::ObjectType::eCuFunctionNVX: return "CuFunctionNVX";
+      case vk::ObjectType::eDebugUtilsMessengerEXT: return "DebugUtilsMessengerEXT";
+      case vk::ObjectType::eAccelerationStructureKHR: return "AccelerationStructureKHR";
+      case vk::ObjectType::eValidationCacheEXT: return "ValidationCacheEXT";
+      case vk::ObjectType::eAccelerationStructureNV: return "AccelerationStructureNV";
+      case vk::ObjectType::ePerformanceConfigurationINTEL: return "PerformanceConfigurationINTEL";
+      case vk::ObjectType::eDeferredOperationKHR: return "DeferredOperationKHR";
+      case vk::ObjectType::eIndirectCommandsLayoutNV: return "IndirectCommandsLayoutNV";
+#  if defined( VK_USE_PLATFORM_FUCHSIA )
+      case vk::ObjectType::eBufferCollectionFUCHSIA: return "BufferCollectionFUCHSIA";
+#  endif /*VK_USE_PLATFORM_FUCHSIA*/
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
 VKAPI_ATTR VkResult VKAPI_CALL vkCreateDebugUtilsMessengerEXT( VkInstance                                 instance,
                                                                const VkDebugUtilsMessengerCreateInfoEXT * pCreateInfo,
                                                                const VkAllocationCallbacks *              pAllocator,
@@ -58,8 +152,8 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debugMessageFunc( VkDebugUtilsMessageSeverityFlag
 {
   std::string message;
 
-  message += vk::to_string( static_cast<vk::DebugUtilsMessageSeverityFlagBitsEXT>( messageSeverity ) ) + ": " +
-             vk::to_string( static_cast<vk::DebugUtilsMessageTypeFlagsEXT>( messageTypes ) ) + ":\n";
+  message += to_string( static_cast<vk::DebugUtilsMessageSeverityFlagBitsEXT>( messageSeverity ) ) + ": " +
+             to_string( static_cast<vk::DebugUtilsMessageTypeFlagsEXT>( messageTypes ) ) + ":\n";
   message += std::string( "\t" ) + "messageIDName   = <" + pCallbackData->pMessageIdName + ">\n";
   message += std::string( "\t" ) + "messageIdNumber = " + std::to_string( pCallbackData->messageIdNumber ) + "\n";
   message += std::string( "\t" ) + "message         = <" + pCallbackData->pMessage + ">\n";
@@ -84,7 +178,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debugMessageFunc( VkDebugUtilsMessageSeverityFlag
     for ( uint32_t i = 0; i < pCallbackData->objectCount; i++ )
     {
       message += std::string( "\t" ) + "Object " + std::to_string( i ) + "\n";
-      message += std::string( "\t\t" ) + "objectType   = " + vk::to_string( static_cast<vk::ObjectType>( pCallbackData->pObjects[i].objectType ) ) + "\n";
+      message += std::string( "\t\t" ) + "objectType   = " + to_string( static_cast<vk::ObjectType>( pCallbackData->pObjects[i].objectType ) ) + "\n";
       message += std::string( "\t\t" ) + "objectHandle = " + std::to_string( pCallbackData->pObjects[i].objectHandle ) + "\n";
       if ( pCallbackData->pObjects[i].pObjectName )
       {

--- a/RAII_Samples/EnumerateDevicesAdvanced/EnumerateDevicesAdvanced.cpp
+++ b/RAII_Samples/EnumerateDevicesAdvanced/EnumerateDevicesAdvanced.cpp
@@ -24,6 +24,27 @@
 static char const * AppName    = "EnumerateDevicesAdvanced";
 static char const * EngineName = "Vulkan.hpp";
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::PhysicalDeviceType value )
+  {
+    switch ( value )
+    {
+      case vk::PhysicalDeviceType::eOther: return "Other";
+      case vk::PhysicalDeviceType::eIntegratedGpu: return "IntegratedGpu";
+      case vk::PhysicalDeviceType::eDiscreteGpu: return "DiscreteGpu";
+      case vk::PhysicalDeviceType::eVirtualGpu: return "VirtualGpu";
+      case vk::PhysicalDeviceType::eCpu: return "Cpu";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
 int main( int /*argc*/, char ** /*argv*/ )
 {
   try
@@ -56,7 +77,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       std::cout << "deviceId: " << std::setw( 6 ) << properties.deviceID << '\n';
       std::cout << std::noshowbase << std::right << std::setfill( ' ' ) << std::dec;
 
-      std::cout << "deviceType: " << vk::to_string( properties.deviceType ) << "\n";
+      std::cout << "deviceType: " << to_string( properties.deviceType ) << "\n";
 
       std::cout << "deviceName: " << properties.deviceName << '\n';
 

--- a/RAII_Samples/PhysicalDeviceMemoryProperties/PhysicalDeviceMemoryProperties.cpp
+++ b/RAII_Samples/PhysicalDeviceMemoryProperties/PhysicalDeviceMemoryProperties.cpp
@@ -24,6 +24,56 @@
 static char const * AppName    = "PhysicalDeviceMemoryProperties";
 static char const * EngineName = "Vulkan.hpp";
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::MemoryHeapFlags value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::MemoryHeapFlagBits::eDeviceLocal )
+      result += "DeviceLocal | ";
+    if ( value & vk::MemoryHeapFlagBits::eMultiInstance )
+      result += "MultiInstance | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::MemoryPropertyFlags value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::MemoryPropertyFlagBits::eDeviceLocal )
+      result += "DeviceLocal | ";
+    if ( value & vk::MemoryPropertyFlagBits::eHostVisible )
+      result += "HostVisible | ";
+    if ( value & vk::MemoryPropertyFlagBits::eHostCoherent )
+      result += "HostCoherent | ";
+    if ( value & vk::MemoryPropertyFlagBits::eHostCached )
+      result += "HostCached | ";
+    if ( value & vk::MemoryPropertyFlagBits::eLazilyAllocated )
+      result += "LazilyAllocated | ";
+    if ( value & vk::MemoryPropertyFlagBits::eProtected )
+      result += "Protected | ";
+    if ( value & vk::MemoryPropertyFlagBits::eDeviceCoherentAMD )
+      result += "DeviceCoherentAMD | ";
+    if ( value & vk::MemoryPropertyFlagBits::eDeviceUncachedAMD )
+      result += "DeviceUncachedAMD | ";
+    if ( value & vk::MemoryPropertyFlagBits::eRdmaCapableNV )
+      result += "RdmaCapableNV | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
 std::string formatSize( vk::DeviceSize size )
 {
   std::ostringstream oss;
@@ -75,7 +125,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       for ( uint32_t j = 0; j < memoryProperties.memoryHeapCount; j++ )
       {
         std::cout << "  " << j << ": size = " << formatSize( memoryProperties.memoryHeaps[j].size )
-                  << ", flags = " << vk::to_string( memoryProperties.memoryHeaps[j].flags ) << "\n";
+                  << ", flags = " << to_string( memoryProperties.memoryHeaps[j].flags ) << "\n";
         if ( containsMemoryBudget )
         {
           std::cout << "     heapBudget = " << formatSize( memoryBudgetProperties.heapBudget[j] )
@@ -86,7 +136,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       for ( uint32_t j = 0; j < memoryProperties.memoryTypeCount; j++ )
       {
         std::cout << "  " << j << ": heapIndex = " << memoryProperties.memoryTypes[j].heapIndex
-                  << ", flags = " << vk::to_string( memoryProperties.memoryTypes[j].propertyFlags ) << "\n";
+                  << ", flags = " << to_string( memoryProperties.memoryTypes[j].propertyFlags ) << "\n";
       }
     }
 

--- a/RAII_Samples/PhysicalDeviceProperties/PhysicalDeviceProperties.cpp
+++ b/RAII_Samples/PhysicalDeviceProperties/PhysicalDeviceProperties.cpp
@@ -25,6 +25,216 @@
 static char const * AppName    = "PhysicalDeviceProperties";
 static char const * EngineName = "Vulkan.hpp";
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::DriverId value )
+  {
+    switch ( value )
+    {
+      case vk::DriverId::eAmdProprietary: return "AmdProprietary";
+      case vk::DriverId::eAmdOpenSource: return "AmdOpenSource";
+      case vk::DriverId::eMesaRadv: return "MesaRadv";
+      case vk::DriverId::eNvidiaProprietary: return "NvidiaProprietary";
+      case vk::DriverId::eIntelProprietaryWindows: return "IntelProprietaryWindows";
+      case vk::DriverId::eIntelOpenSourceMESA: return "IntelOpenSourceMESA";
+      case vk::DriverId::eImaginationProprietary: return "ImaginationProprietary";
+      case vk::DriverId::eQualcommProprietary: return "QualcommProprietary";
+      case vk::DriverId::eArmProprietary: return "ArmProprietary";
+      case vk::DriverId::eGoogleSwiftshader: return "GoogleSwiftshader";
+      case vk::DriverId::eGgpProprietary: return "GgpProprietary";
+      case vk::DriverId::eBroadcomProprietary: return "BroadcomProprietary";
+      case vk::DriverId::eMesaLlvmpipe: return "MesaLlvmpipe";
+      case vk::DriverId::eMoltenvk: return "Moltenvk";
+      case vk::DriverId::eCoreaviProprietary: return "CoreaviProprietary";
+      case vk::DriverId::eJuiceProprietary: return "JuiceProprietary";
+      case vk::DriverId::eVerisiliconProprietary: return "VerisiliconProprietary";
+      case vk::DriverId::eMesaTurnip: return "MesaTurnip";
+      case vk::DriverId::eMesaV3Dv: return "MesaV3Dv";
+      case vk::DriverId::eMesaPanvk: return "MesaPanvk";
+      case vk::DriverId::eSamsungProprietary: return "SamsungProprietary";
+      case vk::DriverId::eMesaVenus: return "MesaVenus";
+      case vk::DriverId::eMesaDozen: return "MesaDozen";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+
+  std::string to_string( vk::PhysicalDeviceType value )
+  {
+    switch ( value )
+    {
+      case vk::PhysicalDeviceType::eOther: return "Other";
+      case vk::PhysicalDeviceType::eIntegratedGpu: return "IntegratedGpu";
+      case vk::PhysicalDeviceType::eDiscreteGpu: return "DiscreteGpu";
+      case vk::PhysicalDeviceType::eVirtualGpu: return "VirtualGpu";
+      case vk::PhysicalDeviceType::eCpu: return "Cpu";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+
+  std::string to_string( vk::PointClippingBehavior value )
+  {
+    switch ( value )
+    {
+      case vk::PointClippingBehavior::eAllClipPlanes: return "AllClipPlanes";
+      case vk::PointClippingBehavior::eUserClipPlanesOnly: return "UserClipPlanesOnly";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+
+  std::string to_string( vk::ResolveModeFlags value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::ResolveModeFlagBits::eSampleZero )
+      result += "SampleZero | ";
+    if ( value & vk::ResolveModeFlagBits::eAverage )
+      result += "Average | ";
+    if ( value & vk::ResolveModeFlagBits::eMin )
+      result += "Min | ";
+    if ( value & vk::ResolveModeFlagBits::eMax )
+      result += "Max | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::SampleCountFlags value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::SampleCountFlagBits::e1 )
+      result += "1 | ";
+    if ( value & vk::SampleCountFlagBits::e2 )
+      result += "2 | ";
+    if ( value & vk::SampleCountFlagBits::e4 )
+      result += "4 | ";
+    if ( value & vk::SampleCountFlagBits::e8 )
+      result += "8 | ";
+    if ( value & vk::SampleCountFlagBits::e16 )
+      result += "16 | ";
+    if ( value & vk::SampleCountFlagBits::e32 )
+      result += "32 | ";
+    if ( value & vk::SampleCountFlagBits::e64 )
+      result += "64 | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::ShaderCorePropertiesFlagsAMD )
+  {
+    return "{}";
+  }
+
+  std::string to_string( vk::ShaderFloatControlsIndependence value )
+  {
+    switch ( value )
+    {
+      case vk::ShaderFloatControlsIndependence::e32BitOnly: return "32BitOnly";
+      case vk::ShaderFloatControlsIndependence::eAll: return "All";
+      case vk::ShaderFloatControlsIndependence::eNone: return "None";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+
+  std::string to_string( vk::ShaderStageFlags value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::ShaderStageFlagBits::eVertex )
+      result += "Vertex | ";
+    if ( value & vk::ShaderStageFlagBits::eTessellationControl )
+      result += "TessellationControl | ";
+    if ( value & vk::ShaderStageFlagBits::eTessellationEvaluation )
+      result += "TessellationEvaluation | ";
+    if ( value & vk::ShaderStageFlagBits::eGeometry )
+      result += "Geometry | ";
+    if ( value & vk::ShaderStageFlagBits::eFragment )
+      result += "Fragment | ";
+    if ( value & vk::ShaderStageFlagBits::eCompute )
+      result += "Compute | ";
+    if ( value & vk::ShaderStageFlagBits::eRaygenKHR )
+      result += "RaygenKHR | ";
+    if ( value & vk::ShaderStageFlagBits::eAnyHitKHR )
+      result += "AnyHitKHR | ";
+    if ( value & vk::ShaderStageFlagBits::eClosestHitKHR )
+      result += "ClosestHitKHR | ";
+    if ( value & vk::ShaderStageFlagBits::eMissKHR )
+      result += "MissKHR | ";
+    if ( value & vk::ShaderStageFlagBits::eIntersectionKHR )
+      result += "IntersectionKHR | ";
+    if ( value & vk::ShaderStageFlagBits::eCallableKHR )
+      result += "CallableKHR | ";
+    if ( value & vk::ShaderStageFlagBits::eTaskNV )
+      result += "TaskNV | ";
+    if ( value & vk::ShaderStageFlagBits::eMeshNV )
+      result += "MeshNV | ";
+    if ( value & vk::ShaderStageFlagBits::eSubpassShadingHUAWEI )
+      result += "SubpassShadingHUAWEI | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::SubgroupFeatureFlags value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::SubgroupFeatureFlagBits::eBasic )
+      result += "Basic | ";
+    if ( value & vk::SubgroupFeatureFlagBits::eVote )
+      result += "Vote | ";
+    if ( value & vk::SubgroupFeatureFlagBits::eArithmetic )
+      result += "Arithmetic | ";
+    if ( value & vk::SubgroupFeatureFlagBits::eBallot )
+      result += "Ballot | ";
+    if ( value & vk::SubgroupFeatureFlagBits::eShuffle )
+      result += "Shuffle | ";
+    if ( value & vk::SubgroupFeatureFlagBits::eShuffleRelative )
+      result += "ShuffleRelative | ";
+    if ( value & vk::SubgroupFeatureFlagBits::eClustered )
+      result += "Clustered | ";
+    if ( value & vk::SubgroupFeatureFlagBits::eQuad )
+      result += "Quad | ";
+    if ( value & vk::SubgroupFeatureFlagBits::ePartitionedNV )
+      result += "PartitionedNV | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::VendorId value )
+  {
+    switch ( value )
+    {
+      case vk::VendorId::eVIV: return "VIV";
+      case vk::VendorId::eVSI: return "VSI";
+      case vk::VendorId::eKazan: return "Kazan";
+      case vk::VendorId::eCodeplay: return "Codeplay";
+      case vk::VendorId::eMESA: return "MESA";
+      case vk::VendorId::ePocl: return "Pocl";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
 std::string decodeAPIVersion( uint32_t apiVersion )
 {
   return std::to_string( VK_VERSION_MAJOR( apiVersion ) ) + "." + std::to_string( VK_VERSION_MINOR( apiVersion ) ) + "." +
@@ -59,7 +269,7 @@ std::string decodeVendorID( uint32_t vendorID )
   else
   {
     // above 0x10000 should be vkVendorIDs
-    return vk::to_string( vk::VendorId( vendorID ) );
+    return to_string( vk::VendorId( vendorID ) );
   }
 }
 
@@ -154,281 +364,190 @@ int main( int /*argc*/, char ** /*argv*/ )
                                            vk::PhysicalDeviceTransformFeedbackPropertiesEXT,
                                            vk::PhysicalDeviceVertexAttributeDivisorPropertiesEXT>();
       vk::PhysicalDeviceProperties const & properties = properties2.get<vk::PhysicalDeviceProperties2>().properties;
-      std::cout << "\t"
-                << "Properties:\n";
-      std::cout << "\t\t"
-                << "apiVersion        = " << decodeAPIVersion( properties.apiVersion ) << "\n";
-      std::cout << "\t\t"
-                << "driverVersion     = " << decodeDriverVersion( properties.driverVersion, properties.vendorID ) << "\n";
-      std::cout << "\t\t"
-                << "vendorID          = " << decodeVendorID( properties.vendorID ) << "\n";
-      std::cout << "\t\t"
-                << "deviceID          = " << properties.deviceID << "\n";
-      std::cout << "\t\t"
-                << "deviceType        = " << vk::to_string( properties.deviceType ) << "\n";
-      std::cout << "\t\t"
-                << "deviceName        = " << properties.deviceName << "\n";
-      std::cout << "\t\t"
-                << "pipelineCacheUUID = " << vk::su::UUID( properties.pipelineCacheUUID ) << "\n";
-      std::cout << "\t\t"
-                << "limits:\n";
-      std::cout << "\t\t\t"
-                << "bufferImageGranularity                          = " << properties.limits.bufferImageGranularity << "\n";
-      std::cout << "\t\t\t"
-                << "discreteQueuePriorities                         = " << properties.limits.discreteQueuePriorities << "\n";
-      std::cout << "\t\t\t"
-                << "framebufferColorSampleCounts                    = " << vk::to_string( properties.limits.framebufferColorSampleCounts ) << "\n";
-      std::cout << "\t\t\t"
-                << "framebufferDepthSampleCounts                    = " << vk::to_string( properties.limits.framebufferDepthSampleCounts ) << "\n";
-      std::cout << "\t\t\t"
-                << "framebufferNoAttachmentsSampleCounts            = " << vk::to_string( properties.limits.framebufferNoAttachmentsSampleCounts ) << "\n";
-      std::cout << "\t\t\t"
-                << "framebufferStencilSampleCounts                  = " << vk::to_string( properties.limits.framebufferStencilSampleCounts ) << "\n";
-      std::cout << "\t\t\t"
-                << "lineWidthGranularity                            = " << properties.limits.lineWidthGranularity << "\n";
-      std::cout << "\t\t\t"
-                << "lineWidthRange                                  = "
+      std::cout << std::string( "\t" ) << "Properties:\n";
+      std::cout << std::string( "\t\t" ) << "apiVersion        = " << decodeAPIVersion( properties.apiVersion ) << "\n";
+      std::cout << std::string( "\t\t" ) << "driverVersion     = " << decodeDriverVersion( properties.driverVersion, properties.vendorID ) << "\n";
+      std::cout << std::string( "\t\t" ) << "vendorID          = " << decodeVendorID( properties.vendorID ) << "\n";
+      std::cout << std::string( "\t\t" ) << "deviceID          = " << properties.deviceID << "\n";
+      std::cout << std::string( "\t\t" ) << "deviceType        = " << to_string( properties.deviceType ) << "\n";
+      std::cout << std::string( "\t\t" ) << "deviceName        = " << properties.deviceName << "\n";
+      std::cout << std::string( "\t\t" ) << "pipelineCacheUUID = " << vk::su::UUID( properties.pipelineCacheUUID ) << "\n";
+      std::cout << std::string( "\t\t" ) << "limits:\n";
+      std::cout << std::string( "\t\t\t" ) << "bufferImageGranularity                          = " << properties.limits.bufferImageGranularity << "\n";
+      std::cout << std::string( "\t\t\t" ) << "discreteQueuePriorities                         = " << properties.limits.discreteQueuePriorities << "\n";
+      std::cout << std::string( "\t\t\t" )
+                << "framebufferColorSampleCounts                    = " << to_string( properties.limits.framebufferColorSampleCounts ) << "\n";
+      std::cout << std::string( "\t\t\t" )
+                << "framebufferDepthSampleCounts                    = " << to_string( properties.limits.framebufferDepthSampleCounts ) << "\n";
+      std::cout << std::string( "\t\t\t" )
+                << "framebufferNoAttachmentsSampleCounts            = " << to_string( properties.limits.framebufferNoAttachmentsSampleCounts ) << "\n";
+      std::cout << std::string( "\t\t\t" )
+                << "framebufferStencilSampleCounts                  = " << to_string( properties.limits.framebufferStencilSampleCounts ) << "\n";
+      std::cout << std::string( "\t\t\t" ) << "lineWidthGranularity                            = " << properties.limits.lineWidthGranularity << "\n";
+      std::cout << std::string( "\t\t\t" ) << "lineWidthRange                                  = "
                 << "[" << properties.limits.lineWidthRange[0] << ", " << properties.limits.lineWidthRange[1] << "]"
                 << "\n";
-      std::cout << "\t\t\t"
-                << "maxBoundDescriptorSets                          = " << properties.limits.maxBoundDescriptorSets << "\n";
-      std::cout << "\t\t\t"
-                << "maxClipDistances                                = " << properties.limits.maxClipDistances << "\n";
-      std::cout << "\t\t\t"
-                << "maxColorAttachments                             = " << properties.limits.maxColorAttachments << "\n";
-      std::cout << "\t\t\t"
-                << "maxCombinedClipAndCullDistances                 = " << properties.limits.maxCombinedClipAndCullDistances << "\n";
-      std::cout << "\t\t\t"
-                << "maxComputeSharedMemorySize                      = " << properties.limits.maxComputeSharedMemorySize << "\n";
-      std::cout << "\t\t\t"
-                << "maxComputeWorkGroupCount                        = "
+      std::cout << std::string( "\t\t\t" ) << "maxBoundDescriptorSets                          = " << properties.limits.maxBoundDescriptorSets << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxClipDistances                                = " << properties.limits.maxClipDistances << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxColorAttachments                             = " << properties.limits.maxColorAttachments << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxCombinedClipAndCullDistances                 = " << properties.limits.maxCombinedClipAndCullDistances << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxComputeSharedMemorySize                      = " << properties.limits.maxComputeSharedMemorySize << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxComputeWorkGroupCount                        = "
                 << "[" << properties.limits.maxComputeWorkGroupCount[0] << ", " << properties.limits.maxComputeWorkGroupCount[1] << ", "
                 << properties.limits.maxComputeWorkGroupCount[2] << "]"
                 << "\n";
-      std::cout << "\t\t\t"
-                << "maxComputeWorkGroupInvocations                  = " << properties.limits.maxComputeWorkGroupInvocations << "\n";
-      std::cout << "\t\t\t"
-                << "maxComputeWorkGroupSize                         = "
+      std::cout << std::string( "\t\t\t" ) << "maxComputeWorkGroupInvocations                  = " << properties.limits.maxComputeWorkGroupInvocations << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxComputeWorkGroupSize                         = "
                 << "[" << properties.limits.maxComputeWorkGroupSize[0] << ", " << properties.limits.maxComputeWorkGroupSize[1] << ", "
                 << properties.limits.maxComputeWorkGroupSize[2] << "]"
                 << "\n";
-      std::cout << "\t\t\t"
-                << "maxCullDistances                                = " << properties.limits.maxCullDistances << "\n";
-      std::cout << "\t\t\t"
-                << "maxDescriptorSetInputAttachments                = " << properties.limits.maxDescriptorSetInputAttachments << "\n";
-      std::cout << "\t\t\t"
-                << "maxDescriptorSetSampledImages                   = " << properties.limits.maxDescriptorSetSampledImages << "\n";
-      std::cout << "\t\t\t"
-                << "maxDescriptorSetSamplers                        = " << properties.limits.maxDescriptorSetSamplers << "\n";
-      std::cout << "\t\t\t"
-                << "maxDescriptorSetStorageBuffers                  = " << properties.limits.maxDescriptorSetStorageBuffers << "\n";
-      std::cout << "\t\t\t"
-                << "maxDescriptorSetStorageBuffersDynamic           = " << properties.limits.maxDescriptorSetStorageBuffersDynamic << "\n";
-      std::cout << "\t\t\t"
-                << "maxDescriptorSetStorageImages                   = " << properties.limits.maxDescriptorSetStorageImages << "\n";
-      std::cout << "\t\t\t"
-                << "maxDescriptorSetUniformBuffers                  = " << properties.limits.maxDescriptorSetUniformBuffers << "\n";
-      std::cout << "\t\t\t"
-                << "maxDescriptorSetUniformBuffersDynamic           = " << properties.limits.maxDescriptorSetUniformBuffersDynamic << "\n";
-      std::cout << "\t\t\t"
-                << "maxDrawIndexedIndexValue                        = " << properties.limits.maxDrawIndexedIndexValue << "\n";
-      std::cout << "\t\t\t"
-                << "maxDrawIndirectCount                            = " << properties.limits.maxDrawIndirectCount << "\n";
-      std::cout << "\t\t\t"
-                << "maxFragmentCombinedOutputResources              = " << properties.limits.maxFragmentCombinedOutputResources << "\n";
-      std::cout << "\t\t\t"
-                << "maxFragmentDualSrcAttachments                   = " << properties.limits.maxFragmentDualSrcAttachments << "\n";
-      std::cout << "\t\t\t"
-                << "maxFragmentInputComponents                      = " << properties.limits.maxFragmentInputComponents << "\n";
-      std::cout << "\t\t\t"
-                << "maxFragmentOutputAttachments                    = " << properties.limits.maxFragmentOutputAttachments << "\n";
-      std::cout << "\t\t\t"
-                << "maxFramebufferHeight                            = " << properties.limits.maxFramebufferHeight << "\n";
-      std::cout << "\t\t\t"
-                << "maxFramebufferLayers                            = " << properties.limits.maxFramebufferLayers << "\n";
-      std::cout << "\t\t\t"
-                << "maxFramebufferWidth                             = " << properties.limits.maxFramebufferWidth << "\n";
-      std::cout << "\t\t\t"
-                << "maxGeometryInputComponents                      = " << properties.limits.maxGeometryInputComponents << "\n";
-      std::cout << "\t\t\t"
-                << "maxGeometryOutputComponents                     = " << properties.limits.maxGeometryOutputComponents << "\n";
-      std::cout << "\t\t\t"
-                << "maxGeometryOutputVertices                       = " << properties.limits.maxGeometryOutputVertices << "\n";
-      std::cout << "\t\t\t"
-                << "maxGeometryShaderInvocations                    = " << properties.limits.maxGeometryShaderInvocations << "\n";
-      std::cout << "\t\t\t"
-                << "maxGeometryTotalOutputComponents                = " << properties.limits.maxGeometryTotalOutputComponents << "\n";
-      std::cout << "\t\t\t"
-                << "maxImageArrayLayers                             = " << properties.limits.maxImageArrayLayers << "\n";
-      std::cout << "\t\t\t"
-                << "maxImageDimension1D                             = " << properties.limits.maxImageDimension1D << "\n";
-      std::cout << "\t\t\t"
-                << "maxImageDimension2D                             = " << properties.limits.maxImageDimension2D << "\n";
-      std::cout << "\t\t\t"
-                << "maxImageDimension3D                             = " << properties.limits.maxImageDimension3D << "\n";
-      std::cout << "\t\t\t"
-                << "maxImageDimensionCube                           = " << properties.limits.maxImageDimensionCube << "\n";
-      std::cout << "\t\t\t"
-                << "maxInterpolationOffset                          = " << properties.limits.maxInterpolationOffset << "\n";
-      std::cout << "\t\t\t"
-                << "maxMemoryAllocationCount                        = " << properties.limits.maxMemoryAllocationCount << "\n";
-      std::cout << "\t\t\t"
-                << "maxPerStageDescriptorInputAttachments           = " << properties.limits.maxPerStageDescriptorInputAttachments << "\n";
-      std::cout << "\t\t\t"
-                << "maxPerStageDescriptorSampledImages              = " << properties.limits.maxPerStageDescriptorSampledImages << "\n";
-      std::cout << "\t\t\t"
-                << "maxPerStageDescriptorSamplers                   = " << properties.limits.maxPerStageDescriptorSamplers << "\n";
-      std::cout << "\t\t\t"
-                << "maxPerStageDescriptorStorageBuffers             = " << properties.limits.maxPerStageDescriptorStorageBuffers << "\n";
-      std::cout << "\t\t\t"
-                << "maxPerStageDescriptorStorageImages              = " << properties.limits.maxPerStageDescriptorStorageImages << "\n";
-      std::cout << "\t\t\t"
-                << "maxPerStageDescriptorUniformBuffers             = " << properties.limits.maxPerStageDescriptorUniformBuffers << "\n";
-      std::cout << "\t\t\t"
-                << "maxPerStageResources                            = " << properties.limits.maxPerStageResources << "\n";
-      std::cout << "\t\t\t"
-                << "maxPushConstantsSize                            = " << properties.limits.maxPushConstantsSize << "\n";
-      std::cout << "\t\t\t"
-                << "maxSampleMaskWords                              = " << properties.limits.maxSampleMaskWords << "\n";
-      std::cout << "\t\t\t"
-                << "maxSamplerAllocationCount                       = " << properties.limits.maxSamplerAllocationCount << "\n";
-      std::cout << "\t\t\t"
-                << "maxSamplerAnisotropy                            = " << properties.limits.maxSamplerAnisotropy << "\n";
-      std::cout << "\t\t\t"
-                << "maxSamplerLodBias                               = " << properties.limits.maxSamplerLodBias << "\n";
-      std::cout << "\t\t\t"
-                << "maxStorageBufferRange                           = " << properties.limits.maxStorageBufferRange << "\n";
-      std::cout << "\t\t\t"
+      std::cout << std::string( "\t\t\t" ) << "maxCullDistances                                = " << properties.limits.maxCullDistances << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDescriptorSetInputAttachments                = " << properties.limits.maxDescriptorSetInputAttachments
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDescriptorSetSampledImages                   = " << properties.limits.maxDescriptorSetSampledImages << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDescriptorSetSamplers                        = " << properties.limits.maxDescriptorSetSamplers << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDescriptorSetStorageBuffers                  = " << properties.limits.maxDescriptorSetStorageBuffers << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDescriptorSetStorageBuffersDynamic           = " << properties.limits.maxDescriptorSetStorageBuffersDynamic
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDescriptorSetStorageImages                   = " << properties.limits.maxDescriptorSetStorageImages << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDescriptorSetUniformBuffers                  = " << properties.limits.maxDescriptorSetUniformBuffers << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDescriptorSetUniformBuffersDynamic           = " << properties.limits.maxDescriptorSetUniformBuffersDynamic
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDrawIndexedIndexValue                        = " << properties.limits.maxDrawIndexedIndexValue << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDrawIndirectCount                            = " << properties.limits.maxDrawIndirectCount << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxFragmentCombinedOutputResources              = " << properties.limits.maxFragmentCombinedOutputResources
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxFragmentDualSrcAttachments                   = " << properties.limits.maxFragmentDualSrcAttachments << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxFragmentInputComponents                      = " << properties.limits.maxFragmentInputComponents << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxFragmentOutputAttachments                    = " << properties.limits.maxFragmentOutputAttachments << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxFramebufferHeight                            = " << properties.limits.maxFramebufferHeight << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxFramebufferLayers                            = " << properties.limits.maxFramebufferLayers << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxFramebufferWidth                             = " << properties.limits.maxFramebufferWidth << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxGeometryInputComponents                      = " << properties.limits.maxGeometryInputComponents << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxGeometryOutputComponents                     = " << properties.limits.maxGeometryOutputComponents << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxGeometryOutputVertices                       = " << properties.limits.maxGeometryOutputVertices << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxGeometryShaderInvocations                    = " << properties.limits.maxGeometryShaderInvocations << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxGeometryTotalOutputComponents                = " << properties.limits.maxGeometryTotalOutputComponents
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxImageArrayLayers                             = " << properties.limits.maxImageArrayLayers << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxImageDimension1D                             = " << properties.limits.maxImageDimension1D << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxImageDimension2D                             = " << properties.limits.maxImageDimension2D << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxImageDimension3D                             = " << properties.limits.maxImageDimension3D << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxImageDimensionCube                           = " << properties.limits.maxImageDimensionCube << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxInterpolationOffset                          = " << properties.limits.maxInterpolationOffset << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxMemoryAllocationCount                        = " << properties.limits.maxMemoryAllocationCount << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxPerStageDescriptorInputAttachments           = " << properties.limits.maxPerStageDescriptorInputAttachments
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxPerStageDescriptorSampledImages              = " << properties.limits.maxPerStageDescriptorSampledImages
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxPerStageDescriptorSamplers                   = " << properties.limits.maxPerStageDescriptorSamplers << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxPerStageDescriptorStorageBuffers             = " << properties.limits.maxPerStageDescriptorStorageBuffers
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxPerStageDescriptorStorageImages              = " << properties.limits.maxPerStageDescriptorStorageImages
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxPerStageDescriptorUniformBuffers             = " << properties.limits.maxPerStageDescriptorUniformBuffers
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxPerStageResources                            = " << properties.limits.maxPerStageResources << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxPushConstantsSize                            = " << properties.limits.maxPushConstantsSize << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxSampleMaskWords                              = " << properties.limits.maxSampleMaskWords << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxSamplerAllocationCount                       = " << properties.limits.maxSamplerAllocationCount << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxSamplerAnisotropy                            = " << properties.limits.maxSamplerAnisotropy << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxSamplerLodBias                               = " << properties.limits.maxSamplerLodBias << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxStorageBufferRange                           = " << properties.limits.maxStorageBufferRange << "\n";
+      std::cout << std::string( "\t\t\t" )
                 << "maxTessellationControlPerPatchOutputComponents  = " << properties.limits.maxTessellationControlPerPatchOutputComponents << "\n";
-      std::cout << "\t\t\t"
+      std::cout << std::string( "\t\t\t" )
                 << "maxTessellationControlPerVertexInputComponents  = " << properties.limits.maxTessellationControlPerVertexInputComponents << "\n";
-      std::cout << "\t\t\t"
+      std::cout << std::string( "\t\t\t" )
                 << "maxTessellationControlPerVertexOutputComponents = " << properties.limits.maxTessellationControlPerVertexOutputComponents << "\n";
-      std::cout << "\t\t\t"
+      std::cout << std::string( "\t\t\t" )
                 << "maxTessellationControlTotalOutputComponents     = " << properties.limits.maxTessellationControlTotalOutputComponents << "\n";
-      std::cout << "\t\t\t"
-                << "maxTessellationEvaluationInputComponents        = " << properties.limits.maxTessellationEvaluationInputComponents << "\n";
-      std::cout << "\t\t\t"
+      std::cout << std::string( "\t\t\t" ) << "maxTessellationEvaluationInputComponents        = " << properties.limits.maxTessellationEvaluationInputComponents
+                << "\n";
+      std::cout << std::string( "\t\t\t" )
                 << "maxTessellationEvaluationOutputComponents       = " << properties.limits.maxTessellationEvaluationOutputComponents << "\n";
-      std::cout << "\t\t\t"
-                << "maxTessellationGenerationLevel                  = " << properties.limits.maxTessellationGenerationLevel << "\n";
-      std::cout << "\t\t\t"
-                << "maxTessellationPatchSize                        = " << properties.limits.maxTessellationPatchSize << "\n";
-      std::cout << "\t\t\t"
-                << "maxTexelBufferElements                          = " << properties.limits.maxTexelBufferElements << "\n";
-      std::cout << "\t\t\t"
-                << "maxTexelGatherOffset                            = " << properties.limits.maxTexelGatherOffset << "\n";
-      std::cout << "\t\t\t"
-                << "maxTexelOffset                                  = " << properties.limits.maxTexelOffset << "\n";
-      std::cout << "\t\t\t"
-                << "maxUniformBufferRange                           = " << properties.limits.maxUniformBufferRange << "\n";
-      std::cout << "\t\t\t"
-                << "maxVertexInputAttributeOffset                   = " << properties.limits.maxVertexInputAttributeOffset << "\n";
-      std::cout << "\t\t\t"
-                << "maxVertexInputAttributes                        = " << properties.limits.maxVertexInputAttributes << "\n";
-      std::cout << "\t\t\t"
-                << "maxVertexInputBindings                          = " << properties.limits.maxVertexInputBindings << "\n";
-      std::cout << "\t\t\t"
-                << "maxVertexInputBindingStride                     = " << properties.limits.maxVertexInputBindingStride << "\n";
-      std::cout << "\t\t\t"
-                << "maxVertexOutputComponents                       = " << properties.limits.maxVertexOutputComponents << "\n";
-      std::cout << "\t\t\t"
-                << "maxViewportDimensions                           = "
+      std::cout << std::string( "\t\t\t" ) << "maxTessellationGenerationLevel                  = " << properties.limits.maxTessellationGenerationLevel << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxTessellationPatchSize                        = " << properties.limits.maxTessellationPatchSize << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxTexelBufferElements                          = " << properties.limits.maxTexelBufferElements << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxTexelGatherOffset                            = " << properties.limits.maxTexelGatherOffset << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxTexelOffset                                  = " << properties.limits.maxTexelOffset << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxUniformBufferRange                           = " << properties.limits.maxUniformBufferRange << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxVertexInputAttributeOffset                   = " << properties.limits.maxVertexInputAttributeOffset << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxVertexInputAttributes                        = " << properties.limits.maxVertexInputAttributes << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxVertexInputBindings                          = " << properties.limits.maxVertexInputBindings << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxVertexInputBindingStride                     = " << properties.limits.maxVertexInputBindingStride << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxVertexOutputComponents                       = " << properties.limits.maxVertexOutputComponents << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxViewportDimensions                           = "
                 << "[" << properties.limits.maxViewportDimensions[0] << ", " << properties.limits.maxViewportDimensions[1] << "]"
                 << "\n";
-      std::cout << "\t\t\t"
-                << "maxViewports                                    = " << properties.limits.maxViewports << "\n";
-      std::cout << "\t\t\t"
-                << "minInterpolationOffset                          = " << properties.limits.minInterpolationOffset << "\n";
-      std::cout << "\t\t\t"
-                << "minMemoryMapAlignment                           = " << properties.limits.minMemoryMapAlignment << "\n";
-      std::cout << "\t\t\t"
-                << "minStorageBufferOffsetAlignment                 = " << properties.limits.minStorageBufferOffsetAlignment << "\n";
-      std::cout << "\t\t\t"
-                << "minTexelBufferOffsetAlignment                   = " << properties.limits.minTexelBufferOffsetAlignment << "\n";
-      std::cout << "\t\t\t"
-                << "minTexelGatherOffset                            = " << properties.limits.minTexelGatherOffset << "\n";
-      std::cout << "\t\t\t"
-                << "minTexelOffset                                  = " << properties.limits.minTexelOffset << "\n";
-      std::cout << "\t\t\t"
-                << "minUniformBufferOffsetAlignment                 = " << properties.limits.minUniformBufferOffsetAlignment << "\n";
-      std::cout << "\t\t\t"
-                << "mipmapPrecisionBits                             = " << properties.limits.mipmapPrecisionBits << "\n";
-      std::cout << "\t\t\t"
-                << "nonCoherentAtomSize                             = " << properties.limits.nonCoherentAtomSize << "\n";
-      std::cout << "\t\t\t"
-                << "optimalBufferCopyOffsetAlignment                = " << properties.limits.optimalBufferCopyOffsetAlignment << "\n";
-      std::cout << "\t\t\t"
-                << "optimalBufferCopyRowPitchAlignment              = " << properties.limits.optimalBufferCopyRowPitchAlignment << "\n";
-      std::cout << "\t\t\t"
-                << "pointSizeGranularity                            = " << properties.limits.pointSizeGranularity << "\n";
-      std::cout << "\t\t\t"
-                << "pointSizeRange                                  = "
+      std::cout << std::string( "\t\t\t" ) << "maxViewports                                    = " << properties.limits.maxViewports << "\n";
+      std::cout << std::string( "\t\t\t" ) << "minInterpolationOffset                          = " << properties.limits.minInterpolationOffset << "\n";
+      std::cout << std::string( "\t\t\t" ) << "minMemoryMapAlignment                           = " << properties.limits.minMemoryMapAlignment << "\n";
+      std::cout << std::string( "\t\t\t" ) << "minStorageBufferOffsetAlignment                 = " << properties.limits.minStorageBufferOffsetAlignment << "\n";
+      std::cout << std::string( "\t\t\t" ) << "minTexelBufferOffsetAlignment                   = " << properties.limits.minTexelBufferOffsetAlignment << "\n";
+      std::cout << std::string( "\t\t\t" ) << "minTexelGatherOffset                            = " << properties.limits.minTexelGatherOffset << "\n";
+      std::cout << std::string( "\t\t\t" ) << "minTexelOffset                                  = " << properties.limits.minTexelOffset << "\n";
+      std::cout << std::string( "\t\t\t" ) << "minUniformBufferOffsetAlignment                 = " << properties.limits.minUniformBufferOffsetAlignment << "\n";
+      std::cout << std::string( "\t\t\t" ) << "mipmapPrecisionBits                             = " << properties.limits.mipmapPrecisionBits << "\n";
+      std::cout << std::string( "\t\t\t" ) << "nonCoherentAtomSize                             = " << properties.limits.nonCoherentAtomSize << "\n";
+      std::cout << std::string( "\t\t\t" ) << "optimalBufferCopyOffsetAlignment                = " << properties.limits.optimalBufferCopyOffsetAlignment
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "optimalBufferCopyRowPitchAlignment              = " << properties.limits.optimalBufferCopyRowPitchAlignment
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "pointSizeGranularity                            = " << properties.limits.pointSizeGranularity << "\n";
+      std::cout << std::string( "\t\t\t" ) << "pointSizeRange                                  = "
                 << "[" << properties.limits.pointSizeRange[0] << ", " << properties.limits.pointSizeRange[1] << "]"
                 << "\n";
-      std::cout << "\t\t\t"
-                << "sampledImageColorSampleCounts                   = " << vk::to_string( properties.limits.sampledImageColorSampleCounts ) << "\n";
-      std::cout << "\t\t\t"
-                << "sampledImageDepthSampleCounts                   = " << vk::to_string( properties.limits.sampledImageDepthSampleCounts ) << "\n";
-      std::cout << "\t\t\t"
-                << "sampledImageIntegerSampleCounts                 = " << vk::to_string( properties.limits.sampledImageIntegerSampleCounts ) << "\n";
-      std::cout << "\t\t\t"
-                << "sampledImageStencilSampleCounts                 = " << vk::to_string( properties.limits.sampledImageStencilSampleCounts ) << "\n";
-      std::cout << "\t\t\t"
-                << "sparseAddressSpaceSize                          = " << properties.limits.sparseAddressSpaceSize << "\n";
-      std::cout << "\t\t\t"
-                << "standardSampleLocations                         = " << !!properties.limits.standardSampleLocations << "\n";
-      std::cout << "\t\t\t"
-                << "storageImageSampleCounts                        = " << vk::to_string( properties.limits.storageImageSampleCounts ) << "\n";
-      std::cout << "\t\t\t"
-                << "strictLines                                     = " << !!properties.limits.strictLines << "\n";
-      std::cout << "\t\t\t"
-                << "subPixelInterpolationOffsetBits                 = " << properties.limits.subPixelInterpolationOffsetBits << "\n";
-      std::cout << "\t\t\t"
-                << "subPixelPrecisionBits                           = " << properties.limits.subPixelPrecisionBits << "\n";
-      std::cout << "\t\t\t"
-                << "subTexelPrecisionBits                           = " << properties.limits.subTexelPrecisionBits << "\n";
-      std::cout << "\t\t\t"
-                << "timestampComputeAndGraphics                     = " << !!properties.limits.timestampComputeAndGraphics << "\n";
-      std::cout << "\t\t\t"
-                << "timestampPeriod                                 = " << properties.limits.timestampPeriod << "\n";
-      std::cout << "\t\t\t"
-                << "viewportBoundsRange                             = "
+      std::cout << std::string( "\t\t\t" )
+                << "sampledImageColorSampleCounts                   = " << to_string( properties.limits.sampledImageColorSampleCounts ) << "\n";
+      std::cout << std::string( "\t\t\t" )
+                << "sampledImageDepthSampleCounts                   = " << to_string( properties.limits.sampledImageDepthSampleCounts ) << "\n";
+      std::cout << std::string( "\t\t\t" )
+                << "sampledImageIntegerSampleCounts                 = " << to_string( properties.limits.sampledImageIntegerSampleCounts ) << "\n";
+      std::cout << std::string( "\t\t\t" )
+                << "sampledImageStencilSampleCounts                 = " << to_string( properties.limits.sampledImageStencilSampleCounts ) << "\n";
+      std::cout << std::string( "\t\t\t" ) << "sparseAddressSpaceSize                          = " << properties.limits.sparseAddressSpaceSize << "\n";
+      std::cout << std::string( "\t\t\t" ) << "standardSampleLocations                         = " << !!properties.limits.standardSampleLocations << "\n";
+      std::cout << std::string( "\t\t\t" ) << "storageImageSampleCounts                        = " << to_string( properties.limits.storageImageSampleCounts )
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "strictLines                                     = " << !!properties.limits.strictLines << "\n";
+      std::cout << std::string( "\t\t\t" ) << "subPixelInterpolationOffsetBits                 = " << properties.limits.subPixelInterpolationOffsetBits << "\n";
+      std::cout << std::string( "\t\t\t" ) << "subPixelPrecisionBits                           = " << properties.limits.subPixelPrecisionBits << "\n";
+      std::cout << std::string( "\t\t\t" ) << "subTexelPrecisionBits                           = " << properties.limits.subTexelPrecisionBits << "\n";
+      std::cout << std::string( "\t\t\t" ) << "timestampComputeAndGraphics                     = " << !!properties.limits.timestampComputeAndGraphics << "\n";
+      std::cout << std::string( "\t\t\t" ) << "timestampPeriod                                 = " << properties.limits.timestampPeriod << "\n";
+      std::cout << std::string( "\t\t\t" ) << "viewportBoundsRange                             = "
                 << "[" << properties.limits.viewportBoundsRange[0] << ", " << properties.limits.viewportBoundsRange[1] << "]"
                 << "\n";
-      std::cout << "\t\t\t"
-                << "viewportSubPixelBits                            = " << properties.limits.viewportSubPixelBits << "\n";
-      std::cout << "\t\t"
-                << "sparseProperties:\n";
-      std::cout << "\t\t\t"
-                << "residencyAlignedMipSize                   = " << !!properties.sparseProperties.residencyAlignedMipSize << "\n";
-      std::cout << "\t\t\t"
-                << "residencyNonResidentStrict                = " << !!properties.sparseProperties.residencyNonResidentStrict << "\n";
-      std::cout << "\t\t\t"
-                << "residencyStandard2DBlockShape             = " << !!properties.sparseProperties.residencyStandard2DBlockShape << "\n";
-      std::cout << "\t\t\t"
+      std::cout << std::string( "\t\t\t" ) << "viewportSubPixelBits                            = " << properties.limits.viewportSubPixelBits << "\n";
+      std::cout << std::string( "\t\t" ) << "sparseProperties:\n";
+      std::cout << std::string( "\t\t\t" ) << "residencyAlignedMipSize                   = " << !!properties.sparseProperties.residencyAlignedMipSize << "\n";
+      std::cout << std::string( "\t\t\t" ) << "residencyNonResidentStrict                = " << !!properties.sparseProperties.residencyNonResidentStrict
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "residencyStandard2DBlockShape             = " << !!properties.sparseProperties.residencyStandard2DBlockShape
+                << "\n";
+      std::cout << std::string( "\t\t\t" )
                 << "residencyStandard2DMultisampleBlockShape  = " << !!properties.sparseProperties.residencyStandard2DMultisampleBlockShape << "\n";
-      std::cout << "\t\t\t"
-                << "residencyStandard3DBlockShape             = " << !!properties.sparseProperties.residencyStandard3DBlockShape << "\n";
+      std::cout << std::string( "\t\t\t" ) << "residencyStandard3DBlockShape             = " << !!properties.sparseProperties.residencyStandard3DBlockShape
+                << "\n";
       std::cout << "\n";
 
       if ( vk::su::contains( extensionProperties, "VK_EXT_blend_operation_advanced" ) )
       {
         vk::PhysicalDeviceBlendOperationAdvancedPropertiesEXT const & blendOperationAdvancedProperties =
           properties2.get<vk::PhysicalDeviceBlendOperationAdvancedPropertiesEXT>();
-        std::cout << "\t"
-                  << "BlendOperationAdvancedProperties:\n";
-        std::cout << "\t\t"
-                  << "advancedBlendAllOperations            = " << !!blendOperationAdvancedProperties.advancedBlendAllOperations << "\n";
-        std::cout << "\t\t"
-                  << "advancedBlendCorrelatedOverlap        = " << !!blendOperationAdvancedProperties.advancedBlendCorrelatedOverlap << "\n";
-        std::cout << "\t\t"
-                  << "advancedBlendIndependentBlend         = " << !!blendOperationAdvancedProperties.advancedBlendIndependentBlend << "\n";
-        std::cout << "\t\t"
-                  << "advancedBlendMaxColorAttachments      = " << blendOperationAdvancedProperties.advancedBlendMaxColorAttachments << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t" ) << "BlendOperationAdvancedProperties:\n";
+        std::cout << std::string( "\t\t" ) << "advancedBlendAllOperations            = " << !!blendOperationAdvancedProperties.advancedBlendAllOperations
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "advancedBlendCorrelatedOverlap        = " << !!blendOperationAdvancedProperties.advancedBlendCorrelatedOverlap
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "advancedBlendIndependentBlend         = " << !!blendOperationAdvancedProperties.advancedBlendIndependentBlend
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "advancedBlendMaxColorAttachments      = " << blendOperationAdvancedProperties.advancedBlendMaxColorAttachments
+                  << "\n";
+        std::cout << std::string( "\t\t" )
                   << "advancedBlendNonPremultipliedDstColor = " << !!blendOperationAdvancedProperties.advancedBlendNonPremultipliedDstColor << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "advancedBlendNonPremultipliedSrcColor = " << !!blendOperationAdvancedProperties.advancedBlendNonPremultipliedSrcColor << "\n";
         std::cout << "\n";
       }
@@ -437,28 +556,27 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceConservativeRasterizationPropertiesEXT const & conservativeRasterizationProperties =
           properties2.get<vk::PhysicalDeviceConservativeRasterizationPropertiesEXT>();
-        std::cout << "\t"
-                  << "ConservativeRasterizationProperties:\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t" ) << "ConservativeRasterizationProperties:\n";
+        std::cout << std::string( "\t\t" )
                   << "conservativePointAndLineRasterization       = " << !!conservativeRasterizationProperties.conservativePointAndLineRasterization << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "conservativeRasterizationPostDepthCoverage  = " << !!conservativeRasterizationProperties.conservativeRasterizationPostDepthCoverage
                   << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "degenerateLinesRasterized                   = " << !!conservativeRasterizationProperties.degenerateLinesRasterized << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "degenerateTrianglesRasterized               = " << !!conservativeRasterizationProperties.degenerateTrianglesRasterized << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "extraPrimitiveOverestimationSizeGranularity = " << conservativeRasterizationProperties.extraPrimitiveOverestimationSizeGranularity
                   << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "fullyCoveredFragmentShaderInputVariable     = " << !!conservativeRasterizationProperties.fullyCoveredFragmentShaderInputVariable << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxExtraPrimitiveOverestimationSize         = " << conservativeRasterizationProperties.maxExtraPrimitiveOverestimationSize << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "primitiveOverestimationSize                 = " << conservativeRasterizationProperties.primitiveOverestimationSize << "\n";
-        std::cout << "\t\t"
-                  << "primitiveUnderestimation                    = " << !!conservativeRasterizationProperties.primitiveUnderestimation << "\n";
+        std::cout << std::string( "\t\t" ) << "primitiveUnderestimation                    = " << !!conservativeRasterizationProperties.primitiveUnderestimation
+                  << "\n";
         std::cout << "\n";
       }
 
@@ -466,10 +584,9 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceCooperativeMatrixPropertiesNV const & cooperativeMatrixProperties =
           properties2.get<vk::PhysicalDeviceCooperativeMatrixPropertiesNV>();
-        std::cout << "\t"
-                  << "CooperativeMatrixProperties:\n";
-        std::cout << "\t\t"
-                  << "cooperativeMatrixSupportedStages  = " << vk::to_string( cooperativeMatrixProperties.cooperativeMatrixSupportedStages ) << "\n";
+        std::cout << std::string( "\t" ) << "CooperativeMatrixProperties:\n";
+        std::cout << std::string( "\t\t" )
+                  << "cooperativeMatrixSupportedStages  = " << to_string( cooperativeMatrixProperties.cooperativeMatrixSupportedStages ) << "\n";
         std::cout << "\n";
       }
 
@@ -477,16 +594,13 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceDepthStencilResolvePropertiesKHR const & depthStencilResolveProperties =
           properties2.get<vk::PhysicalDeviceDepthStencilResolvePropertiesKHR>();
-        std::cout << "\t"
-                  << "DepthStencilResolveProperties:\n";
-        std::cout << "\t\t"
-                  << "independentResolve            = " << !!depthStencilResolveProperties.independentResolve << "\n";
-        std::cout << "\t\t"
-                  << "independentResolveNone        = " << !!depthStencilResolveProperties.independentResolveNone << "\n";
-        std::cout << "\t\t"
-                  << "supportedDepthResolveModes    = " << vk::to_string( depthStencilResolveProperties.supportedDepthResolveModes ) << "\n";
-        std::cout << "\t\t"
-                  << "supportedStencilResolveModes  = " << vk::to_string( depthStencilResolveProperties.supportedStencilResolveModes ) << "\n";
+        std::cout << std::string( "\t" ) << "DepthStencilResolveProperties:\n";
+        std::cout << std::string( "\t\t" ) << "independentResolve            = " << !!depthStencilResolveProperties.independentResolve << "\n";
+        std::cout << std::string( "\t\t" ) << "independentResolveNone        = " << !!depthStencilResolveProperties.independentResolveNone << "\n";
+        std::cout << std::string( "\t\t" ) << "supportedDepthResolveModes    = " << to_string( depthStencilResolveProperties.supportedDepthResolveModes )
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "supportedStencilResolveModes  = " << to_string( depthStencilResolveProperties.supportedStencilResolveModes )
+                  << "\n";
         std::cout << "\n";
       }
 
@@ -494,71 +608,58 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceDescriptorIndexingPropertiesEXT const & descriptorIndexingProperties =
           properties2.get<vk::PhysicalDeviceDescriptorIndexingPropertiesEXT>();
-        std::cout << "\t"
-                  << "DescriptorIndexingProperties:\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t" ) << "DescriptorIndexingProperties:\n";
+        std::cout << std::string( "\t\t" )
                   << "maxDescriptorSetUpdateAfterBindInputAttachments       = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindInputAttachments
                   << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxDescriptorSetUpdateAfterBindSampledImages          = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindSampledImages
                   << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxDescriptorSetUpdateAfterBindSamplers               = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindSamplers << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxDescriptorSetUpdateAfterBindStorageBuffers         = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindStorageBuffers
                   << "\n";
-        std::cout << "\t\t"
-                  << "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic  = "
+        std::cout << std::string( "\t\t" ) << "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic  = "
                   << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindStorageBuffersDynamic << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxDescriptorSetUpdateAfterBindStorageImages          = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindStorageImages
                   << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxDescriptorSetUpdateAfterBindUniformBuffers         = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindUniformBuffers
                   << "\n";
-        std::cout << "\t\t"
-                  << "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic  = "
+        std::cout << std::string( "\t\t" ) << "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic  = "
                   << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindUniformBuffersDynamic << "\n";
-        std::cout << "\t\t"
-                  << "maxPerStageDescriptorUpdateAfterBindInputAttachments  = "
+        std::cout << std::string( "\t\t" ) << "maxPerStageDescriptorUpdateAfterBindInputAttachments  = "
                   << descriptorIndexingProperties.maxPerStageDescriptorUpdateAfterBindInputAttachments << "\n";
-        std::cout << "\t\t"
-                  << "maxPerStageDescriptorUpdateAfterBindSampledImages     = "
+        std::cout << std::string( "\t\t" ) << "maxPerStageDescriptorUpdateAfterBindSampledImages     = "
                   << descriptorIndexingProperties.maxPerStageDescriptorUpdateAfterBindSampledImages << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxPerStageDescriptorUpdateAfterBindSamplers          = " << descriptorIndexingProperties.maxPerStageDescriptorUpdateAfterBindSamplers
                   << "\n";
-        std::cout << "\t\t"
-                  << "maxPerStageDescriptorUpdateAfterBindStorageBuffers    = "
+        std::cout << std::string( "\t\t" ) << "maxPerStageDescriptorUpdateAfterBindStorageBuffers    = "
                   << descriptorIndexingProperties.maxPerStageDescriptorUpdateAfterBindStorageBuffers << "\n";
-        std::cout << "\t\t"
-                  << "maxPerStageDescriptorUpdateAfterBindStorageImages     = "
+        std::cout << std::string( "\t\t" ) << "maxPerStageDescriptorUpdateAfterBindStorageImages     = "
                   << descriptorIndexingProperties.maxPerStageDescriptorUpdateAfterBindStorageImages << "\n";
-        std::cout << "\t\t"
-                  << "maxPerStageDescriptorUpdateAfterBindUniformBuffers    = "
+        std::cout << std::string( "\t\t" ) << "maxPerStageDescriptorUpdateAfterBindUniformBuffers    = "
                   << descriptorIndexingProperties.maxPerStageDescriptorUpdateAfterBindUniformBuffers << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxPerStageUpdateAfterBindResources                   = " << descriptorIndexingProperties.maxPerStageUpdateAfterBindResources << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxUpdateAfterBindDescriptorsInAllPools               = " << descriptorIndexingProperties.maxUpdateAfterBindDescriptorsInAllPools << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "quadDivergentImplicitLod                              = " << !!descriptorIndexingProperties.quadDivergentImplicitLod << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "robustBufferAccessUpdateAfterBind                     = " << !!descriptorIndexingProperties.robustBufferAccessUpdateAfterBind << "\n";
-        std::cout << "\t\t"
-                  << "shaderInputAttachmentArrayNonUniformIndexingNative    = "
+        std::cout << std::string( "\t\t" ) << "shaderInputAttachmentArrayNonUniformIndexingNative    = "
                   << !!descriptorIndexingProperties.shaderInputAttachmentArrayNonUniformIndexingNative << "\n";
-        std::cout << "\t\t"
-                  << "shaderSampledImageArrayNonUniformIndexingNative       = "
+        std::cout << std::string( "\t\t" ) << "shaderSampledImageArrayNonUniformIndexingNative       = "
                   << !!descriptorIndexingProperties.shaderSampledImageArrayNonUniformIndexingNative << "\n";
-        std::cout << "\t\t"
-                  << "shaderStorageBufferArrayNonUniformIndexingNative      = "
+        std::cout << std::string( "\t\t" ) << "shaderStorageBufferArrayNonUniformIndexingNative      = "
                   << !!descriptorIndexingProperties.shaderStorageBufferArrayNonUniformIndexingNative << "\n";
-        std::cout << "\t\t"
-                  << "shaderStorageImageArrayNonUniformIndexingNative       = "
+        std::cout << std::string( "\t\t" ) << "shaderStorageImageArrayNonUniformIndexingNative       = "
                   << !!descriptorIndexingProperties.shaderStorageImageArrayNonUniformIndexingNative << "\n";
-        std::cout << "\t\t"
-                  << "shaderUniformBufferArrayNonUniformIndexingNative      = "
+        std::cout << std::string( "\t\t" ) << "shaderUniformBufferArrayNonUniformIndexingNative      = "
                   << !!descriptorIndexingProperties.shaderUniformBufferArrayNonUniformIndexingNative << "\n";
         std::cout << "\n";
       }
@@ -566,26 +667,19 @@ int main( int /*argc*/, char ** /*argv*/ )
       if ( vk::su::contains( extensionProperties, "VK_EXT_discard_rectangles" ) )
       {
         vk::PhysicalDeviceDiscardRectanglePropertiesEXT const & discardRectangleProperties = properties2.get<vk::PhysicalDeviceDiscardRectanglePropertiesEXT>();
-        std::cout << "\t"
-                  << "DiscardRectangleProperties:\n";
-        std::cout << "\t\t"
-                  << "maxDiscardRectangles  = " << discardRectangleProperties.maxDiscardRectangles << "\n";
+        std::cout << std::string( "\t" ) << "DiscardRectangleProperties:\n";
+        std::cout << std::string( "\t\t" ) << "maxDiscardRectangles  = " << discardRectangleProperties.maxDiscardRectangles << "\n";
         std::cout << "\n";
       }
 
       if ( vk::su::contains( extensionProperties, "VK_KHR_driver_properties" ) )
       {
         vk::PhysicalDeviceDriverPropertiesKHR const & driverProperties = properties2.get<vk::PhysicalDeviceDriverPropertiesKHR>();
-        std::cout << "\t"
-                  << "DriverProperties:\n";
-        std::cout << "\t\t"
-                  << "driverID            = " << vk::to_string( driverProperties.driverID ) << "\n";
-        std::cout << "\t\t"
-                  << "driverName          = " << driverProperties.driverName << "\n";
-        std::cout << "\t\t"
-                  << "driverInfo          = " << driverProperties.driverInfo << "\n";
-        std::cout << "\t\t"
-                  << "conformanceVersion  = " << static_cast<uint32_t>( driverProperties.conformanceVersion.major ) << "."
+        std::cout << std::string( "\t" ) << "DriverProperties:\n";
+        std::cout << std::string( "\t\t" ) << "driverID            = " << to_string( driverProperties.driverID ) << "\n";
+        std::cout << std::string( "\t\t" ) << "driverName          = " << driverProperties.driverName << "\n";
+        std::cout << std::string( "\t\t" ) << "driverInfo          = " << driverProperties.driverInfo << "\n";
+        std::cout << std::string( "\t\t" ) << "conformanceVersion  = " << static_cast<uint32_t>( driverProperties.conformanceVersion.major ) << "."
                   << static_cast<uint32_t>( driverProperties.conformanceVersion.minor ) << "."
                   << static_cast<uint32_t>( driverProperties.conformanceVersion.subminor ) << "."
                   << static_cast<uint32_t>( driverProperties.conformanceVersion.patch ) << std::dec << "\n";
@@ -596,52 +690,37 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceExternalMemoryHostPropertiesEXT const & externalMemoryHostProperties =
           properties2.get<vk::PhysicalDeviceExternalMemoryHostPropertiesEXT>();
-        std::cout << "\t"
-                  << "ExternalMemoryHostProperties:\n";
-        std::cout << "\t\t"
-                  << "minImportedHostPointerAlignment = " << externalMemoryHostProperties.minImportedHostPointerAlignment << "\n";
+        std::cout << std::string( "\t" ) << "ExternalMemoryHostProperties:\n";
+        std::cout << std::string( "\t\t" ) << "minImportedHostPointerAlignment = " << externalMemoryHostProperties.minImportedHostPointerAlignment << "\n";
         std::cout << "\n";
       }
 
       if ( vk::su::contains( extensionProperties, "VK_KHR_shader_float_controls" ) )
       {
         vk::PhysicalDeviceFloatControlsPropertiesKHR const & floatControlsProperties = properties2.get<vk::PhysicalDeviceFloatControlsPropertiesKHR>();
-        std::cout << "\t"
-                  << "FloatControlsProperties:\n";
-        std::cout << "\t\t"
-                  << "denormBehaviorIndependence            = " << vk::to_string( floatControlsProperties.denormBehaviorIndependence ) << "\n";
-        std::cout << "\t\t"
-                  << "roundingModeIndependence              = " << vk::to_string( floatControlsProperties.roundingModeIndependence ) << "\n";
-        std::cout << "\t\t"
-                  << "shaderDenormFlushToZeroFloat16        = " << !!floatControlsProperties.shaderDenormFlushToZeroFloat16 << "\n";
-        std::cout << "\t\t"
-                  << "shaderDenormFlushToZeroFloat32        = " << !!floatControlsProperties.shaderDenormFlushToZeroFloat32 << "\n";
-        std::cout << "\t\t"
-                  << "shaderDenormFlushToZeroFloat64        = " << !!floatControlsProperties.shaderDenormFlushToZeroFloat64 << "\n";
-        std::cout << "\t\t"
-                  << "shaderDenormPreserveFloat16           = " << !!floatControlsProperties.shaderDenormPreserveFloat16 << "\n";
-        std::cout << "\t\t"
-                  << "shaderDenormPreserveFloat32           = " << !!floatControlsProperties.shaderDenormPreserveFloat32 << "\n";
-        std::cout << "\t\t"
-                  << "shaderDenormPreserveFloat64           = " << !!floatControlsProperties.shaderDenormPreserveFloat64 << "\n";
-        std::cout << "\t\t"
-                  << "shaderRoundingModeRTEFloat16          = " << !!floatControlsProperties.shaderRoundingModeRTEFloat16 << "\n";
-        std::cout << "\t\t"
-                  << "shaderRoundingModeRTEFloat32          = " << !!floatControlsProperties.shaderRoundingModeRTEFloat32 << "\n";
-        std::cout << "\t\t"
-                  << "shaderRoundingModeRTEFloat64          = " << !!floatControlsProperties.shaderRoundingModeRTEFloat64 << "\n";
-        std::cout << "\t\t"
-                  << "shaderRoundingModeRTZFloat16          = " << !!floatControlsProperties.shaderRoundingModeRTZFloat16 << "\n";
-        std::cout << "\t\t"
-                  << "shaderRoundingModeRTZFloat32          = " << !!floatControlsProperties.shaderRoundingModeRTZFloat32 << "\n";
-        std::cout << "\t\t"
-                  << "shaderRoundingModeRTZFloat64          = " << !!floatControlsProperties.shaderRoundingModeRTZFloat64 << "\n";
-        std::cout << "\t\t"
-                  << "shaderSignedZeroInfNanPreserveFloat16 = " << !!floatControlsProperties.shaderSignedZeroInfNanPreserveFloat16 << "\n";
-        std::cout << "\t\t"
-                  << "shaderSignedZeroInfNanPreserveFloat32 = " << !!floatControlsProperties.shaderSignedZeroInfNanPreserveFloat32 << "\n";
-        std::cout << "\t\t"
-                  << "shaderSignedZeroInfNanPreserveFloat64 = " << !!floatControlsProperties.shaderSignedZeroInfNanPreserveFloat64 << "\n";
+        std::cout << std::string( "\t" ) << "FloatControlsProperties:\n";
+        std::cout << std::string( "\t\t" ) << "denormBehaviorIndependence            = " << to_string( floatControlsProperties.denormBehaviorIndependence )
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "roundingModeIndependence              = " << to_string( floatControlsProperties.roundingModeIndependence )
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderDenormFlushToZeroFloat16        = " << !!floatControlsProperties.shaderDenormFlushToZeroFloat16 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderDenormFlushToZeroFloat32        = " << !!floatControlsProperties.shaderDenormFlushToZeroFloat32 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderDenormFlushToZeroFloat64        = " << !!floatControlsProperties.shaderDenormFlushToZeroFloat64 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderDenormPreserveFloat16           = " << !!floatControlsProperties.shaderDenormPreserveFloat16 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderDenormPreserveFloat32           = " << !!floatControlsProperties.shaderDenormPreserveFloat32 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderDenormPreserveFloat64           = " << !!floatControlsProperties.shaderDenormPreserveFloat64 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderRoundingModeRTEFloat16          = " << !!floatControlsProperties.shaderRoundingModeRTEFloat16 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderRoundingModeRTEFloat32          = " << !!floatControlsProperties.shaderRoundingModeRTEFloat32 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderRoundingModeRTEFloat64          = " << !!floatControlsProperties.shaderRoundingModeRTEFloat64 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderRoundingModeRTZFloat16          = " << !!floatControlsProperties.shaderRoundingModeRTZFloat16 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderRoundingModeRTZFloat32          = " << !!floatControlsProperties.shaderRoundingModeRTZFloat32 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderRoundingModeRTZFloat64          = " << !!floatControlsProperties.shaderRoundingModeRTZFloat64 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderSignedZeroInfNanPreserveFloat16 = " << !!floatControlsProperties.shaderSignedZeroInfNanPreserveFloat16
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderSignedZeroInfNanPreserveFloat32 = " << !!floatControlsProperties.shaderSignedZeroInfNanPreserveFloat32
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderSignedZeroInfNanPreserveFloat64 = " << !!floatControlsProperties.shaderSignedZeroInfNanPreserveFloat64
+                  << "\n";
         std::cout << "\n";
       }
 
@@ -649,52 +728,39 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceFragmentDensityMapPropertiesEXT const & fragmentDensityMapProperties =
           properties2.get<vk::PhysicalDeviceFragmentDensityMapPropertiesEXT>();
-        std::cout << "\t"
-                  << "FragmentDensityProperties:\n";
-        std::cout << "\t\t"
-                  << "fragmentDensityInvocations  = " << !!fragmentDensityMapProperties.fragmentDensityInvocations << "\n";
-        std::cout << "\t\t"
-                  << "maxFragmentDensityTexelSize = " << fragmentDensityMapProperties.maxFragmentDensityTexelSize.width << " x "
+        std::cout << std::string( "\t" ) << "FragmentDensityProperties:\n";
+        std::cout << std::string( "\t\t" ) << "fragmentDensityInvocations  = " << !!fragmentDensityMapProperties.fragmentDensityInvocations << "\n";
+        std::cout << std::string( "\t\t" ) << "maxFragmentDensityTexelSize = " << fragmentDensityMapProperties.maxFragmentDensityTexelSize.width << " x "
                   << fragmentDensityMapProperties.maxFragmentDensityTexelSize.height << "\n";
-        std::cout << "\t\t"
-                  << "minFragmentDensityTexelSize = " << fragmentDensityMapProperties.minFragmentDensityTexelSize.width << " x "
+        std::cout << std::string( "\t\t" ) << "minFragmentDensityTexelSize = " << fragmentDensityMapProperties.minFragmentDensityTexelSize.width << " x "
                   << fragmentDensityMapProperties.minFragmentDensityTexelSize.height << "\n";
         std::cout << "\n";
       }
 
       vk::PhysicalDeviceIDProperties const & idProperties = properties2.get<vk::PhysicalDeviceIDProperties>();
-      std::cout << "\t"
-                << "IDProperties:\n";
-      std::cout << "\t\t"
-                << "deviceUUID      = " << vk::su::UUID( idProperties.deviceUUID ) << "\n";
-      std::cout << "\t\t"
-                << "driverUUID      = " << vk::su::UUID( idProperties.driverUUID ) << "\n";
-      std::cout << "\t\t"
-                << "deviceLUID      = " << vk::su::LUID( idProperties.deviceLUID ) << "\n";
-      std::cout << "\t\t"
-                << "deviceNodeMask  = " << std::hex << idProperties.deviceNodeMask << std::dec << "\n";
-      std::cout << "\t\t"
-                << "deviceLUIDValid = " << !!idProperties.deviceLUIDValid << "\n";
+      std::cout << std::string( "\t" ) << "IDProperties:\n";
+      std::cout << std::string( "\t\t" ) << "deviceUUID      = " << vk::su::UUID( idProperties.deviceUUID ) << "\n";
+      std::cout << std::string( "\t\t" ) << "driverUUID      = " << vk::su::UUID( idProperties.driverUUID ) << "\n";
+      std::cout << std::string( "\t\t" ) << "deviceLUID      = " << vk::su::LUID( idProperties.deviceLUID ) << "\n";
+      std::cout << std::string( "\t\t" ) << "deviceNodeMask  = " << std::hex << idProperties.deviceNodeMask << std::dec << "\n";
+      std::cout << std::string( "\t\t" ) << "deviceLUIDValid = " << !!idProperties.deviceLUIDValid << "\n";
       std::cout << "\n";
 
       if ( vk::su::contains( extensionProperties, "VK_EXT_inline_uniform_block" ) )
       {
         vk::PhysicalDeviceInlineUniformBlockPropertiesEXT const & inlineUniformBlockProperties =
           properties2.get<vk::PhysicalDeviceInlineUniformBlockPropertiesEXT>();
-        std::cout << "\t"
-                  << "InlineUniformBlockProperties:\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t" ) << "InlineUniformBlockProperties:\n";
+        std::cout << std::string( "\t\t" )
                   << "maxDescriptorSetInlineUniformBlocks                     = " << inlineUniformBlockProperties.maxDescriptorSetInlineUniformBlocks << "\n";
-        std::cout << "\t\t"
-                  << "maxDescriptorSetUpdateAfterBindInlineUniformBlocks      = "
+        std::cout << std::string( "\t\t" ) << "maxDescriptorSetUpdateAfterBindInlineUniformBlocks      = "
                   << inlineUniformBlockProperties.maxDescriptorSetUpdateAfterBindInlineUniformBlocks << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxInlineUniformBlockSize                               = " << inlineUniformBlockProperties.maxInlineUniformBlockSize << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxPerStageDescriptorInlineUniformBlocks                = " << inlineUniformBlockProperties.maxPerStageDescriptorInlineUniformBlocks
                   << "\n";
-        std::cout << "\t\t"
-                  << "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks = "
+        std::cout << std::string( "\t\t" ) << "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks = "
                   << inlineUniformBlockProperties.maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks << "\n";
         std::cout << "\n";
       }
@@ -703,59 +769,40 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceLineRasterizationPropertiesEXT const & lineRasterizationProperties =
           properties2.get<vk::PhysicalDeviceLineRasterizationPropertiesEXT>();
-        std::cout << "\t"
-                  << "LineRasterizationProperties:\n";
-        std::cout << "\t\t"
-                  << "lineSubPixelPrecisionBits = " << lineRasterizationProperties.lineSubPixelPrecisionBits << "\n";
+        std::cout << std::string( "\t" ) << "LineRasterizationProperties:\n";
+        std::cout << std::string( "\t\t" ) << "lineSubPixelPrecisionBits = " << lineRasterizationProperties.lineSubPixelPrecisionBits << "\n";
         std::cout << "\n";
       }
 
       vk::PhysicalDeviceMaintenance3Properties const & maintenance3Properties = properties2.get<vk::PhysicalDeviceMaintenance3Properties>();
-      std::cout << "\t"
-                << "Maintenance3Properties:\n";
-      std::cout << "\t\t"
-                << "maxMemoryAllocationSize = " << maintenance3Properties.maxMemoryAllocationSize << "\n";
-      std::cout << "\t\t"
-                << "maxPerSetDescriptors    = " << maintenance3Properties.maxPerSetDescriptors << "\n";
+      std::cout << std::string( "\t" ) << "Maintenance3Properties:\n";
+      std::cout << std::string( "\t\t" ) << "maxMemoryAllocationSize = " << maintenance3Properties.maxMemoryAllocationSize << "\n";
+      std::cout << std::string( "\t\t" ) << "maxPerSetDescriptors    = " << maintenance3Properties.maxPerSetDescriptors << "\n";
       std::cout << "\n";
 
       if ( vk::su::contains( extensionProperties, "VK_NV_mesh_shader" ) )
       {
         vk::PhysicalDeviceMeshShaderPropertiesNV const & meshShaderProperties = properties2.get<vk::PhysicalDeviceMeshShaderPropertiesNV>();
-        std::cout << "\t"
-                  << "MeshShaderProperties:\n";
-        std::cout << "\t\t"
-                  << "maxDrawMeshTasksCount             = " << meshShaderProperties.maxDrawMeshTasksCount << "\n";
-        std::cout << "\t\t"
-                  << "maxMeshMultiviewViewCount         = " << meshShaderProperties.maxMeshMultiviewViewCount << "\n";
-        std::cout << "\t\t"
-                  << "maxMeshOutputPrimitives           = " << meshShaderProperties.maxMeshOutputPrimitives << "\n";
-        std::cout << "\t\t"
-                  << "maxMeshOutputVertices             = " << meshShaderProperties.maxMeshOutputVertices << "\n";
-        std::cout << "\t\t"
-                  << "maxMeshTotalMemorySize            = " << meshShaderProperties.maxMeshTotalMemorySize << "\n";
-        std::cout << "\t\t"
-                  << "maxMeshWorkGroupInvocations       = " << meshShaderProperties.maxMeshWorkGroupInvocations << "\n";
-        std::cout << "\t\t"
-                  << "maxMeshWorkGroupSize              = "
+        std::cout << std::string( "\t" ) << "MeshShaderProperties:\n";
+        std::cout << std::string( "\t\t" ) << "maxDrawMeshTasksCount             = " << meshShaderProperties.maxDrawMeshTasksCount << "\n";
+        std::cout << std::string( "\t\t" ) << "maxMeshMultiviewViewCount         = " << meshShaderProperties.maxMeshMultiviewViewCount << "\n";
+        std::cout << std::string( "\t\t" ) << "maxMeshOutputPrimitives           = " << meshShaderProperties.maxMeshOutputPrimitives << "\n";
+        std::cout << std::string( "\t\t" ) << "maxMeshOutputVertices             = " << meshShaderProperties.maxMeshOutputVertices << "\n";
+        std::cout << std::string( "\t\t" ) << "maxMeshTotalMemorySize            = " << meshShaderProperties.maxMeshTotalMemorySize << "\n";
+        std::cout << std::string( "\t\t" ) << "maxMeshWorkGroupInvocations       = " << meshShaderProperties.maxMeshWorkGroupInvocations << "\n";
+        std::cout << std::string( "\t\t" ) << "maxMeshWorkGroupSize              = "
                   << "[" << meshShaderProperties.maxMeshWorkGroupSize[0] << ", " << meshShaderProperties.maxMeshWorkGroupSize[1] << ", "
                   << meshShaderProperties.maxMeshWorkGroupSize[2] << "]"
                   << "\n";
-        std::cout << "\t\t"
-                  << "maxTaskOutputCount                = " << meshShaderProperties.maxTaskOutputCount << "\n";
-        std::cout << "\t\t"
-                  << "maxTaskTotalMemorySize            = " << meshShaderProperties.maxTaskTotalMemorySize << "\n";
-        std::cout << "\t\t"
-                  << "maxTaskWorkGroupInvocations       = " << meshShaderProperties.maxTaskWorkGroupInvocations << "\n";
-        std::cout << "\t\t"
-                  << "maxTaskWorkGroupSize              = "
+        std::cout << std::string( "\t\t" ) << "maxTaskOutputCount                = " << meshShaderProperties.maxTaskOutputCount << "\n";
+        std::cout << std::string( "\t\t" ) << "maxTaskTotalMemorySize            = " << meshShaderProperties.maxTaskTotalMemorySize << "\n";
+        std::cout << std::string( "\t\t" ) << "maxTaskWorkGroupInvocations       = " << meshShaderProperties.maxTaskWorkGroupInvocations << "\n";
+        std::cout << std::string( "\t\t" ) << "maxTaskWorkGroupSize              = "
                   << "[" << meshShaderProperties.maxTaskWorkGroupSize[0] << ", " << meshShaderProperties.maxTaskWorkGroupSize[1] << ", "
                   << meshShaderProperties.maxTaskWorkGroupSize[2] << "]"
                   << "\n";
-        std::cout << "\t\t"
-                  << "meshOutputPerPrimitiveGranularity = " << meshShaderProperties.meshOutputPerPrimitiveGranularity << "\n";
-        std::cout << "\t\t"
-                  << "meshOutputPerVertexGranularity    = " << meshShaderProperties.meshOutputPerVertexGranularity << "\n";
+        std::cout << std::string( "\t\t" ) << "meshOutputPerPrimitiveGranularity = " << meshShaderProperties.meshOutputPerPrimitiveGranularity << "\n";
+        std::cout << std::string( "\t\t" ) << "meshOutputPerVertexGranularity    = " << meshShaderProperties.meshOutputPerVertexGranularity << "\n";
         std::cout << "\n";
       }
 
@@ -763,108 +810,78 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceMultiviewPerViewAttributesPropertiesNVX const & multiviewPerViewAttributesProperties =
           properties2.get<vk::PhysicalDeviceMultiviewPerViewAttributesPropertiesNVX>();
-        std::cout << "\t"
-                  << "MultiviewPerViewAttributesProperties:\n";
-        std::cout << "\t\t"
-                  << "perViewPositionAllComponents  = " << !!multiviewPerViewAttributesProperties.perViewPositionAllComponents << "\n";
+        std::cout << std::string( "\t" ) << "MultiviewPerViewAttributesProperties:\n";
+        std::cout << std::string( "\t\t" ) << "perViewPositionAllComponents  = " << !!multiviewPerViewAttributesProperties.perViewPositionAllComponents << "\n";
         std::cout << "\n";
       }
 
       vk::PhysicalDeviceMultiviewProperties const & multiviewProperties = properties2.get<vk::PhysicalDeviceMultiviewProperties>();
-      std::cout << "\t"
-                << "MultiviewProperties:\n";
-      std::cout << "\t\t"
-                << "maxMultiviewInstanceIndex = " << multiviewProperties.maxMultiviewInstanceIndex << "\n";
-      std::cout << "\t\t"
-                << "maxMultiviewViewCount     = " << multiviewProperties.maxMultiviewViewCount << "\n";
+      std::cout << std::string( "\t" ) << "MultiviewProperties:\n";
+      std::cout << std::string( "\t\t" ) << "maxMultiviewInstanceIndex = " << multiviewProperties.maxMultiviewInstanceIndex << "\n";
+      std::cout << std::string( "\t\t" ) << "maxMultiviewViewCount     = " << multiviewProperties.maxMultiviewViewCount << "\n";
       std::cout << "\n";
 
       if ( vk::su::contains( extensionProperties, "VK_EXT_pci_bus_info" ) )
       {
         vk::PhysicalDevicePCIBusInfoPropertiesEXT const & pciBusInfoProperties = properties2.get<vk::PhysicalDevicePCIBusInfoPropertiesEXT>();
-        std::cout << "\t"
-                  << "PCIBusInfoProperties:\n";
-        std::cout << "\t\t"
-                  << "pciDomain   = " << pciBusInfoProperties.pciDomain << "\n";
-        std::cout << "\t\t"
-                  << "pciBus      = " << pciBusInfoProperties.pciBus << "\n";
-        std::cout << "\t\t"
-                  << "pciDevice   = " << pciBusInfoProperties.pciDevice << "\n";
-        std::cout << "\t\t"
-                  << "pciFunction = " << pciBusInfoProperties.pciFunction << "\n";
+        std::cout << std::string( "\t" ) << "PCIBusInfoProperties:\n";
+        std::cout << std::string( "\t\t" ) << "pciDomain   = " << pciBusInfoProperties.pciDomain << "\n";
+        std::cout << std::string( "\t\t" ) << "pciBus      = " << pciBusInfoProperties.pciBus << "\n";
+        std::cout << std::string( "\t\t" ) << "pciDevice   = " << pciBusInfoProperties.pciDevice << "\n";
+        std::cout << std::string( "\t\t" ) << "pciFunction = " << pciBusInfoProperties.pciFunction << "\n";
         std::cout << "\n";
       }
 
       if ( vk::su::contains( extensionProperties, "VK_KHR_maintenance2" ) )
       {
         vk::PhysicalDevicePointClippingProperties const & pointClippingProperties = properties2.get<vk::PhysicalDevicePointClippingProperties>();
-        std::cout << "\t"
-                  << "PointClippingProperties:\n";
-        std::cout << "\t\t"
-                  << "pointClippingBehavior = " << vk::to_string( pointClippingProperties.pointClippingBehavior ) << "\n";
+        std::cout << std::string( "\t" ) << "PointClippingProperties:\n";
+        std::cout << std::string( "\t\t" ) << "pointClippingBehavior = " << to_string( pointClippingProperties.pointClippingBehavior ) << "\n";
         std::cout << "\n";
       }
 
       vk::PhysicalDeviceProtectedMemoryProperties const & protectedMemoryProperties = properties2.get<vk::PhysicalDeviceProtectedMemoryProperties>();
-      std::cout << "\t"
-                << "ProtectedMemoryProperties:\n";
-      std::cout << "\t\t"
-                << "protectedNoFault  = " << !!protectedMemoryProperties.protectedNoFault << "\n";
+      std::cout << std::string( "\t" ) << "ProtectedMemoryProperties:\n";
+      std::cout << std::string( "\t\t" ) << "protectedNoFault  = " << !!protectedMemoryProperties.protectedNoFault << "\n";
       std::cout << "\n";
 
       if ( vk::su::contains( extensionProperties, "VK_KHR_push_descriptor" ) )
       {
         vk::PhysicalDevicePushDescriptorPropertiesKHR const & pushDescriptorProperties = properties2.get<vk::PhysicalDevicePushDescriptorPropertiesKHR>();
-        std::cout << "\t"
-                  << "PushDescriptorProperties:\n";
-        std::cout << "\t\t"
-                  << "maxPushDescriptors  = " << pushDescriptorProperties.maxPushDescriptors << "\n";
+        std::cout << std::string( "\t" ) << "PushDescriptorProperties:\n";
+        std::cout << std::string( "\t\t" ) << "maxPushDescriptors  = " << pushDescriptorProperties.maxPushDescriptors << "\n";
         std::cout << "\n";
       }
 
       if ( vk::su::contains( extensionProperties, "VK_NV_ray_tracing" ) )
       {
         vk::PhysicalDeviceRayTracingPropertiesNV const & rayTracingProperties = properties2.get<vk::PhysicalDeviceRayTracingPropertiesNV>();
-        std::cout << "\t"
-                  << "RayTracingProperties:\n";
-        std::cout << "\t\t"
-                  << "maxDescriptorSetAccelerationStructures  = " << rayTracingProperties.maxDescriptorSetAccelerationStructures << "\n";
-        std::cout << "\t\t"
-                  << "maxGeometryCount                        = " << rayTracingProperties.maxGeometryCount << "\n";
-        std::cout << "\t\t"
-                  << "maxInstanceCount                        = " << rayTracingProperties.maxInstanceCount << "\n";
-        std::cout << "\t\t"
-                  << "maxRecursionDepth                       = " << rayTracingProperties.maxRecursionDepth << "\n";
-        std::cout << "\t\t"
-                  << "maxShaderGroupStride                    = " << rayTracingProperties.maxShaderGroupStride << "\n";
-        std::cout << "\t\t"
-                  << "maxTriangleCount                        = " << rayTracingProperties.maxTriangleCount << "\n";
-        std::cout << "\t\t"
-                  << "shaderGroupBaseAlignment                = " << rayTracingProperties.shaderGroupBaseAlignment << "\n";
-        std::cout << "\t\t"
-                  << "shaderGroupHandleSize                   = " << rayTracingProperties.shaderGroupHandleSize << "\n";
+        std::cout << std::string( "\t" ) << "RayTracingProperties:\n";
+        std::cout << std::string( "\t\t" ) << "maxDescriptorSetAccelerationStructures  = " << rayTracingProperties.maxDescriptorSetAccelerationStructures
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "maxGeometryCount                        = " << rayTracingProperties.maxGeometryCount << "\n";
+        std::cout << std::string( "\t\t" ) << "maxInstanceCount                        = " << rayTracingProperties.maxInstanceCount << "\n";
+        std::cout << std::string( "\t\t" ) << "maxRecursionDepth                       = " << rayTracingProperties.maxRecursionDepth << "\n";
+        std::cout << std::string( "\t\t" ) << "maxShaderGroupStride                    = " << rayTracingProperties.maxShaderGroupStride << "\n";
+        std::cout << std::string( "\t\t" ) << "maxTriangleCount                        = " << rayTracingProperties.maxTriangleCount << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderGroupBaseAlignment                = " << rayTracingProperties.shaderGroupBaseAlignment << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderGroupHandleSize                   = " << rayTracingProperties.shaderGroupHandleSize << "\n";
         std::cout << "\n";
       }
 
       if ( vk::su::contains( extensionProperties, "VK_EXT_sample_locations" ) )
       {
         vk::PhysicalDeviceSampleLocationsPropertiesEXT const & sampleLocationProperties = properties2.get<vk::PhysicalDeviceSampleLocationsPropertiesEXT>();
-        std::cout << "\t"
-                  << "SampleLocationProperties:\n";
-        std::cout << "\t\t"
-                  << "maxSampleLocationGridSize     = " << sampleLocationProperties.maxSampleLocationGridSize.width << " x "
+        std::cout << std::string( "\t" ) << "SampleLocationProperties:\n";
+        std::cout << std::string( "\t\t" ) << "maxSampleLocationGridSize     = " << sampleLocationProperties.maxSampleLocationGridSize.width << " x "
                   << sampleLocationProperties.maxSampleLocationGridSize.height << "\n";
-        std::cout << "\t\t"
-                  << "sampleLocationCoordinateRange = "
+        std::cout << std::string( "\t\t" ) << "sampleLocationCoordinateRange = "
                   << "[" << sampleLocationProperties.sampleLocationCoordinateRange[0] << ", " << sampleLocationProperties.sampleLocationCoordinateRange[1]
                   << "]"
                   << "\n";
-        std::cout << "\t\t"
-                  << "sampleLocationSampleCounts    = " << vk::to_string( sampleLocationProperties.sampleLocationSampleCounts ) << "\n";
-        std::cout << "\t\t"
-                  << "sampleLocationSubPixelBits    = " << sampleLocationProperties.sampleLocationSubPixelBits << "\n";
-        std::cout << "\t\t"
-                  << "variableSampleLocations       = " << !!sampleLocationProperties.variableSampleLocations << "\n";
+        std::cout << std::string( "\t\t" ) << "sampleLocationSampleCounts    = " << to_string( sampleLocationProperties.sampleLocationSampleCounts ) << "\n";
+        std::cout << std::string( "\t\t" ) << "sampleLocationSubPixelBits    = " << sampleLocationProperties.sampleLocationSubPixelBits << "\n";
+        std::cout << std::string( "\t\t" ) << "variableSampleLocations       = " << !!sampleLocationProperties.variableSampleLocations << "\n";
         std::cout << "\n";
       }
 
@@ -872,118 +889,83 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceSamplerFilterMinmaxPropertiesEXT const & samplerFilterMinmaxProperties =
           properties2.get<vk::PhysicalDeviceSamplerFilterMinmaxPropertiesEXT>();
-        std::cout << "\t"
-                  << "SamplerFilterMinmaxProperties:\n";
-        std::cout << "\t\t"
-                  << "filterMinmaxImageComponentMapping   = " << !!samplerFilterMinmaxProperties.filterMinmaxImageComponentMapping << "\n";
-        std::cout << "\t\t"
-                  << "filterMinmaxSingleComponentFormats  = " << !!samplerFilterMinmaxProperties.filterMinmaxSingleComponentFormats << "\n";
+        std::cout << std::string( "\t" ) << "SamplerFilterMinmaxProperties:\n";
+        std::cout << std::string( "\t\t" ) << "filterMinmaxImageComponentMapping   = " << !!samplerFilterMinmaxProperties.filterMinmaxImageComponentMapping
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "filterMinmaxSingleComponentFormats  = " << !!samplerFilterMinmaxProperties.filterMinmaxSingleComponentFormats
+                  << "\n";
         std::cout << "\n";
       }
 
       if ( vk::su::contains( extensionProperties, "VK_AMD_shader_core_properties2" ) )
       {
         vk::PhysicalDeviceShaderCoreProperties2AMD const & shaderCoreProperties2 = properties2.get<vk::PhysicalDeviceShaderCoreProperties2AMD>();
-        std::cout << "\t"
-                  << "ShaderCoreProperties2:\n";
-        std::cout << "\t\t"
-                  << "activeComputeUnitCount  = " << shaderCoreProperties2.activeComputeUnitCount << "\n";
-        std::cout << "\t\t"
-                  << "shaderCoreFeatures      = " << vk::to_string( shaderCoreProperties2.shaderCoreFeatures ) << "\n";
+        std::cout << std::string( "\t" ) << "ShaderCoreProperties2:\n";
+        std::cout << std::string( "\t\t" ) << "activeComputeUnitCount  = " << shaderCoreProperties2.activeComputeUnitCount << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderCoreFeatures      = " << to_string( shaderCoreProperties2.shaderCoreFeatures ) << "\n";
         std::cout << "\n";
       }
 
       if ( vk::su::contains( extensionProperties, "VK_AMD_shader_core_properties2" ) )
       {
         vk::PhysicalDeviceShaderCorePropertiesAMD const & shaderCoreProperties = properties2.get<vk::PhysicalDeviceShaderCorePropertiesAMD>();
-        std::cout << "\t"
-                  << "ShaderCoreProperties:\n";
-        std::cout << "\t\t"
-                  << "computeUnitsPerShaderArray  = " << shaderCoreProperties.computeUnitsPerShaderArray << "\n";
-        std::cout << "\t\t"
-                  << "maxSgprAllocation           = " << shaderCoreProperties.maxSgprAllocation << "\n";
-        std::cout << "\t\t"
-                  << "maxVgprAllocation           = " << shaderCoreProperties.maxVgprAllocation << "\n";
-        std::cout << "\t\t"
-                  << "minSgprAllocation           = " << shaderCoreProperties.minSgprAllocation << "\n";
-        std::cout << "\t\t"
-                  << "minVgprAllocation           = " << shaderCoreProperties.minVgprAllocation << "\n";
-        std::cout << "\t\t"
-                  << "sgprAllocationGranularity   = " << shaderCoreProperties.sgprAllocationGranularity << "\n";
-        std::cout << "\t\t"
-                  << "sgprsPerSimd                = " << shaderCoreProperties.sgprsPerSimd << "\n";
-        std::cout << "\t\t"
-                  << "shaderArraysPerEngineCount  = " << shaderCoreProperties.shaderArraysPerEngineCount << "\n";
-        std::cout << "\t\t"
-                  << "shaderEngineCount           = " << shaderCoreProperties.shaderEngineCount << "\n";
-        std::cout << "\t\t"
-                  << "simdPerComputeUnit          = " << shaderCoreProperties.simdPerComputeUnit << "\n";
-        std::cout << "\t\t"
-                  << "vgprAllocationGranularity   = " << shaderCoreProperties.vgprAllocationGranularity << "\n";
-        std::cout << "\t\t"
-                  << "vgprsPerSimd                = " << shaderCoreProperties.vgprsPerSimd << "\n";
-        std::cout << "\t\t"
-                  << "wavefrontSize               = " << shaderCoreProperties.wavefrontSize << "\n";
-        std::cout << "\t\t"
-                  << "wavefrontsPerSimd           = " << shaderCoreProperties.wavefrontsPerSimd << "\n";
+        std::cout << std::string( "\t" ) << "ShaderCoreProperties:\n";
+        std::cout << std::string( "\t\t" ) << "computeUnitsPerShaderArray  = " << shaderCoreProperties.computeUnitsPerShaderArray << "\n";
+        std::cout << std::string( "\t\t" ) << "maxSgprAllocation           = " << shaderCoreProperties.maxSgprAllocation << "\n";
+        std::cout << std::string( "\t\t" ) << "maxVgprAllocation           = " << shaderCoreProperties.maxVgprAllocation << "\n";
+        std::cout << std::string( "\t\t" ) << "minSgprAllocation           = " << shaderCoreProperties.minSgprAllocation << "\n";
+        std::cout << std::string( "\t\t" ) << "minVgprAllocation           = " << shaderCoreProperties.minVgprAllocation << "\n";
+        std::cout << std::string( "\t\t" ) << "sgprAllocationGranularity   = " << shaderCoreProperties.sgprAllocationGranularity << "\n";
+        std::cout << std::string( "\t\t" ) << "sgprsPerSimd                = " << shaderCoreProperties.sgprsPerSimd << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderArraysPerEngineCount  = " << shaderCoreProperties.shaderArraysPerEngineCount << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderEngineCount           = " << shaderCoreProperties.shaderEngineCount << "\n";
+        std::cout << std::string( "\t\t" ) << "simdPerComputeUnit          = " << shaderCoreProperties.simdPerComputeUnit << "\n";
+        std::cout << std::string( "\t\t" ) << "vgprAllocationGranularity   = " << shaderCoreProperties.vgprAllocationGranularity << "\n";
+        std::cout << std::string( "\t\t" ) << "vgprsPerSimd                = " << shaderCoreProperties.vgprsPerSimd << "\n";
+        std::cout << std::string( "\t\t" ) << "wavefrontSize               = " << shaderCoreProperties.wavefrontSize << "\n";
+        std::cout << std::string( "\t\t" ) << "wavefrontsPerSimd           = " << shaderCoreProperties.wavefrontsPerSimd << "\n";
         std::cout << "\n";
       }
 
       if ( vk::su::contains( extensionProperties, "VK_NV_shader_sm_builtins" ) )
       {
         vk::PhysicalDeviceShaderSMBuiltinsPropertiesNV const & shaderSMBuiltinsProperties = properties2.get<vk::PhysicalDeviceShaderSMBuiltinsPropertiesNV>();
-        std::cout << "\t"
-                  << "ShaderSMBuiltinsProperties:\n";
-        std::cout << "\t\t"
-                  << "shaderSMCount     = " << shaderSMBuiltinsProperties.shaderSMCount << "\n";
-        std::cout << "\t\t"
-                  << "shaderWarpsPerSM  = " << shaderSMBuiltinsProperties.shaderWarpsPerSM << "\n";
+        std::cout << std::string( "\t" ) << "ShaderSMBuiltinsProperties:\n";
+        std::cout << std::string( "\t\t" ) << "shaderSMCount     = " << shaderSMBuiltinsProperties.shaderSMCount << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderWarpsPerSM  = " << shaderSMBuiltinsProperties.shaderWarpsPerSM << "\n";
         std::cout << "\n";
       }
 
       if ( vk::su::contains( extensionProperties, "VK_NV_shading_rate_image" ) )
       {
         vk::PhysicalDeviceShadingRateImagePropertiesNV const & shadingRageImageProperties = properties2.get<vk::PhysicalDeviceShadingRateImagePropertiesNV>();
-        std::cout << "\t"
-                  << "ShadingRateImageProperties:\n";
-        std::cout << "\t\t"
-                  << "shadingRateMaxCoarseSamples = " << shadingRageImageProperties.shadingRateMaxCoarseSamples << "\n";
-        std::cout << "\t\t"
-                  << "shadingRatePaletteSize      = " << shadingRageImageProperties.shadingRatePaletteSize << "\n";
-        std::cout << "\t\t"
-                  << "shadingRatePaletteSize      = "
+        std::cout << std::string( "\t" ) << "ShadingRateImageProperties:\n";
+        std::cout << std::string( "\t\t" ) << "shadingRateMaxCoarseSamples = " << shadingRageImageProperties.shadingRateMaxCoarseSamples << "\n";
+        std::cout << std::string( "\t\t" ) << "shadingRatePaletteSize      = " << shadingRageImageProperties.shadingRatePaletteSize << "\n";
+        std::cout << std::string( "\t\t" ) << "shadingRatePaletteSize      = "
                   << "[" << shadingRageImageProperties.shadingRateTexelSize.width << " x " << shadingRageImageProperties.shadingRateTexelSize.height << "]"
                   << "\n";
         std::cout << "\n";
       }
 
       vk::PhysicalDeviceSubgroupProperties const & subgroupProperties = properties2.get<vk::PhysicalDeviceSubgroupProperties>();
-      std::cout << "\t"
-                << "SubgroupProperties:\n";
-      std::cout << "\t\t"
-                << "quadOperationsInAllStages = " << !!subgroupProperties.quadOperationsInAllStages << "\n";
-      std::cout << "\t\t"
-                << "subgroupSize              = " << subgroupProperties.subgroupSize << "\n";
-      std::cout << "\t\t"
-                << "supportedOperations       = " << vk::to_string( subgroupProperties.supportedOperations ) << "\n";
-      std::cout << "\t\t"
-                << "supportedStages           = " << vk::to_string( subgroupProperties.supportedStages ) << "\n";
+      std::cout << std::string( "\t" ) << "SubgroupProperties:\n";
+      std::cout << std::string( "\t\t" ) << "quadOperationsInAllStages = " << !!subgroupProperties.quadOperationsInAllStages << "\n";
+      std::cout << std::string( "\t\t" ) << "subgroupSize              = " << subgroupProperties.subgroupSize << "\n";
+      std::cout << std::string( "\t\t" ) << "supportedOperations       = " << to_string( subgroupProperties.supportedOperations ) << "\n";
+      std::cout << std::string( "\t\t" ) << "supportedStages           = " << to_string( subgroupProperties.supportedStages ) << "\n";
       std::cout << "\n";
 
       if ( vk::su::contains( extensionProperties, "VK_EXT_subgroup_size_control" ) )
       {
         vk::PhysicalDeviceSubgroupSizeControlPropertiesEXT const & subgroupSizeControlProperties =
           properties2.get<vk::PhysicalDeviceSubgroupSizeControlPropertiesEXT>();
-        std::cout << "\t"
-                  << "SubgroupSizeControlProperties:\n";
-        std::cout << "\t\t"
-                  << "maxComputeWorkgroupSubgroups  = " << subgroupSizeControlProperties.maxComputeWorkgroupSubgroups << "\n";
-        std::cout << "\t\t"
-                  << "maxSubgroupSize               = " << subgroupSizeControlProperties.maxSubgroupSize << "\n";
-        std::cout << "\t\t"
-                  << "minSubgroupSize               = " << subgroupSizeControlProperties.minSubgroupSize << "\n";
-        std::cout << "\t\t"
-                  << "requiredSubgroupSizeStages    = " << vk::to_string( subgroupSizeControlProperties.requiredSubgroupSizeStages ) << "\n";
+        std::cout << std::string( "\t" ) << "SubgroupSizeControlProperties:\n";
+        std::cout << std::string( "\t\t" ) << "maxComputeWorkgroupSubgroups  = " << subgroupSizeControlProperties.maxComputeWorkgroupSubgroups << "\n";
+        std::cout << std::string( "\t\t" ) << "maxSubgroupSize               = " << subgroupSizeControlProperties.maxSubgroupSize << "\n";
+        std::cout << std::string( "\t\t" ) << "minSubgroupSize               = " << subgroupSizeControlProperties.minSubgroupSize << "\n";
+        std::cout << std::string( "\t\t" ) << "requiredSubgroupSizeStages    = " << to_string( subgroupSizeControlProperties.requiredSubgroupSizeStages )
+                  << "\n";
         std::cout << "\n";
       }
 
@@ -991,10 +973,9 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceTimelineSemaphorePropertiesKHR const & timelineSemaphoreProperties =
           properties2.get<vk::PhysicalDeviceTimelineSemaphorePropertiesKHR>();
-        std::cout << "\t"
-                  << "TimelineSemaphoreProperties:\n";
-        std::cout << "\t\t"
-                  << "maxTimelineSemaphoreValueDifference = " << timelineSemaphoreProperties.maxTimelineSemaphoreValueDifference << "\n";
+        std::cout << std::string( "\t" ) << "TimelineSemaphoreProperties:\n";
+        std::cout << std::string( "\t\t" ) << "maxTimelineSemaphoreValueDifference = " << timelineSemaphoreProperties.maxTimelineSemaphoreValueDifference
+                  << "\n";
         std::cout << "\n";
       }
 
@@ -1002,16 +983,15 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceTexelBufferAlignmentPropertiesEXT const & texelBufferAlignmentProperties =
           properties2.get<vk::PhysicalDeviceTexelBufferAlignmentPropertiesEXT>();
-        std::cout << "\t"
-                  << "TexelBufferAlignmentProperties:\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t" ) << "TexelBufferAlignmentProperties:\n";
+        std::cout << std::string( "\t\t" )
                   << "storageTexelBufferOffsetAlignmentBytes        = " << texelBufferAlignmentProperties.storageTexelBufferOffsetAlignmentBytes << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "storageTexelBufferOffsetSingleTexelAlignment  = " << !!texelBufferAlignmentProperties.storageTexelBufferOffsetSingleTexelAlignment
                   << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "uniformTexelBufferOffsetAlignmentBytes        = " << texelBufferAlignmentProperties.uniformTexelBufferOffsetAlignmentBytes << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "uniformTexelBufferOffsetSingleTexelAlignment  = " << !!texelBufferAlignmentProperties.uniformTexelBufferOffsetSingleTexelAlignment
                   << "\n";
         std::cout << "\n";
@@ -1021,27 +1001,25 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceTransformFeedbackPropertiesEXT const & transformFeedbackProperties =
           properties2.get<vk::PhysicalDeviceTransformFeedbackPropertiesEXT>();
-        std::cout << "\t"
-                  << "TransformFeedbackProperties:\n";
-        std::cout << "\t\t"
-                  << "maxTransformFeedbackBufferDataSize          = " << transformFeedbackProperties.maxTransformFeedbackBufferDataSize << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t" ) << "TransformFeedbackProperties:\n";
+        std::cout << std::string( "\t\t" ) << "maxTransformFeedbackBufferDataSize          = " << transformFeedbackProperties.maxTransformFeedbackBufferDataSize
+                  << "\n";
+        std::cout << std::string( "\t\t" )
                   << "maxTransformFeedbackBufferDataStride        = " << transformFeedbackProperties.maxTransformFeedbackBufferDataStride << "\n";
-        std::cout << "\t\t"
-                  << "maxTransformFeedbackBuffers                 = " << transformFeedbackProperties.maxTransformFeedbackBuffers << "\n";
-        std::cout << "\t\t"
-                  << "maxTransformFeedbackBufferSize              = " << transformFeedbackProperties.maxTransformFeedbackBufferSize << "\n";
-        std::cout << "\t\t"
-                  << "maxTransformFeedbackStreamDataSize          = " << transformFeedbackProperties.maxTransformFeedbackStreamDataSize << "\n";
-        std::cout << "\t\t"
-                  << "maxTransformFeedbackStreams                 = " << transformFeedbackProperties.maxTransformFeedbackStreams << "\n";
-        std::cout << "\t\t"
-                  << "transformFeedbackDraw                       = " << !!transformFeedbackProperties.transformFeedbackDraw << "\n";
-        std::cout << "\t\t"
-                  << "transformFeedbackQueries                    = " << !!transformFeedbackProperties.transformFeedbackQueries << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" ) << "maxTransformFeedbackBuffers                 = " << transformFeedbackProperties.maxTransformFeedbackBuffers
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "maxTransformFeedbackBufferSize              = " << transformFeedbackProperties.maxTransformFeedbackBufferSize
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "maxTransformFeedbackStreamDataSize          = " << transformFeedbackProperties.maxTransformFeedbackStreamDataSize
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "maxTransformFeedbackStreams                 = " << transformFeedbackProperties.maxTransformFeedbackStreams
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "transformFeedbackDraw                       = " << !!transformFeedbackProperties.transformFeedbackDraw << "\n";
+        std::cout << std::string( "\t\t" ) << "transformFeedbackQueries                    = " << !!transformFeedbackProperties.transformFeedbackQueries
+                  << "\n";
+        std::cout << std::string( "\t\t" )
                   << "transformFeedbackRasterizationStreamSelect  = " << !!transformFeedbackProperties.transformFeedbackRasterizationStreamSelect << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "transformFeedbackStreamsLinesTriangles      = " << !!transformFeedbackProperties.transformFeedbackStreamsLinesTriangles << "\n";
         std::cout << "\n";
       }
@@ -1050,10 +1028,8 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceVertexAttributeDivisorPropertiesEXT const & vertexAttributeDivisorProperties =
           properties2.get<vk::PhysicalDeviceVertexAttributeDivisorPropertiesEXT>();
-        std::cout << "\t"
-                  << "VertexAttributeDivisorProperties:\n";
-        std::cout << "\t\t"
-                  << "maxVertexAttribDivisor  = " << vertexAttributeDivisorProperties.maxVertexAttribDivisor << "\n";
+        std::cout << std::string( "\t" ) << "VertexAttributeDivisorProperties:\n";
+        std::cout << std::string( "\t\t" ) << "maxVertexAttribDivisor  = " << vertexAttributeDivisorProperties.maxVertexAttribDivisor << "\n";
         std::cout << "\n";
       }
     }

--- a/RAII_Samples/PhysicalDeviceQueueFamilyProperties/PhysicalDeviceQueueFamilyProperties.cpp
+++ b/RAII_Samples/PhysicalDeviceQueueFamilyProperties/PhysicalDeviceQueueFamilyProperties.cpp
@@ -25,6 +25,102 @@
 static char const * AppName    = "PhysicalDeviceQueueFamilyProperties";
 static char const * EngineName = "Vulkan.hpp";
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::PipelineStageFlags value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::PipelineStageFlagBits::eTopOfPipe )
+      result += "TopOfPipe | ";
+    if ( value & vk::PipelineStageFlagBits::eDrawIndirect )
+      result += "DrawIndirect | ";
+    if ( value & vk::PipelineStageFlagBits::eVertexInput )
+      result += "VertexInput | ";
+    if ( value & vk::PipelineStageFlagBits::eVertexShader )
+      result += "VertexShader | ";
+    if ( value & vk::PipelineStageFlagBits::eTessellationControlShader )
+      result += "TessellationControlShader | ";
+    if ( value & vk::PipelineStageFlagBits::eTessellationEvaluationShader )
+      result += "TessellationEvaluationShader | ";
+    if ( value & vk::PipelineStageFlagBits::eGeometryShader )
+      result += "GeometryShader | ";
+    if ( value & vk::PipelineStageFlagBits::eFragmentShader )
+      result += "FragmentShader | ";
+    if ( value & vk::PipelineStageFlagBits::eEarlyFragmentTests )
+      result += "EarlyFragmentTests | ";
+    if ( value & vk::PipelineStageFlagBits::eLateFragmentTests )
+      result += "LateFragmentTests | ";
+    if ( value & vk::PipelineStageFlagBits::eColorAttachmentOutput )
+      result += "ColorAttachmentOutput | ";
+    if ( value & vk::PipelineStageFlagBits::eComputeShader )
+      result += "ComputeShader | ";
+    if ( value & vk::PipelineStageFlagBits::eTransfer )
+      result += "Transfer | ";
+    if ( value & vk::PipelineStageFlagBits::eBottomOfPipe )
+      result += "BottomOfPipe | ";
+    if ( value & vk::PipelineStageFlagBits::eHost )
+      result += "Host | ";
+    if ( value & vk::PipelineStageFlagBits::eAllGraphics )
+      result += "AllGraphics | ";
+    if ( value & vk::PipelineStageFlagBits::eAllCommands )
+      result += "AllCommands | ";
+    if ( value & vk::PipelineStageFlagBits::eTransformFeedbackEXT )
+      result += "TransformFeedbackEXT | ";
+    if ( value & vk::PipelineStageFlagBits::eConditionalRenderingEXT )
+      result += "ConditionalRenderingEXT | ";
+    if ( value & vk::PipelineStageFlagBits::eAccelerationStructureBuildKHR )
+      result += "AccelerationStructureBuildKHR | ";
+    if ( value & vk::PipelineStageFlagBits::eRayTracingShaderKHR )
+      result += "RayTracingShaderKHR | ";
+    if ( value & vk::PipelineStageFlagBits::eTaskShaderNV )
+      result += "TaskShaderNV | ";
+    if ( value & vk::PipelineStageFlagBits::eMeshShaderNV )
+      result += "MeshShaderNV | ";
+    if ( value & vk::PipelineStageFlagBits::eFragmentDensityProcessEXT )
+      result += "FragmentDensityProcessEXT | ";
+    if ( value & vk::PipelineStageFlagBits::eFragmentShadingRateAttachmentKHR )
+      result += "FragmentShadingRateAttachmentKHR | ";
+    if ( value & vk::PipelineStageFlagBits::eCommandPreprocessNV )
+      result += "CommandPreprocessNV | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::QueueFlags value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::QueueFlagBits::eGraphics )
+      result += "Graphics | ";
+    if ( value & vk::QueueFlagBits::eCompute )
+      result += "Compute | ";
+    if ( value & vk::QueueFlagBits::eTransfer )
+      result += "Transfer | ";
+    if ( value & vk::QueueFlagBits::eSparseBinding )
+      result += "SparseBinding | ";
+    if ( value & vk::QueueFlagBits::eProtected )
+      result += "Protected | ";
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
+    if ( value & vk::QueueFlagBits::eVideoDecodeKHR )
+      result += "VideoDecodeKHR | ";
+    if ( value & vk::QueueFlagBits::eVideoEncodeKHR )
+      result += "VideoEncodeKHR | ";
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
 int main( int /*argc*/, char ** /*argv*/ )
 {
   try
@@ -53,21 +149,22 @@ int main( int /*argc*/, char ** /*argv*/ )
       auto queueFamilyProperties2 = physicalDevices[i].getQueueFamilyProperties2<Chain>();
       for ( size_t j = 0; j < queueFamilyProperties2.size(); j++ )
       {
-        std::cout << "\tQueueFamily " << j << " :" << std::endl;
+        std::cout << std::string( "\t" ) << "QueueFamily " << j << " :" << std::endl;
         vk::QueueFamilyProperties const & properties = queueFamilyProperties2[j].get<vk::QueueFamilyProperties2>().queueFamilyProperties;
-        std::cout << "\t\tQueueFamilyProperties:" << std::endl;
-        std::cout << "\t\t\tqueueFlags                  = " << vk::to_string( properties.queueFlags ) << std::endl;
-        std::cout << "\t\t\tqueueCount                  = " << properties.queueCount << std::endl;
-        std::cout << "\t\t\ttimestampValidBits          = " << properties.timestampValidBits << std::endl;
-        std::cout << "\t\t\tminImageTransferGranularity = " << properties.minImageTransferGranularity.width << " x "
+        std::cout << std::string( "\t\t" ) << "QueueFamilyProperties:" << std::endl;
+        std::cout << std::string( "\t\t\t" ) << "queueFlags                  = " << to_string( properties.queueFlags ) << std::endl;
+        std::cout << std::string( "\t\t\t" ) << "queueCount                  = " << properties.queueCount << std::endl;
+        std::cout << std::string( "\t\t\t" ) << "timestampValidBits          = " << properties.timestampValidBits << std::endl;
+        std::cout << std::string( "\t\t\t" ) << "minImageTransferGranularity = " << properties.minImageTransferGranularity.width << " x "
                   << properties.minImageTransferGranularity.height << " x " << properties.minImageTransferGranularity.depth << std::endl;
         std::cout << std::endl;
 
         if ( vk::su::contains( extensionProperties, "VK_NV_device_diagnostic_checkpoints" ) )
         {
           vk::QueueFamilyCheckpointPropertiesNV const & checkpointProperties = queueFamilyProperties2[j].get<vk::QueueFamilyCheckpointPropertiesNV>();
-          std::cout << "\t\tCheckPointPropertiesNV:" << std::endl;
-          std::cout << "\t\t\tcheckpointExecutionStageMask  = " << vk::to_string( checkpointProperties.checkpointExecutionStageMask ) << std::endl;
+          std::cout << std::string( "\t\t" ) << "CheckPointPropertiesNV:" << std::endl;
+          std::cout << std::string( "\t\t\t" ) << "checkpointExecutionStageMask  = " << to_string( checkpointProperties.checkpointExecutionStageMask )
+                    << std::endl;
           std::cout << std::endl;
         }
       }

--- a/RAII_Samples/RayTracing/RayTracing.cpp
+++ b/RAII_Samples/RayTracing/RayTracing.cpp
@@ -54,6 +54,71 @@
 static char const * AppName    = "RayTracing";
 static char const * EngineName = "Vulkan.hpp";
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::Result value )
+  {
+    switch ( value )
+    {
+      case vk::Result::eSuccess: return "Success";
+      case vk::Result::eNotReady: return "NotReady";
+      case vk::Result::eTimeout: return "Timeout";
+      case vk::Result::eEventSet: return "EventSet";
+      case vk::Result::eEventReset: return "EventReset";
+      case vk::Result::eIncomplete: return "Incomplete";
+      case vk::Result::eErrorOutOfHostMemory: return "ErrorOutOfHostMemory";
+      case vk::Result::eErrorOutOfDeviceMemory: return "ErrorOutOfDeviceMemory";
+      case vk::Result::eErrorInitializationFailed: return "ErrorInitializationFailed";
+      case vk::Result::eErrorDeviceLost: return "ErrorDeviceLost";
+      case vk::Result::eErrorMemoryMapFailed: return "ErrorMemoryMapFailed";
+      case vk::Result::eErrorLayerNotPresent: return "ErrorLayerNotPresent";
+      case vk::Result::eErrorExtensionNotPresent: return "ErrorExtensionNotPresent";
+      case vk::Result::eErrorFeatureNotPresent: return "ErrorFeatureNotPresent";
+      case vk::Result::eErrorIncompatibleDriver: return "ErrorIncompatibleDriver";
+      case vk::Result::eErrorTooManyObjects: return "ErrorTooManyObjects";
+      case vk::Result::eErrorFormatNotSupported: return "ErrorFormatNotSupported";
+      case vk::Result::eErrorFragmentedPool: return "ErrorFragmentedPool";
+      case vk::Result::eErrorUnknown: return "ErrorUnknown";
+      case vk::Result::eErrorOutOfPoolMemory: return "ErrorOutOfPoolMemory";
+      case vk::Result::eErrorInvalidExternalHandle: return "ErrorInvalidExternalHandle";
+      case vk::Result::eErrorFragmentation: return "ErrorFragmentation";
+      case vk::Result::eErrorInvalidOpaqueCaptureAddress: return "ErrorInvalidOpaqueCaptureAddress";
+      case vk::Result::ePipelineCompileRequired: return "PipelineCompileRequired";
+      case vk::Result::eErrorSurfaceLostKHR: return "ErrorSurfaceLostKHR";
+      case vk::Result::eErrorNativeWindowInUseKHR: return "ErrorNativeWindowInUseKHR";
+      case vk::Result::eSuboptimalKHR: return "SuboptimalKHR";
+      case vk::Result::eErrorOutOfDateKHR: return "ErrorOutOfDateKHR";
+      case vk::Result::eErrorIncompatibleDisplayKHR: return "ErrorIncompatibleDisplayKHR";
+      case vk::Result::eErrorValidationFailedEXT: return "ErrorValidationFailedEXT";
+      case vk::Result::eErrorInvalidShaderNV: return "ErrorInvalidShaderNV";
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
+      case vk::Result::eErrorImageUsageNotSupportedKHR: return "ErrorImageUsageNotSupportedKHR";
+      case vk::Result::eErrorVideoPictureLayoutNotSupportedKHR: return "ErrorVideoPictureLayoutNotSupportedKHR";
+      case vk::Result::eErrorVideoProfileOperationNotSupportedKHR: return "ErrorVideoProfileOperationNotSupportedKHR";
+      case vk::Result::eErrorVideoProfileFormatNotSupportedKHR: return "ErrorVideoProfileFormatNotSupportedKHR";
+      case vk::Result::eErrorVideoProfileCodecNotSupportedKHR: return "ErrorVideoProfileCodecNotSupportedKHR";
+      case vk::Result::eErrorVideoStdVersionNotSupportedKHR: return "ErrorVideoStdVersionNotSupportedKHR";
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
+      case vk::Result::eErrorInvalidDrmFormatModifierPlaneLayoutEXT: return "ErrorInvalidDrmFormatModifierPlaneLayoutEXT";
+      case vk::Result::eErrorNotPermittedKHR: return "ErrorNotPermittedKHR";
+#  if defined( VK_USE_PLATFORM_WIN32_KHR )
+      case vk::Result::eErrorFullScreenExclusiveModeLostEXT: return "ErrorFullScreenExclusiveModeLostEXT";
+#  endif /*VK_USE_PLATFORM_WIN32_KHR*/
+      case vk::Result::eThreadIdleKHR: return "ThreadIdleKHR";
+      case vk::Result::eThreadDoneKHR: return "ThreadDoneKHR";
+      case vk::Result::eOperationDeferredKHR: return "OperationDeferredKHR";
+      case vk::Result::eOperationNotDeferredKHR: return "OperationNotDeferredKHR";
+      case vk::Result::eErrorCompressionExhaustedEXT: return "ErrorCompressionExhaustedEXT";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
 struct GeometryInstanceData
 {
   GeometryInstanceData(
@@ -523,7 +588,7 @@ static void check_vk_result( VkResult err )
 {
   if ( err != 0 )
   {
-    std::cerr << AppName << ": Vulkan error " << vk::to_string( static_cast<vk::Result>( err ) );
+    std::cerr << AppName << ": Vulkan error " << to_string( static_cast<vk::Result>( err ) );
     if ( err < 0 )
     {
       abort();

--- a/RAII_Samples/SurfaceCapabilities/SurfaceCapabilities.cpp
+++ b/RAII_Samples/SurfaceCapabilities/SurfaceCapabilities.cpp
@@ -25,29 +25,145 @@
 static char const * AppName    = "SurfaceCapabilities";
 static char const * EngineName = "Vulkan.hpp";
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::CompositeAlphaFlagsKHR value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::CompositeAlphaFlagBitsKHR::eOpaque )
+      result += "Opaque | ";
+    if ( value & vk::CompositeAlphaFlagBitsKHR::ePreMultiplied )
+      result += "PreMultiplied | ";
+    if ( value & vk::CompositeAlphaFlagBitsKHR::ePostMultiplied )
+      result += "PostMultiplied | ";
+    if ( value & vk::CompositeAlphaFlagBitsKHR::eInherit )
+      result += "Inherit | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::ImageUsageFlags value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::ImageUsageFlagBits::eTransferSrc )
+      result += "TransferSrc | ";
+    if ( value & vk::ImageUsageFlagBits::eTransferDst )
+      result += "TransferDst | ";
+    if ( value & vk::ImageUsageFlagBits::eSampled )
+      result += "Sampled | ";
+    if ( value & vk::ImageUsageFlagBits::eStorage )
+      result += "Storage | ";
+    if ( value & vk::ImageUsageFlagBits::eColorAttachment )
+      result += "ColorAttachment | ";
+    if ( value & vk::ImageUsageFlagBits::eDepthStencilAttachment )
+      result += "DepthStencilAttachment | ";
+    if ( value & vk::ImageUsageFlagBits::eTransientAttachment )
+      result += "TransientAttachment | ";
+    if ( value & vk::ImageUsageFlagBits::eInputAttachment )
+      result += "InputAttachment | ";
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
+    if ( value & vk::ImageUsageFlagBits::eVideoDecodeDstKHR )
+      result += "VideoDecodeDstKHR | ";
+    if ( value & vk::ImageUsageFlagBits::eVideoDecodeSrcKHR )
+      result += "VideoDecodeSrcKHR | ";
+    if ( value & vk::ImageUsageFlagBits::eVideoDecodeDpbKHR )
+      result += "VideoDecodeDpbKHR | ";
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
+    if ( value & vk::ImageUsageFlagBits::eFragmentDensityMapEXT )
+      result += "FragmentDensityMapEXT | ";
+    if ( value & vk::ImageUsageFlagBits::eFragmentShadingRateAttachmentKHR )
+      result += "FragmentShadingRateAttachmentKHR | ";
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
+    if ( value & vk::ImageUsageFlagBits::eVideoEncodeDstKHR )
+      result += "VideoEncodeDstKHR | ";
+    if ( value & vk::ImageUsageFlagBits::eVideoEncodeSrcKHR )
+      result += "VideoEncodeSrcKHR | ";
+    if ( value & vk::ImageUsageFlagBits::eVideoEncodeDpbKHR )
+      result += "VideoEncodeDpbKHR | ";
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
+    if ( value & vk::ImageUsageFlagBits::eInvocationMaskHUAWEI )
+      result += "InvocationMaskHUAWEI | ";
+    if ( value & vk::ImageUsageFlagBits::eSampleWeightQCOM )
+      result += "SampleWeightQCOM | ";
+    if ( value & vk::ImageUsageFlagBits::eSampleBlockMatchQCOM )
+      result += "SampleBlockMatchQCOM | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::SurfaceTransformFlagBitsKHR value )
+  {
+    switch ( value )
+    {
+      case vk::SurfaceTransformFlagBitsKHR::eIdentity: return "Identity";
+      case vk::SurfaceTransformFlagBitsKHR::eRotate90: return "Rotate90";
+      case vk::SurfaceTransformFlagBitsKHR::eRotate180: return "Rotate180";
+      case vk::SurfaceTransformFlagBitsKHR::eRotate270: return "Rotate270";
+      case vk::SurfaceTransformFlagBitsKHR::eHorizontalMirror: return "HorizontalMirror";
+      case vk::SurfaceTransformFlagBitsKHR::eHorizontalMirrorRotate90: return "HorizontalMirrorRotate90";
+      case vk::SurfaceTransformFlagBitsKHR::eHorizontalMirrorRotate180: return "HorizontalMirrorRotate180";
+      case vk::SurfaceTransformFlagBitsKHR::eHorizontalMirrorRotate270: return "HorizontalMirrorRotate270";
+      case vk::SurfaceTransformFlagBitsKHR::eInherit: return "Inherit";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+
+  std::string to_string( vk::SurfaceTransformFlagsKHR value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::SurfaceTransformFlagBitsKHR::eIdentity )
+      result += "Identity | ";
+    if ( value & vk::SurfaceTransformFlagBitsKHR::eRotate90 )
+      result += "Rotate90 | ";
+    if ( value & vk::SurfaceTransformFlagBitsKHR::eRotate180 )
+      result += "Rotate180 | ";
+    if ( value & vk::SurfaceTransformFlagBitsKHR::eRotate270 )
+      result += "Rotate270 | ";
+    if ( value & vk::SurfaceTransformFlagBitsKHR::eHorizontalMirror )
+      result += "HorizontalMirror | ";
+    if ( value & vk::SurfaceTransformFlagBitsKHR::eHorizontalMirrorRotate90 )
+      result += "HorizontalMirrorRotate90 | ";
+    if ( value & vk::SurfaceTransformFlagBitsKHR::eHorizontalMirrorRotate180 )
+      result += "HorizontalMirrorRotate180 | ";
+    if ( value & vk::SurfaceTransformFlagBitsKHR::eHorizontalMirrorRotate270 )
+      result += "HorizontalMirrorRotate270 | ";
+    if ( value & vk::SurfaceTransformFlagBitsKHR::eInherit )
+      result += "Inherit | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
 void cout( vk::SurfaceCapabilitiesKHR const & surfaceCapabilities )
 {
-  std::cout << "\tCapabilities:\n";
-  std::cout << "\t\t"
-            << "currentExtent           = " << surfaceCapabilities.currentExtent.width << " x " << surfaceCapabilities.currentExtent.height << "\n";
-  std::cout << "\t\t"
-            << "currentTransform        = " << vk::to_string( surfaceCapabilities.currentTransform ) << "\n";
-  std::cout << "\t\t"
-            << "maxImageArrayLayers     = " << surfaceCapabilities.maxImageArrayLayers << "\n";
-  std::cout << "\t\t"
-            << "maxImageCount           = " << surfaceCapabilities.maxImageCount << "\n";
-  std::cout << "\t\t"
-            << "maxImageExtent          = " << surfaceCapabilities.maxImageExtent.width << " x " << surfaceCapabilities.maxImageExtent.height << "\n";
-  std::cout << "\t\t"
-            << "minImageCount           = " << surfaceCapabilities.minImageCount << "\n";
-  std::cout << "\t\t"
-            << "minImageExtent          = " << surfaceCapabilities.minImageExtent.width << " x " << surfaceCapabilities.minImageExtent.height << "\n";
-  std::cout << "\t\t"
-            << "supportedCompositeAlpha = " << vk::to_string( surfaceCapabilities.supportedCompositeAlpha ) << "\n";
-  std::cout << "\t\t"
-            << "supportedTransforms     = " << vk::to_string( surfaceCapabilities.supportedTransforms ) << "\n";
-  std::cout << "\t\t"
-            << "supportedUsageFlags     = " << vk::to_string( surfaceCapabilities.supportedUsageFlags ) << "\n";
+  std::cout << std::string( "\t" ) << "Capabilities:\n";
+  std::cout << std::string( "\t\t" ) << "currentExtent           = " << surfaceCapabilities.currentExtent.width << " x "
+            << surfaceCapabilities.currentExtent.height << "\n";
+  std::cout << std::string( "\t\t" ) << "currentTransform        = " << to_string( surfaceCapabilities.currentTransform ) << "\n";
+  std::cout << std::string( "\t\t" ) << "maxImageArrayLayers     = " << surfaceCapabilities.maxImageArrayLayers << "\n";
+  std::cout << std::string( "\t\t" ) << "maxImageCount           = " << surfaceCapabilities.maxImageCount << "\n";
+  std::cout << std::string( "\t\t" ) << "maxImageExtent          = " << surfaceCapabilities.maxImageExtent.width << " x "
+            << surfaceCapabilities.maxImageExtent.height << "\n";
+  std::cout << std::string( "\t\t" ) << "minImageCount           = " << surfaceCapabilities.minImageCount << "\n";
+  std::cout << std::string( "\t\t" ) << "minImageExtent          = " << surfaceCapabilities.minImageExtent.width << " x "
+            << surfaceCapabilities.minImageExtent.height << "\n";
+  std::cout << std::string( "\t\t" ) << "supportedCompositeAlpha = " << to_string( surfaceCapabilities.supportedCompositeAlpha ) << "\n";
+  std::cout << std::string( "\t\t" ) << "supportedTransforms     = " << to_string( surfaceCapabilities.supportedTransforms ) << "\n";
+  std::cout << std::string( "\t\t" ) << "supportedUsageFlags     = " << to_string( surfaceCapabilities.supportedUsageFlags ) << "\n";
   std::cout << "\n";
 }
 
@@ -105,18 +221,17 @@ int main( int /*argc*/, char ** /*argv*/ )
         {
           vk::DisplayNativeHdrSurfaceCapabilitiesAMD displayNativeHdrSurfaceCapabilities =
             surfaceCapabilities2.get<vk::DisplayNativeHdrSurfaceCapabilitiesAMD>();
-          std::cout << "\tDisplayNativeHdrSurfaceCapabilitiesAMD:\n";
-          std::cout << "\t\t"
-                    << "localDimmingSupport = " << !!displayNativeHdrSurfaceCapabilities.localDimmingSupport << "\n";
+          std::cout << std::string( "\t" ) << "DisplayNativeHdrSurfaceCapabilitiesAMD:\n";
+          std::cout << std::string( "\t\t" ) << "localDimmingSupport = " << !!displayNativeHdrSurfaceCapabilities.localDimmingSupport << "\n";
           std::cout << "\n";
         }
 
         if ( vk::su::contains( extensionProperties, "VK_KHR_shared_presentable_image" ) )
         {
           vk::SharedPresentSurfaceCapabilitiesKHR sharedPresentSurfaceCapabilities = surfaceCapabilities2.get<vk::SharedPresentSurfaceCapabilitiesKHR>();
-          std::cout << "\tSharedPresentSurfaceCapabilitiesKHR:\n";
-          std::cout << "\t\t"
-                    << "sharedPresentSupportedUsageFlags  = " << vk::to_string( sharedPresentSurfaceCapabilities.sharedPresentSupportedUsageFlags ) << "\n";
+          std::cout << std::string( "\t" ) << "SharedPresentSurfaceCapabilitiesKHR:\n";
+          std::cout << std::string( "\t\t" )
+                    << "sharedPresentSupportedUsageFlags  = " << to_string( sharedPresentSurfaceCapabilities.sharedPresentSupportedUsageFlags ) << "\n";
           std::cout << "\n";
         }
 
@@ -124,18 +239,17 @@ int main( int /*argc*/, char ** /*argv*/ )
         {
           vk::SurfaceCapabilitiesFullScreenExclusiveEXT surfaceCapabilitiesFullScreenExclusive =
             surfaceCapabilities2.get<vk::SurfaceCapabilitiesFullScreenExclusiveEXT>();
-          std::cout << "\tSurfaceCapabilitiesFullScreenExclusiveEXT:\n";
-          std::cout << "\t\t"
-                    << "fullScreenExclusiveSupported  = " << !!surfaceCapabilitiesFullScreenExclusive.fullScreenExclusiveSupported << "\n";
+          std::cout << std::string( "\t" ) << "SurfaceCapabilitiesFullScreenExclusiveEXT:\n";
+          std::cout << std::string( "\t\t" ) << "fullScreenExclusiveSupported  = " << !!surfaceCapabilitiesFullScreenExclusive.fullScreenExclusiveSupported
+                    << "\n";
           std::cout << "\n";
         }
 
         if ( vk::su::contains( extensionProperties, "VK_KHR_surface_protected_capabilities" ) )
         {
           vk::SurfaceProtectedCapabilitiesKHR surfaceProtectedCapabilities = surfaceCapabilities2.get<vk::SurfaceProtectedCapabilitiesKHR>();
-          std::cout << "\tSurfaceProtectedCapabilitiesKHR:\n";
-          std::cout << "\t\t"
-                    << "supportsProtected  = " << !!surfaceProtectedCapabilities.supportsProtected << "\n";
+          std::cout << std::string( "\t" ) << "SurfaceProtectedCapabilitiesKHR:\n";
+          std::cout << std::string( "\t\t" ) << "supportsProtected  = " << !!surfaceProtectedCapabilities.supportsProtected << "\n";
           std::cout << "\n";
         }
       }

--- a/RAII_Samples/SurfaceFormats/SurfaceFormats.cpp
+++ b/RAII_Samples/SurfaceFormats/SurfaceFormats.cpp
@@ -25,6 +25,293 @@
 static char const * AppName    = "SurfaceFormats";
 static char const * EngineName = "Vulkan.hpp";
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::ColorSpaceKHR value )
+  {
+    switch ( value )
+    {
+      case vk::ColorSpaceKHR::eSrgbNonlinear: return "SrgbNonlinear";
+      case vk::ColorSpaceKHR::eDisplayP3NonlinearEXT: return "DisplayP3NonlinearEXT";
+      case vk::ColorSpaceKHR::eExtendedSrgbLinearEXT: return "ExtendedSrgbLinearEXT";
+      case vk::ColorSpaceKHR::eDisplayP3LinearEXT: return "DisplayP3LinearEXT";
+      case vk::ColorSpaceKHR::eDciP3NonlinearEXT: return "DciP3NonlinearEXT";
+      case vk::ColorSpaceKHR::eBt709LinearEXT: return "Bt709LinearEXT";
+      case vk::ColorSpaceKHR::eBt709NonlinearEXT: return "Bt709NonlinearEXT";
+      case vk::ColorSpaceKHR::eBt2020LinearEXT: return "Bt2020LinearEXT";
+      case vk::ColorSpaceKHR::eHdr10St2084EXT: return "Hdr10St2084EXT";
+      case vk::ColorSpaceKHR::eDolbyvisionEXT: return "DolbyvisionEXT";
+      case vk::ColorSpaceKHR::eHdr10HlgEXT: return "Hdr10HlgEXT";
+      case vk::ColorSpaceKHR::eAdobergbLinearEXT: return "AdobergbLinearEXT";
+      case vk::ColorSpaceKHR::eAdobergbNonlinearEXT: return "AdobergbNonlinearEXT";
+      case vk::ColorSpaceKHR::ePassThroughEXT: return "PassThroughEXT";
+      case vk::ColorSpaceKHR::eExtendedSrgbNonlinearEXT: return "ExtendedSrgbNonlinearEXT";
+      case vk::ColorSpaceKHR::eDisplayNativeAMD: return "DisplayNativeAMD";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+
+  std::string to_string( vk::Format value )
+  {
+    switch ( value )
+    {
+      case vk::Format::eUndefined: return "Undefined";
+      case vk::Format::eR4G4UnormPack8: return "R4G4UnormPack8";
+      case vk::Format::eR4G4B4A4UnormPack16: return "R4G4B4A4UnormPack16";
+      case vk::Format::eB4G4R4A4UnormPack16: return "B4G4R4A4UnormPack16";
+      case vk::Format::eR5G6B5UnormPack16: return "R5G6B5UnormPack16";
+      case vk::Format::eB5G6R5UnormPack16: return "B5G6R5UnormPack16";
+      case vk::Format::eR5G5B5A1UnormPack16: return "R5G5B5A1UnormPack16";
+      case vk::Format::eB5G5R5A1UnormPack16: return "B5G5R5A1UnormPack16";
+      case vk::Format::eA1R5G5B5UnormPack16: return "A1R5G5B5UnormPack16";
+      case vk::Format::eR8Unorm: return "R8Unorm";
+      case vk::Format::eR8Snorm: return "R8Snorm";
+      case vk::Format::eR8Uscaled: return "R8Uscaled";
+      case vk::Format::eR8Sscaled: return "R8Sscaled";
+      case vk::Format::eR8Uint: return "R8Uint";
+      case vk::Format::eR8Sint: return "R8Sint";
+      case vk::Format::eR8Srgb: return "R8Srgb";
+      case vk::Format::eR8G8Unorm: return "R8G8Unorm";
+      case vk::Format::eR8G8Snorm: return "R8G8Snorm";
+      case vk::Format::eR8G8Uscaled: return "R8G8Uscaled";
+      case vk::Format::eR8G8Sscaled: return "R8G8Sscaled";
+      case vk::Format::eR8G8Uint: return "R8G8Uint";
+      case vk::Format::eR8G8Sint: return "R8G8Sint";
+      case vk::Format::eR8G8Srgb: return "R8G8Srgb";
+      case vk::Format::eR8G8B8Unorm: return "R8G8B8Unorm";
+      case vk::Format::eR8G8B8Snorm: return "R8G8B8Snorm";
+      case vk::Format::eR8G8B8Uscaled: return "R8G8B8Uscaled";
+      case vk::Format::eR8G8B8Sscaled: return "R8G8B8Sscaled";
+      case vk::Format::eR8G8B8Uint: return "R8G8B8Uint";
+      case vk::Format::eR8G8B8Sint: return "R8G8B8Sint";
+      case vk::Format::eR8G8B8Srgb: return "R8G8B8Srgb";
+      case vk::Format::eB8G8R8Unorm: return "B8G8R8Unorm";
+      case vk::Format::eB8G8R8Snorm: return "B8G8R8Snorm";
+      case vk::Format::eB8G8R8Uscaled: return "B8G8R8Uscaled";
+      case vk::Format::eB8G8R8Sscaled: return "B8G8R8Sscaled";
+      case vk::Format::eB8G8R8Uint: return "B8G8R8Uint";
+      case vk::Format::eB8G8R8Sint: return "B8G8R8Sint";
+      case vk::Format::eB8G8R8Srgb: return "B8G8R8Srgb";
+      case vk::Format::eR8G8B8A8Unorm: return "R8G8B8A8Unorm";
+      case vk::Format::eR8G8B8A8Snorm: return "R8G8B8A8Snorm";
+      case vk::Format::eR8G8B8A8Uscaled: return "R8G8B8A8Uscaled";
+      case vk::Format::eR8G8B8A8Sscaled: return "R8G8B8A8Sscaled";
+      case vk::Format::eR8G8B8A8Uint: return "R8G8B8A8Uint";
+      case vk::Format::eR8G8B8A8Sint: return "R8G8B8A8Sint";
+      case vk::Format::eR8G8B8A8Srgb: return "R8G8B8A8Srgb";
+      case vk::Format::eB8G8R8A8Unorm: return "B8G8R8A8Unorm";
+      case vk::Format::eB8G8R8A8Snorm: return "B8G8R8A8Snorm";
+      case vk::Format::eB8G8R8A8Uscaled: return "B8G8R8A8Uscaled";
+      case vk::Format::eB8G8R8A8Sscaled: return "B8G8R8A8Sscaled";
+      case vk::Format::eB8G8R8A8Uint: return "B8G8R8A8Uint";
+      case vk::Format::eB8G8R8A8Sint: return "B8G8R8A8Sint";
+      case vk::Format::eB8G8R8A8Srgb: return "B8G8R8A8Srgb";
+      case vk::Format::eA8B8G8R8UnormPack32: return "A8B8G8R8UnormPack32";
+      case vk::Format::eA8B8G8R8SnormPack32: return "A8B8G8R8SnormPack32";
+      case vk::Format::eA8B8G8R8UscaledPack32: return "A8B8G8R8UscaledPack32";
+      case vk::Format::eA8B8G8R8SscaledPack32: return "A8B8G8R8SscaledPack32";
+      case vk::Format::eA8B8G8R8UintPack32: return "A8B8G8R8UintPack32";
+      case vk::Format::eA8B8G8R8SintPack32: return "A8B8G8R8SintPack32";
+      case vk::Format::eA8B8G8R8SrgbPack32: return "A8B8G8R8SrgbPack32";
+      case vk::Format::eA2R10G10B10UnormPack32: return "A2R10G10B10UnormPack32";
+      case vk::Format::eA2R10G10B10SnormPack32: return "A2R10G10B10SnormPack32";
+      case vk::Format::eA2R10G10B10UscaledPack32: return "A2R10G10B10UscaledPack32";
+      case vk::Format::eA2R10G10B10SscaledPack32: return "A2R10G10B10SscaledPack32";
+      case vk::Format::eA2R10G10B10UintPack32: return "A2R10G10B10UintPack32";
+      case vk::Format::eA2R10G10B10SintPack32: return "A2R10G10B10SintPack32";
+      case vk::Format::eA2B10G10R10UnormPack32: return "A2B10G10R10UnormPack32";
+      case vk::Format::eA2B10G10R10SnormPack32: return "A2B10G10R10SnormPack32";
+      case vk::Format::eA2B10G10R10UscaledPack32: return "A2B10G10R10UscaledPack32";
+      case vk::Format::eA2B10G10R10SscaledPack32: return "A2B10G10R10SscaledPack32";
+      case vk::Format::eA2B10G10R10UintPack32: return "A2B10G10R10UintPack32";
+      case vk::Format::eA2B10G10R10SintPack32: return "A2B10G10R10SintPack32";
+      case vk::Format::eR16Unorm: return "R16Unorm";
+      case vk::Format::eR16Snorm: return "R16Snorm";
+      case vk::Format::eR16Uscaled: return "R16Uscaled";
+      case vk::Format::eR16Sscaled: return "R16Sscaled";
+      case vk::Format::eR16Uint: return "R16Uint";
+      case vk::Format::eR16Sint: return "R16Sint";
+      case vk::Format::eR16Sfloat: return "R16Sfloat";
+      case vk::Format::eR16G16Unorm: return "R16G16Unorm";
+      case vk::Format::eR16G16Snorm: return "R16G16Snorm";
+      case vk::Format::eR16G16Uscaled: return "R16G16Uscaled";
+      case vk::Format::eR16G16Sscaled: return "R16G16Sscaled";
+      case vk::Format::eR16G16Uint: return "R16G16Uint";
+      case vk::Format::eR16G16Sint: return "R16G16Sint";
+      case vk::Format::eR16G16Sfloat: return "R16G16Sfloat";
+      case vk::Format::eR16G16B16Unorm: return "R16G16B16Unorm";
+      case vk::Format::eR16G16B16Snorm: return "R16G16B16Snorm";
+      case vk::Format::eR16G16B16Uscaled: return "R16G16B16Uscaled";
+      case vk::Format::eR16G16B16Sscaled: return "R16G16B16Sscaled";
+      case vk::Format::eR16G16B16Uint: return "R16G16B16Uint";
+      case vk::Format::eR16G16B16Sint: return "R16G16B16Sint";
+      case vk::Format::eR16G16B16Sfloat: return "R16G16B16Sfloat";
+      case vk::Format::eR16G16B16A16Unorm: return "R16G16B16A16Unorm";
+      case vk::Format::eR16G16B16A16Snorm: return "R16G16B16A16Snorm";
+      case vk::Format::eR16G16B16A16Uscaled: return "R16G16B16A16Uscaled";
+      case vk::Format::eR16G16B16A16Sscaled: return "R16G16B16A16Sscaled";
+      case vk::Format::eR16G16B16A16Uint: return "R16G16B16A16Uint";
+      case vk::Format::eR16G16B16A16Sint: return "R16G16B16A16Sint";
+      case vk::Format::eR16G16B16A16Sfloat: return "R16G16B16A16Sfloat";
+      case vk::Format::eR32Uint: return "R32Uint";
+      case vk::Format::eR32Sint: return "R32Sint";
+      case vk::Format::eR32Sfloat: return "R32Sfloat";
+      case vk::Format::eR32G32Uint: return "R32G32Uint";
+      case vk::Format::eR32G32Sint: return "R32G32Sint";
+      case vk::Format::eR32G32Sfloat: return "R32G32Sfloat";
+      case vk::Format::eR32G32B32Uint: return "R32G32B32Uint";
+      case vk::Format::eR32G32B32Sint: return "R32G32B32Sint";
+      case vk::Format::eR32G32B32Sfloat: return "R32G32B32Sfloat";
+      case vk::Format::eR32G32B32A32Uint: return "R32G32B32A32Uint";
+      case vk::Format::eR32G32B32A32Sint: return "R32G32B32A32Sint";
+      case vk::Format::eR32G32B32A32Sfloat: return "R32G32B32A32Sfloat";
+      case vk::Format::eR64Uint: return "R64Uint";
+      case vk::Format::eR64Sint: return "R64Sint";
+      case vk::Format::eR64Sfloat: return "R64Sfloat";
+      case vk::Format::eR64G64Uint: return "R64G64Uint";
+      case vk::Format::eR64G64Sint: return "R64G64Sint";
+      case vk::Format::eR64G64Sfloat: return "R64G64Sfloat";
+      case vk::Format::eR64G64B64Uint: return "R64G64B64Uint";
+      case vk::Format::eR64G64B64Sint: return "R64G64B64Sint";
+      case vk::Format::eR64G64B64Sfloat: return "R64G64B64Sfloat";
+      case vk::Format::eR64G64B64A64Uint: return "R64G64B64A64Uint";
+      case vk::Format::eR64G64B64A64Sint: return "R64G64B64A64Sint";
+      case vk::Format::eR64G64B64A64Sfloat: return "R64G64B64A64Sfloat";
+      case vk::Format::eB10G11R11UfloatPack32: return "B10G11R11UfloatPack32";
+      case vk::Format::eE5B9G9R9UfloatPack32: return "E5B9G9R9UfloatPack32";
+      case vk::Format::eD16Unorm: return "D16Unorm";
+      case vk::Format::eX8D24UnormPack32: return "X8D24UnormPack32";
+      case vk::Format::eD32Sfloat: return "D32Sfloat";
+      case vk::Format::eS8Uint: return "S8Uint";
+      case vk::Format::eD16UnormS8Uint: return "D16UnormS8Uint";
+      case vk::Format::eD24UnormS8Uint: return "D24UnormS8Uint";
+      case vk::Format::eD32SfloatS8Uint: return "D32SfloatS8Uint";
+      case vk::Format::eBc1RgbUnormBlock: return "Bc1RgbUnormBlock";
+      case vk::Format::eBc1RgbSrgbBlock: return "Bc1RgbSrgbBlock";
+      case vk::Format::eBc1RgbaUnormBlock: return "Bc1RgbaUnormBlock";
+      case vk::Format::eBc1RgbaSrgbBlock: return "Bc1RgbaSrgbBlock";
+      case vk::Format::eBc2UnormBlock: return "Bc2UnormBlock";
+      case vk::Format::eBc2SrgbBlock: return "Bc2SrgbBlock";
+      case vk::Format::eBc3UnormBlock: return "Bc3UnormBlock";
+      case vk::Format::eBc3SrgbBlock: return "Bc3SrgbBlock";
+      case vk::Format::eBc4UnormBlock: return "Bc4UnormBlock";
+      case vk::Format::eBc4SnormBlock: return "Bc4SnormBlock";
+      case vk::Format::eBc5UnormBlock: return "Bc5UnormBlock";
+      case vk::Format::eBc5SnormBlock: return "Bc5SnormBlock";
+      case vk::Format::eBc6HUfloatBlock: return "Bc6HUfloatBlock";
+      case vk::Format::eBc6HSfloatBlock: return "Bc6HSfloatBlock";
+      case vk::Format::eBc7UnormBlock: return "Bc7UnormBlock";
+      case vk::Format::eBc7SrgbBlock: return "Bc7SrgbBlock";
+      case vk::Format::eEtc2R8G8B8UnormBlock: return "Etc2R8G8B8UnormBlock";
+      case vk::Format::eEtc2R8G8B8SrgbBlock: return "Etc2R8G8B8SrgbBlock";
+      case vk::Format::eEtc2R8G8B8A1UnormBlock: return "Etc2R8G8B8A1UnormBlock";
+      case vk::Format::eEtc2R8G8B8A1SrgbBlock: return "Etc2R8G8B8A1SrgbBlock";
+      case vk::Format::eEtc2R8G8B8A8UnormBlock: return "Etc2R8G8B8A8UnormBlock";
+      case vk::Format::eEtc2R8G8B8A8SrgbBlock: return "Etc2R8G8B8A8SrgbBlock";
+      case vk::Format::eEacR11UnormBlock: return "EacR11UnormBlock";
+      case vk::Format::eEacR11SnormBlock: return "EacR11SnormBlock";
+      case vk::Format::eEacR11G11UnormBlock: return "EacR11G11UnormBlock";
+      case vk::Format::eEacR11G11SnormBlock: return "EacR11G11SnormBlock";
+      case vk::Format::eAstc4x4UnormBlock: return "Astc4x4UnormBlock";
+      case vk::Format::eAstc4x4SrgbBlock: return "Astc4x4SrgbBlock";
+      case vk::Format::eAstc5x4UnormBlock: return "Astc5x4UnormBlock";
+      case vk::Format::eAstc5x4SrgbBlock: return "Astc5x4SrgbBlock";
+      case vk::Format::eAstc5x5UnormBlock: return "Astc5x5UnormBlock";
+      case vk::Format::eAstc5x5SrgbBlock: return "Astc5x5SrgbBlock";
+      case vk::Format::eAstc6x5UnormBlock: return "Astc6x5UnormBlock";
+      case vk::Format::eAstc6x5SrgbBlock: return "Astc6x5SrgbBlock";
+      case vk::Format::eAstc6x6UnormBlock: return "Astc6x6UnormBlock";
+      case vk::Format::eAstc6x6SrgbBlock: return "Astc6x6SrgbBlock";
+      case vk::Format::eAstc8x5UnormBlock: return "Astc8x5UnormBlock";
+      case vk::Format::eAstc8x5SrgbBlock: return "Astc8x5SrgbBlock";
+      case vk::Format::eAstc8x6UnormBlock: return "Astc8x6UnormBlock";
+      case vk::Format::eAstc8x6SrgbBlock: return "Astc8x6SrgbBlock";
+      case vk::Format::eAstc8x8UnormBlock: return "Astc8x8UnormBlock";
+      case vk::Format::eAstc8x8SrgbBlock: return "Astc8x8SrgbBlock";
+      case vk::Format::eAstc10x5UnormBlock: return "Astc10x5UnormBlock";
+      case vk::Format::eAstc10x5SrgbBlock: return "Astc10x5SrgbBlock";
+      case vk::Format::eAstc10x6UnormBlock: return "Astc10x6UnormBlock";
+      case vk::Format::eAstc10x6SrgbBlock: return "Astc10x6SrgbBlock";
+      case vk::Format::eAstc10x8UnormBlock: return "Astc10x8UnormBlock";
+      case vk::Format::eAstc10x8SrgbBlock: return "Astc10x8SrgbBlock";
+      case vk::Format::eAstc10x10UnormBlock: return "Astc10x10UnormBlock";
+      case vk::Format::eAstc10x10SrgbBlock: return "Astc10x10SrgbBlock";
+      case vk::Format::eAstc12x10UnormBlock: return "Astc12x10UnormBlock";
+      case vk::Format::eAstc12x10SrgbBlock: return "Astc12x10SrgbBlock";
+      case vk::Format::eAstc12x12UnormBlock: return "Astc12x12UnormBlock";
+      case vk::Format::eAstc12x12SrgbBlock: return "Astc12x12SrgbBlock";
+      case vk::Format::eG8B8G8R8422Unorm: return "G8B8G8R8422Unorm";
+      case vk::Format::eB8G8R8G8422Unorm: return "B8G8R8G8422Unorm";
+      case vk::Format::eG8B8R83Plane420Unorm: return "G8B8R83Plane420Unorm";
+      case vk::Format::eG8B8R82Plane420Unorm: return "G8B8R82Plane420Unorm";
+      case vk::Format::eG8B8R83Plane422Unorm: return "G8B8R83Plane422Unorm";
+      case vk::Format::eG8B8R82Plane422Unorm: return "G8B8R82Plane422Unorm";
+      case vk::Format::eG8B8R83Plane444Unorm: return "G8B8R83Plane444Unorm";
+      case vk::Format::eR10X6UnormPack16: return "R10X6UnormPack16";
+      case vk::Format::eR10X6G10X6Unorm2Pack16: return "R10X6G10X6Unorm2Pack16";
+      case vk::Format::eR10X6G10X6B10X6A10X6Unorm4Pack16: return "R10X6G10X6B10X6A10X6Unorm4Pack16";
+      case vk::Format::eG10X6B10X6G10X6R10X6422Unorm4Pack16: return "G10X6B10X6G10X6R10X6422Unorm4Pack16";
+      case vk::Format::eB10X6G10X6R10X6G10X6422Unorm4Pack16: return "B10X6G10X6R10X6G10X6422Unorm4Pack16";
+      case vk::Format::eG10X6B10X6R10X63Plane420Unorm3Pack16: return "G10X6B10X6R10X63Plane420Unorm3Pack16";
+      case vk::Format::eG10X6B10X6R10X62Plane420Unorm3Pack16: return "G10X6B10X6R10X62Plane420Unorm3Pack16";
+      case vk::Format::eG10X6B10X6R10X63Plane422Unorm3Pack16: return "G10X6B10X6R10X63Plane422Unorm3Pack16";
+      case vk::Format::eG10X6B10X6R10X62Plane422Unorm3Pack16: return "G10X6B10X6R10X62Plane422Unorm3Pack16";
+      case vk::Format::eG10X6B10X6R10X63Plane444Unorm3Pack16: return "G10X6B10X6R10X63Plane444Unorm3Pack16";
+      case vk::Format::eR12X4UnormPack16: return "R12X4UnormPack16";
+      case vk::Format::eR12X4G12X4Unorm2Pack16: return "R12X4G12X4Unorm2Pack16";
+      case vk::Format::eR12X4G12X4B12X4A12X4Unorm4Pack16: return "R12X4G12X4B12X4A12X4Unorm4Pack16";
+      case vk::Format::eG12X4B12X4G12X4R12X4422Unorm4Pack16: return "G12X4B12X4G12X4R12X4422Unorm4Pack16";
+      case vk::Format::eB12X4G12X4R12X4G12X4422Unorm4Pack16: return "B12X4G12X4R12X4G12X4422Unorm4Pack16";
+      case vk::Format::eG12X4B12X4R12X43Plane420Unorm3Pack16: return "G12X4B12X4R12X43Plane420Unorm3Pack16";
+      case vk::Format::eG12X4B12X4R12X42Plane420Unorm3Pack16: return "G12X4B12X4R12X42Plane420Unorm3Pack16";
+      case vk::Format::eG12X4B12X4R12X43Plane422Unorm3Pack16: return "G12X4B12X4R12X43Plane422Unorm3Pack16";
+      case vk::Format::eG12X4B12X4R12X42Plane422Unorm3Pack16: return "G12X4B12X4R12X42Plane422Unorm3Pack16";
+      case vk::Format::eG12X4B12X4R12X43Plane444Unorm3Pack16: return "G12X4B12X4R12X43Plane444Unorm3Pack16";
+      case vk::Format::eG16B16G16R16422Unorm: return "G16B16G16R16422Unorm";
+      case vk::Format::eB16G16R16G16422Unorm: return "B16G16R16G16422Unorm";
+      case vk::Format::eG16B16R163Plane420Unorm: return "G16B16R163Plane420Unorm";
+      case vk::Format::eG16B16R162Plane420Unorm: return "G16B16R162Plane420Unorm";
+      case vk::Format::eG16B16R163Plane422Unorm: return "G16B16R163Plane422Unorm";
+      case vk::Format::eG16B16R162Plane422Unorm: return "G16B16R162Plane422Unorm";
+      case vk::Format::eG16B16R163Plane444Unorm: return "G16B16R163Plane444Unorm";
+      case vk::Format::eG8B8R82Plane444Unorm: return "G8B8R82Plane444Unorm";
+      case vk::Format::eG10X6B10X6R10X62Plane444Unorm3Pack16: return "G10X6B10X6R10X62Plane444Unorm3Pack16";
+      case vk::Format::eG12X4B12X4R12X42Plane444Unorm3Pack16: return "G12X4B12X4R12X42Plane444Unorm3Pack16";
+      case vk::Format::eG16B16R162Plane444Unorm: return "G16B16R162Plane444Unorm";
+      case vk::Format::eA4R4G4B4UnormPack16: return "A4R4G4B4UnormPack16";
+      case vk::Format::eA4B4G4R4UnormPack16: return "A4B4G4R4UnormPack16";
+      case vk::Format::eAstc4x4SfloatBlock: return "Astc4x4SfloatBlock";
+      case vk::Format::eAstc5x4SfloatBlock: return "Astc5x4SfloatBlock";
+      case vk::Format::eAstc5x5SfloatBlock: return "Astc5x5SfloatBlock";
+      case vk::Format::eAstc6x5SfloatBlock: return "Astc6x5SfloatBlock";
+      case vk::Format::eAstc6x6SfloatBlock: return "Astc6x6SfloatBlock";
+      case vk::Format::eAstc8x5SfloatBlock: return "Astc8x5SfloatBlock";
+      case vk::Format::eAstc8x6SfloatBlock: return "Astc8x6SfloatBlock";
+      case vk::Format::eAstc8x8SfloatBlock: return "Astc8x8SfloatBlock";
+      case vk::Format::eAstc10x5SfloatBlock: return "Astc10x5SfloatBlock";
+      case vk::Format::eAstc10x6SfloatBlock: return "Astc10x6SfloatBlock";
+      case vk::Format::eAstc10x8SfloatBlock: return "Astc10x8SfloatBlock";
+      case vk::Format::eAstc10x10SfloatBlock: return "Astc10x10SfloatBlock";
+      case vk::Format::eAstc12x10SfloatBlock: return "Astc12x10SfloatBlock";
+      case vk::Format::eAstc12x12SfloatBlock: return "Astc12x12SfloatBlock";
+      case vk::Format::ePvrtc12BppUnormBlockIMG: return "Pvrtc12BppUnormBlockIMG";
+      case vk::Format::ePvrtc14BppUnormBlockIMG: return "Pvrtc14BppUnormBlockIMG";
+      case vk::Format::ePvrtc22BppUnormBlockIMG: return "Pvrtc22BppUnormBlockIMG";
+      case vk::Format::ePvrtc24BppUnormBlockIMG: return "Pvrtc24BppUnormBlockIMG";
+      case vk::Format::ePvrtc12BppSrgbBlockIMG: return "Pvrtc12BppSrgbBlockIMG";
+      case vk::Format::ePvrtc14BppSrgbBlockIMG: return "Pvrtc14BppSrgbBlockIMG";
+      case vk::Format::ePvrtc22BppSrgbBlockIMG: return "Pvrtc22BppSrgbBlockIMG";
+      case vk::Format::ePvrtc24BppSrgbBlockIMG: return "Pvrtc24BppSrgbBlockIMG";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
 int main( int /*argc*/, char ** /*argv*/ )
 {
   try
@@ -49,11 +336,9 @@ int main( int /*argc*/, char ** /*argv*/ )
       std::vector<vk::SurfaceFormatKHR> surfaceFormats = physicalDevices[i].getSurfaceFormatsKHR( *surfaceData.surface );
       for ( size_t j = 0; j < surfaceFormats.size(); j++ )
       {
-        std::cout << "\tFormat " << j << "\n";
-        std::cout << "\t\t"
-                  << "colorSpace  = " << vk::to_string( surfaceFormats[j].colorSpace ) << "\n";
-        std::cout << "\t\t"
-                  << "format      = " << vk::to_string( surfaceFormats[j].format ) << "\n";
+        std::cout << std::string( "\t" ) << "Format " << j << "\n";
+        std::cout << std::string( "\t\t" ) << "colorSpace  = " << to_string( surfaceFormats[j].colorSpace ) << "\n";
+        std::cout << std::string( "\t\t" ) << "format      = " << to_string( surfaceFormats[j].format ) << "\n";
         std::cout << "\n";
       }
     }

--- a/README.md
+++ b/README.md
@@ -551,6 +551,13 @@ With the additional header `vulkan_hash.hpp`, you get specializations of `std::h
 When you configure your project using CMake, you can enable SAMPLES_BUILD to add some sample projects to your solution. Most of them are ports from the LunarG samples, but there are some more, like CreateDebugUtilsMessenger, InstanceVersion, PhysicalDeviceDisplayProperties, PhysicalDeviceExtensions, PhysicalDeviceFeatures, PhysicalDeviceGroups, PhysicalDeviceMemoryProperties, PhysicalDeviceProperties, PhysicalDeviceQueueFamilyProperties, and RayTracing. All those samples should just compile and run.
 When you configure your project using CMake, you can enable TESTS_BUILD to add some test projects to your solution. Those tests are just compilation tests and are not required to run.
 
+### Compile time issues
+As vulkan.hpp is pretty big, some compilers might need some time to digest all that stuff. In order to potentially reduce the time needed to compile that header, a couple of defines will be introduced, that allow you to hide certain features. Whenever you don't need that corresponding feature, defining that value might improve your compile time.
+Currently, there are just two such defines:
+- ```VULKAN_HPP_NO_SPACESHIP_OPERATOR```, which removes the spaceship operator on structures (available with C++20)
+- ```VULKAN_HPP_NO_TO_STRING```, which removes the various vk::to_string functions on enums and bitmasks.
+- ```VULKAN_HPP_USE_REFLECT```, this one needs to be defined to use the reflection function on structures. It's very slow to compile, though!
+
 ## Configuration Options
 
 There are a couple of defines you can use to control the feature set and behaviour of vulkan.hpp:
@@ -614,6 +621,10 @@ This is set to be the compiler-dependent attribute used to mark functions as inl
 #### VULKAN_HPP_NAMESPACE
 
 By default, the namespace used with vulkan.hpp is ```vk```. By defining ```VULKAN_HPP_NAMESPACE``` before including vulkan.hpp, you can adjust this.
+
+#### VULKAN_HPP_NO_TO_STRING
+
+By default, there are functions ```vk::to_string``` for enums and bitmasks. If you don't need that functionality, you can define ```VULKAN_HPP_NO_TO_STRING``` to spare some compilation time.
 
 #### VULKAN_HPP_NO_CONSTRUCTORS
 

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -2703,10 +2703,12 @@ std::string VulkanHppGenerator::generateBitmask( std::map<std::string, BitmaskDa
   if ( bitmaskBitsIt->second.values.empty() )
   {
     static std::string bitmaskValuesTemplate = R"(${alias}
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ${bitmaskName} )
   {
     return "{}";
   }
+#endif
 )";
     str += replaceWithMap( bitmaskValuesTemplate, { { "alias", alias }, { "bitmaskName", strippedBitmaskName } } );
   }
@@ -2741,6 +2743,7 @@ std::string VulkanHppGenerator::generateBitmask( std::map<std::string, BitmaskDa
     return ~( ${bitmaskName}( bits ) );
   }
 ${alias}
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ${bitmaskName} value )
   {
     if ( !value )
@@ -2750,6 +2753,7 @@ ${alias}
 ${toStringChecks}
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 )";
 
     std::string allFlags, toStringChecks;
@@ -5377,10 +5381,12 @@ ${cases}      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( 
   }
 
   const std::string enumToStringTemplate = R"(
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ${enumName}${argument} )
   {
 ${functionBody}
   }
+#endif
 )";
 
   return replaceWithMap( enumToStringTemplate,
@@ -14800,7 +14806,14 @@ int main( int argc, char ** argv )
   {
     public:
     virtual const char* name() const VULKAN_HPP_NOEXCEPT override { return VULKAN_HPP_NAMESPACE_STRING"::Result"; }
-    virtual std::string message(int ev) const override { return to_string(static_cast<Result>(ev)); }
+    virtual std::string message(int ev) const override
+    {
+#if defined( VULKAN_HPP_NO_TO_STRING )
+      return std::to_string( ev );
+#else
+      return VULKAN_HPP_NAMESPACE::to_string(static_cast<VULKAN_HPP_NAMESPACE::Result>(ev));
+#endif
+    }
   };
 
   class Error

--- a/samples/CreateDebugUtilsMessenger/CreateDebugUtilsMessenger.cpp
+++ b/samples/CreateDebugUtilsMessenger/CreateDebugUtilsMessenger.cpp
@@ -26,6 +26,100 @@ static char const * EngineName = "Vulkan.hpp";
 PFN_vkCreateDebugUtilsMessengerEXT  pfnVkCreateDebugUtilsMessengerEXT;
 PFN_vkDestroyDebugUtilsMessengerEXT pfnVkDestroyDebugUtilsMessengerEXT;
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::DebugUtilsMessageSeverityFlagBitsEXT value )
+  {
+    switch ( value )
+    {
+      case vk::DebugUtilsMessageSeverityFlagBitsEXT::eVerbose: return "Verbose";
+      case vk::DebugUtilsMessageSeverityFlagBitsEXT::eInfo: return "Info";
+      case vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning: return "Warning";
+      case vk::DebugUtilsMessageSeverityFlagBitsEXT::eError: return "Error";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+
+  std::string to_string( vk::DebugUtilsMessageTypeFlagsEXT value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::DebugUtilsMessageTypeFlagBitsEXT::eGeneral )
+      result += "General | ";
+    if ( value & vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation )
+      result += "Validation | ";
+    if ( value & vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance )
+      result += "Performance | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::ObjectType value )
+  {
+    switch ( value )
+    {
+      case vk::ObjectType::eUnknown: return "Unknown";
+      case vk::ObjectType::eInstance: return "Instance";
+      case vk::ObjectType::ePhysicalDevice: return "PhysicalDevice";
+      case vk::ObjectType::eDevice: return "Device";
+      case vk::ObjectType::eQueue: return "Queue";
+      case vk::ObjectType::eSemaphore: return "Semaphore";
+      case vk::ObjectType::eCommandBuffer: return "CommandBuffer";
+      case vk::ObjectType::eFence: return "Fence";
+      case vk::ObjectType::eDeviceMemory: return "DeviceMemory";
+      case vk::ObjectType::eBuffer: return "Buffer";
+      case vk::ObjectType::eImage: return "Image";
+      case vk::ObjectType::eEvent: return "Event";
+      case vk::ObjectType::eQueryPool: return "QueryPool";
+      case vk::ObjectType::eBufferView: return "BufferView";
+      case vk::ObjectType::eImageView: return "ImageView";
+      case vk::ObjectType::eShaderModule: return "ShaderModule";
+      case vk::ObjectType::ePipelineCache: return "PipelineCache";
+      case vk::ObjectType::ePipelineLayout: return "PipelineLayout";
+      case vk::ObjectType::eRenderPass: return "RenderPass";
+      case vk::ObjectType::ePipeline: return "Pipeline";
+      case vk::ObjectType::eDescriptorSetLayout: return "DescriptorSetLayout";
+      case vk::ObjectType::eSampler: return "Sampler";
+      case vk::ObjectType::eDescriptorPool: return "DescriptorPool";
+      case vk::ObjectType::eDescriptorSet: return "DescriptorSet";
+      case vk::ObjectType::eFramebuffer: return "Framebuffer";
+      case vk::ObjectType::eCommandPool: return "CommandPool";
+      case vk::ObjectType::eSamplerYcbcrConversion: return "SamplerYcbcrConversion";
+      case vk::ObjectType::eDescriptorUpdateTemplate: return "DescriptorUpdateTemplate";
+      case vk::ObjectType::ePrivateDataSlot: return "PrivateDataSlot";
+      case vk::ObjectType::eSurfaceKHR: return "SurfaceKHR";
+      case vk::ObjectType::eSwapchainKHR: return "SwapchainKHR";
+      case vk::ObjectType::eDisplayKHR: return "DisplayKHR";
+      case vk::ObjectType::eDisplayModeKHR: return "DisplayModeKHR";
+      case vk::ObjectType::eDebugReportCallbackEXT: return "DebugReportCallbackEXT";
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
+      case vk::ObjectType::eVideoSessionKHR: return "VideoSessionKHR";
+      case vk::ObjectType::eVideoSessionParametersKHR: return "VideoSessionParametersKHR";
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
+      case vk::ObjectType::eCuModuleNVX: return "CuModuleNVX";
+      case vk::ObjectType::eCuFunctionNVX: return "CuFunctionNVX";
+      case vk::ObjectType::eDebugUtilsMessengerEXT: return "DebugUtilsMessengerEXT";
+      case vk::ObjectType::eAccelerationStructureKHR: return "AccelerationStructureKHR";
+      case vk::ObjectType::eValidationCacheEXT: return "ValidationCacheEXT";
+      case vk::ObjectType::eAccelerationStructureNV: return "AccelerationStructureNV";
+      case vk::ObjectType::ePerformanceConfigurationINTEL: return "PerformanceConfigurationINTEL";
+      case vk::ObjectType::eDeferredOperationKHR: return "DeferredOperationKHR";
+      case vk::ObjectType::eIndirectCommandsLayoutNV: return "IndirectCommandsLayoutNV";
+#  if defined( VK_USE_PLATFORM_FUCHSIA )
+      case vk::ObjectType::eBufferCollectionFUCHSIA: return "BufferCollectionFUCHSIA";
+#  endif /*VK_USE_PLATFORM_FUCHSIA*/
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
 VKAPI_ATTR VkResult VKAPI_CALL vkCreateDebugUtilsMessengerEXT( VkInstance                                 instance,
                                                                const VkDebugUtilsMessengerCreateInfoEXT * pCreateInfo,
                                                                const VkAllocationCallbacks *              pAllocator,
@@ -46,50 +140,38 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debugMessageFunc( VkDebugUtilsMessageSeverityFlag
 {
   std::ostringstream message;
 
-  message << vk::to_string( static_cast<vk::DebugUtilsMessageSeverityFlagBitsEXT>( messageSeverity ) ) << ": "
-          << vk::to_string( static_cast<vk::DebugUtilsMessageTypeFlagsEXT>( messageTypes ) ) << ":\n";
-  message << "\t"
-          << "messageIDName   = <" << pCallbackData->pMessageIdName << ">\n";
-  message << "\t"
-          << "messageIdNumber = " << pCallbackData->messageIdNumber << "\n";
-  message << "\t"
-          << "message         = <" << pCallbackData->pMessage << ">\n";
+  message << to_string( static_cast<vk::DebugUtilsMessageSeverityFlagBitsEXT>( messageSeverity ) ) << ": "
+          << to_string( static_cast<vk::DebugUtilsMessageTypeFlagsEXT>( messageTypes ) ) << ":\n";
+  message << std::string( "\t" ) << "messageIDName   = <" << pCallbackData->pMessageIdName << ">\n";
+  message << std::string( "\t" ) << "messageIdNumber = " << pCallbackData->messageIdNumber << "\n";
+  message << std::string( "\t" ) << "message         = <" << pCallbackData->pMessage << ">\n";
   if ( 0 < pCallbackData->queueLabelCount )
   {
-    message << "\t"
-            << "Queue Labels:\n";
+    message << std::string( "\t" ) << "Queue Labels:\n";
     for ( uint32_t i = 0; i < pCallbackData->queueLabelCount; i++ )
     {
-      message << "\t\t"
-              << "labelName = <" << pCallbackData->pQueueLabels[i].pLabelName << ">\n";
+      message << std::string( "\t\t" ) << "labelName = <" << pCallbackData->pQueueLabels[i].pLabelName << ">\n";
     }
   }
   if ( 0 < pCallbackData->cmdBufLabelCount )
   {
-    message << "\t"
-            << "CommandBuffer Labels:\n";
+    message << std::string( "\t" ) << "CommandBuffer Labels:\n";
     for ( uint32_t i = 0; i < pCallbackData->cmdBufLabelCount; i++ )
     {
-      message << "\t\t"
-              << "labelName = <" << pCallbackData->pCmdBufLabels[i].pLabelName << ">\n";
+      message << std::string( "\t\t" ) << "labelName = <" << pCallbackData->pCmdBufLabels[i].pLabelName << ">\n";
     }
   }
   if ( 0 < pCallbackData->objectCount )
   {
-    message << "\t"
-            << "Objects:\n";
+    message << std::string( "\t" ) << "Objects:\n";
     for ( uint32_t i = 0; i < pCallbackData->objectCount; i++ )
     {
-      message << "\t\t"
-              << "Object " << i << "\n";
-      message << "\t\t\t"
-              << "objectType   = " << vk::to_string( static_cast<vk::ObjectType>( pCallbackData->pObjects[i].objectType ) ) << "\n";
-      message << "\t\t\t"
-              << "objectHandle = " << pCallbackData->pObjects[i].objectHandle << "\n";
+      message << std::string( "\t\t" ) << "Object " << i << "\n";
+      message << std::string( "\t\t\t" ) << "objectType   = " << to_string( static_cast<vk::ObjectType>( pCallbackData->pObjects[i].objectType ) ) << "\n";
+      message << std::string( "\t\t\t" ) << "objectHandle = " << pCallbackData->pObjects[i].objectHandle << "\n";
       if ( pCallbackData->pObjects[i].pObjectName )
       {
-        message << "\t\t\t"
-                << "objectName   = <" << pCallbackData->pObjects[i].pObjectName << ">\n";
+        message << std::string( "\t\t\t" ) << "objectName   = <" << pCallbackData->pObjects[i].pObjectName << ">\n";
       }
     }
   }

--- a/samples/EnableValidationWithCallback/EnableValidationWithCallback.cpp
+++ b/samples/EnableValidationWithCallback/EnableValidationWithCallback.cpp
@@ -38,6 +38,100 @@ static char const * EngineName = "Vulkan.hpp";
 PFN_vkCreateDebugUtilsMessengerEXT  pfnVkCreateDebugUtilsMessengerEXT;
 PFN_vkDestroyDebugUtilsMessengerEXT pfnVkDestroyDebugUtilsMessengerEXT;
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::DebugUtilsMessageSeverityFlagBitsEXT value )
+  {
+    switch ( value )
+    {
+      case vk::DebugUtilsMessageSeverityFlagBitsEXT::eVerbose: return "Verbose";
+      case vk::DebugUtilsMessageSeverityFlagBitsEXT::eInfo: return "Info";
+      case vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning: return "Warning";
+      case vk::DebugUtilsMessageSeverityFlagBitsEXT::eError: return "Error";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+
+  std::string to_string( vk::DebugUtilsMessageTypeFlagsEXT value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::DebugUtilsMessageTypeFlagBitsEXT::eGeneral )
+      result += "General | ";
+    if ( value & vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation )
+      result += "Validation | ";
+    if ( value & vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance )
+      result += "Performance | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::ObjectType value )
+  {
+    switch ( value )
+    {
+      case vk::ObjectType::eUnknown: return "Unknown";
+      case vk::ObjectType::eInstance: return "Instance";
+      case vk::ObjectType::ePhysicalDevice: return "PhysicalDevice";
+      case vk::ObjectType::eDevice: return "Device";
+      case vk::ObjectType::eQueue: return "Queue";
+      case vk::ObjectType::eSemaphore: return "Semaphore";
+      case vk::ObjectType::eCommandBuffer: return "CommandBuffer";
+      case vk::ObjectType::eFence: return "Fence";
+      case vk::ObjectType::eDeviceMemory: return "DeviceMemory";
+      case vk::ObjectType::eBuffer: return "Buffer";
+      case vk::ObjectType::eImage: return "Image";
+      case vk::ObjectType::eEvent: return "Event";
+      case vk::ObjectType::eQueryPool: return "QueryPool";
+      case vk::ObjectType::eBufferView: return "BufferView";
+      case vk::ObjectType::eImageView: return "ImageView";
+      case vk::ObjectType::eShaderModule: return "ShaderModule";
+      case vk::ObjectType::ePipelineCache: return "PipelineCache";
+      case vk::ObjectType::ePipelineLayout: return "PipelineLayout";
+      case vk::ObjectType::eRenderPass: return "RenderPass";
+      case vk::ObjectType::ePipeline: return "Pipeline";
+      case vk::ObjectType::eDescriptorSetLayout: return "DescriptorSetLayout";
+      case vk::ObjectType::eSampler: return "Sampler";
+      case vk::ObjectType::eDescriptorPool: return "DescriptorPool";
+      case vk::ObjectType::eDescriptorSet: return "DescriptorSet";
+      case vk::ObjectType::eFramebuffer: return "Framebuffer";
+      case vk::ObjectType::eCommandPool: return "CommandPool";
+      case vk::ObjectType::eSamplerYcbcrConversion: return "SamplerYcbcrConversion";
+      case vk::ObjectType::eDescriptorUpdateTemplate: return "DescriptorUpdateTemplate";
+      case vk::ObjectType::ePrivateDataSlot: return "PrivateDataSlot";
+      case vk::ObjectType::eSurfaceKHR: return "SurfaceKHR";
+      case vk::ObjectType::eSwapchainKHR: return "SwapchainKHR";
+      case vk::ObjectType::eDisplayKHR: return "DisplayKHR";
+      case vk::ObjectType::eDisplayModeKHR: return "DisplayModeKHR";
+      case vk::ObjectType::eDebugReportCallbackEXT: return "DebugReportCallbackEXT";
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
+      case vk::ObjectType::eVideoSessionKHR: return "VideoSessionKHR";
+      case vk::ObjectType::eVideoSessionParametersKHR: return "VideoSessionParametersKHR";
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
+      case vk::ObjectType::eCuModuleNVX: return "CuModuleNVX";
+      case vk::ObjectType::eCuFunctionNVX: return "CuFunctionNVX";
+      case vk::ObjectType::eDebugUtilsMessengerEXT: return "DebugUtilsMessengerEXT";
+      case vk::ObjectType::eAccelerationStructureKHR: return "AccelerationStructureKHR";
+      case vk::ObjectType::eValidationCacheEXT: return "ValidationCacheEXT";
+      case vk::ObjectType::eAccelerationStructureNV: return "AccelerationStructureNV";
+      case vk::ObjectType::ePerformanceConfigurationINTEL: return "PerformanceConfigurationINTEL";
+      case vk::ObjectType::eDeferredOperationKHR: return "DeferredOperationKHR";
+      case vk::ObjectType::eIndirectCommandsLayoutNV: return "IndirectCommandsLayoutNV";
+#  if defined( VK_USE_PLATFORM_FUCHSIA )
+      case vk::ObjectType::eBufferCollectionFUCHSIA: return "BufferCollectionFUCHSIA";
+#  endif /*VK_USE_PLATFORM_FUCHSIA*/
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
 VKAPI_ATTR VkResult VKAPI_CALL vkCreateDebugUtilsMessengerEXT( VkInstance                                 instance,
                                                                const VkDebugUtilsMessengerCreateInfoEXT * pCreateInfo,
                                                                const VkAllocationCallbacks *              pAllocator,
@@ -58,8 +152,8 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debugMessageFunc( VkDebugUtilsMessageSeverityFlag
 {
   std::string message;
 
-  message += vk::to_string( static_cast<vk::DebugUtilsMessageSeverityFlagBitsEXT>( messageSeverity ) ) + ": " +
-             vk::to_string( static_cast<vk::DebugUtilsMessageTypeFlagsEXT>( messageTypes ) ) + ":\n";
+  message += to_string( static_cast<vk::DebugUtilsMessageSeverityFlagBitsEXT>( messageSeverity ) ) + ": " +
+             to_string( static_cast<vk::DebugUtilsMessageTypeFlagsEXT>( messageTypes ) ) + ":\n";
   message += std::string( "\t" ) + "messageIDName   = <" + pCallbackData->pMessageIdName + ">\n";
   message += std::string( "\t" ) + "messageIdNumber = " + std::to_string( pCallbackData->messageIdNumber ) + "\n";
   message += std::string( "\t" ) + "message         = <" + pCallbackData->pMessage + ">\n";
@@ -84,7 +178,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debugMessageFunc( VkDebugUtilsMessageSeverityFlag
     for ( uint32_t i = 0; i < pCallbackData->objectCount; i++ )
     {
       message += std::string( "\t" ) + "Object " + std::to_string( i ) + "\n";
-      message += std::string( "\t\t" ) + "objectType   = " + vk::to_string( static_cast<vk::ObjectType>( pCallbackData->pObjects[i].objectType ) ) + "\n";
+      message += std::string( "\t\t" ) + "objectType   = " + to_string( static_cast<vk::ObjectType>( pCallbackData->pObjects[i].objectType ) ) + "\n";
       message += std::string( "\t\t" ) + "objectHandle = " + std::to_string( pCallbackData->pObjects[i].objectHandle ) + "\n";
       if ( pCallbackData->pObjects[i].pObjectName )
       {

--- a/samples/EnumerateDevicesAdvanced/EnumerateDevicesAdvanced.cpp
+++ b/samples/EnumerateDevicesAdvanced/EnumerateDevicesAdvanced.cpp
@@ -24,6 +24,27 @@
 static char const * AppName    = "EnumerateDevicesAdvanced";
 static char const * EngineName = "Vulkan.hpp";
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::PhysicalDeviceType value )
+  {
+    switch ( value )
+    {
+      case vk::PhysicalDeviceType::eOther: return "Other";
+      case vk::PhysicalDeviceType::eIntegratedGpu: return "IntegratedGpu";
+      case vk::PhysicalDeviceType::eDiscreteGpu: return "DiscreteGpu";
+      case vk::PhysicalDeviceType::eVirtualGpu: return "VirtualGpu";
+      case vk::PhysicalDeviceType::eCpu: return "Cpu";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
 int main( int /*argc*/, char ** /*argv*/ )
 {
   try
@@ -55,7 +76,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       std::cout << "deviceId: " << std::setw( 6 ) << properties.deviceID << '\n';
       std::cout << std::noshowbase << std::right << std::setfill( ' ' ) << std::dec;
 
-      std::cout << "deviceType: " << vk::to_string( properties.deviceType ) << "\n";
+      std::cout << "deviceType: " << to_string( properties.deviceType ) << "\n";
 
       std::cout << "deviceName: " << properties.deviceName << '\n';
 

--- a/samples/PhysicalDeviceMemoryProperties/PhysicalDeviceMemoryProperties.cpp
+++ b/samples/PhysicalDeviceMemoryProperties/PhysicalDeviceMemoryProperties.cpp
@@ -46,7 +46,57 @@ std::string formatSize( vk::DeviceSize size )
   return oss.str();
 }
 
-int main( int /*argc*/, char ** /*argv*/ )
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::MemoryHeapFlags value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::MemoryHeapFlagBits::eDeviceLocal )
+      result += "DeviceLocal | ";
+    if ( value & vk::MemoryHeapFlagBits::eMultiInstance )
+      result += "MultiInstance | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::MemoryPropertyFlags value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::MemoryPropertyFlagBits::eDeviceLocal )
+      result += "DeviceLocal | ";
+    if ( value & vk::MemoryPropertyFlagBits::eHostVisible )
+      result += "HostVisible | ";
+    if ( value & vk::MemoryPropertyFlagBits::eHostCoherent )
+      result += "HostCoherent | ";
+    if ( value & vk::MemoryPropertyFlagBits::eHostCached )
+      result += "HostCached | ";
+    if ( value & vk::MemoryPropertyFlagBits::eLazilyAllocated )
+      result += "LazilyAllocated | ";
+    if ( value & vk::MemoryPropertyFlagBits::eProtected )
+      result += "Protected | ";
+    if ( value & vk::MemoryPropertyFlagBits::eDeviceCoherentAMD )
+      result += "DeviceCoherentAMD | ";
+    if ( value & vk::MemoryPropertyFlagBits::eDeviceUncachedAMD )
+      result += "DeviceUncachedAMD | ";
+    if ( value & vk::MemoryPropertyFlagBits::eRdmaCapableNV )
+      result += "RdmaCapableNV | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
+  int main( int /*argc*/, char ** /*argv*/ )
 {
   try
   {
@@ -74,7 +124,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       for ( uint32_t j = 0; j < memoryProperties.memoryHeapCount; j++ )
       {
         std::cout << "  " << j << ": size = " << formatSize( memoryProperties.memoryHeaps[j].size )
-                  << ", flags = " << vk::to_string( memoryProperties.memoryHeaps[j].flags ) << "\n";
+                  << ", flags = " << to_string( memoryProperties.memoryHeaps[j].flags ) << "\n";
         if ( containsMemoryBudget )
         {
           std::cout << "     heapBudget = " << formatSize( memoryBudgetProperties.heapBudget[j] )
@@ -85,7 +135,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       for ( uint32_t j = 0; j < memoryProperties.memoryTypeCount; j++ )
       {
         std::cout << "  " << j << ": heapIndex = " << memoryProperties.memoryTypes[j].heapIndex
-                  << ", flags = " << vk::to_string( memoryProperties.memoryTypes[j].propertyFlags ) << "\n";
+                  << ", flags = " << to_string( memoryProperties.memoryTypes[j].propertyFlags ) << "\n";
       }
     }
 

--- a/samples/PhysicalDeviceProperties/PhysicalDeviceProperties.cpp
+++ b/samples/PhysicalDeviceProperties/PhysicalDeviceProperties.cpp
@@ -25,6 +25,208 @@
 static char const * AppName    = "PhysicalDeviceProperties";
 static char const * EngineName = "Vulkan.hpp";
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::DriverId value )
+  {
+    switch ( value )
+    {
+      case vk::DriverId::eAmdProprietary: return "AmdProprietary";
+      case vk::DriverId::eAmdOpenSource: return "AmdOpenSource";
+      case vk::DriverId::eMesaRadv: return "MesaRadv";
+      case vk::DriverId::eNvidiaProprietary: return "NvidiaProprietary";
+      case vk::DriverId::eIntelProprietaryWindows: return "IntelProprietaryWindows";
+      case vk::DriverId::eIntelOpenSourceMESA: return "IntelOpenSourceMESA";
+      case vk::DriverId::eImaginationProprietary: return "ImaginationProprietary";
+      case vk::DriverId::eQualcommProprietary: return "QualcommProprietary";
+      case vk::DriverId::eArmProprietary: return "ArmProprietary";
+      case vk::DriverId::eGoogleSwiftshader: return "GoogleSwiftshader";
+      case vk::DriverId::eGgpProprietary: return "GgpProprietary";
+      case vk::DriverId::eBroadcomProprietary: return "BroadcomProprietary";
+      case vk::DriverId::eMesaLlvmpipe: return "MesaLlvmpipe";
+      case vk::DriverId::eMoltenvk: return "Moltenvk";
+      case vk::DriverId::eCoreaviProprietary: return "CoreaviProprietary";
+      case vk::DriverId::eJuiceProprietary: return "JuiceProprietary";
+      case vk::DriverId::eVerisiliconProprietary: return "VerisiliconProprietary";
+      case vk::DriverId::eMesaTurnip: return "MesaTurnip";
+      case vk::DriverId::eMesaV3Dv: return "MesaV3Dv";
+      case vk::DriverId::eMesaPanvk: return "MesaPanvk";
+      case vk::DriverId::eSamsungProprietary: return "SamsungProprietary";
+      case vk::DriverId::eMesaVenus: return "MesaVenus";
+      case vk::DriverId::eMesaDozen: return "MesaDozen";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+
+  std::string to_string( vk::PhysicalDeviceType value )
+  {
+    switch ( value )
+    {
+      case vk::PhysicalDeviceType::eOther: return "Other";
+      case vk::PhysicalDeviceType::eIntegratedGpu: return "IntegratedGpu";
+      case vk::PhysicalDeviceType::eDiscreteGpu: return "DiscreteGpu";
+      case vk::PhysicalDeviceType::eVirtualGpu: return "VirtualGpu";
+      case vk::PhysicalDeviceType::eCpu: return "Cpu";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+
+  std::string to_string( vk::PointClippingBehavior value )
+  {
+    switch ( value )
+    {
+      case vk::PointClippingBehavior::eAllClipPlanes: return "AllClipPlanes";
+      case vk::PointClippingBehavior::eUserClipPlanesOnly: return "UserClipPlanesOnly";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+
+  std::string to_string( vk::ResolveModeFlags value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::ResolveModeFlagBits::eSampleZero )
+      result += "SampleZero | ";
+    if ( value & vk::ResolveModeFlagBits::eAverage )
+      result += "Average | ";
+    if ( value & vk::ResolveModeFlagBits::eMin )
+      result += "Min | ";
+    if ( value & vk::ResolveModeFlagBits::eMax )
+      result += "Max | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::SampleCountFlags value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::SampleCountFlagBits::e1 )
+      result += "1 | ";
+    if ( value & vk::SampleCountFlagBits::e2 )
+      result += "2 | ";
+    if ( value & vk::SampleCountFlagBits::e4 )
+      result += "4 | ";
+    if ( value & vk::SampleCountFlagBits::e8 )
+      result += "8 | ";
+    if ( value & vk::SampleCountFlagBits::e16 )
+      result += "16 | ";
+    if ( value & vk::SampleCountFlagBits::e32 )
+      result += "32 | ";
+    if ( value & vk::SampleCountFlagBits::e64 )
+      result += "64 | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::ShaderCorePropertiesFlagsAMD )
+  {
+    return "{}";
+  }
+
+  std::string to_string( vk::ShaderFloatControlsIndependence value )
+  {
+    switch ( value )
+    {
+      case vk::ShaderFloatControlsIndependence::e32BitOnly: return "32BitOnly";
+      case vk::ShaderFloatControlsIndependence::eAll: return "All";
+      case vk::ShaderFloatControlsIndependence::eNone: return "None";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+
+  std::string to_string( vk::ShaderStageFlags value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::ShaderStageFlagBits::eVertex )
+      result += "Vertex | ";
+    if ( value & vk::ShaderStageFlagBits::eTessellationControl )
+      result += "TessellationControl | ";
+    if ( value & vk::ShaderStageFlagBits::eTessellationEvaluation )
+      result += "TessellationEvaluation | ";
+    if ( value & vk::ShaderStageFlagBits::eGeometry )
+      result += "Geometry | ";
+    if ( value & vk::ShaderStageFlagBits::eFragment )
+      result += "Fragment | ";
+    if ( value & vk::ShaderStageFlagBits::eCompute )
+      result += "Compute | ";
+    if ( value & vk::ShaderStageFlagBits::eRaygenKHR )
+      result += "RaygenKHR | ";
+    if ( value & vk::ShaderStageFlagBits::eAnyHitKHR )
+      result += "AnyHitKHR | ";
+    if ( value & vk::ShaderStageFlagBits::eClosestHitKHR )
+      result += "ClosestHitKHR | ";
+    if ( value & vk::ShaderStageFlagBits::eMissKHR )
+      result += "MissKHR | ";
+    if ( value & vk::ShaderStageFlagBits::eIntersectionKHR )
+      result += "IntersectionKHR | ";
+    if ( value & vk::ShaderStageFlagBits::eCallableKHR )
+      result += "CallableKHR | ";
+    if ( value & vk::ShaderStageFlagBits::eTaskNV )
+      result += "TaskNV | ";
+    if ( value & vk::ShaderStageFlagBits::eMeshNV )
+      result += "MeshNV | ";
+    if ( value & vk::ShaderStageFlagBits::eSubpassShadingHUAWEI )
+      result += "SubpassShadingHUAWEI | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::SubgroupFeatureFlags value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::SubgroupFeatureFlagBits::eBasic )
+      result += "Basic | ";
+    if ( value & vk::SubgroupFeatureFlagBits::eVote )
+      result += "Vote | ";
+    if ( value & vk::SubgroupFeatureFlagBits::eArithmetic )
+      result += "Arithmetic | ";
+    if ( value & vk::SubgroupFeatureFlagBits::eBallot )
+      result += "Ballot | ";
+    if ( value & vk::SubgroupFeatureFlagBits::eShuffle )
+      result += "Shuffle | ";
+    if ( value & vk::SubgroupFeatureFlagBits::eShuffleRelative )
+      result += "ShuffleRelative | ";
+    if ( value & vk::SubgroupFeatureFlagBits::eClustered )
+      result += "Clustered | ";
+    if ( value & vk::SubgroupFeatureFlagBits::eQuad )
+      result += "Quad | ";
+    if ( value & vk::SubgroupFeatureFlagBits::ePartitionedNV )
+      result += "PartitionedNV | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::VendorId value )
+  {
+    switch ( value )
+    {
+      case vk::VendorId::eVIV: return "VIV";
+      case vk::VendorId::eVSI: return "VSI";
+      case vk::VendorId::eKazan: return "Kazan";
+      case vk::VendorId::eCodeplay: return "Codeplay";
+      case vk::VendorId::eMESA: return "MESA";
+      case vk::VendorId::ePocl: return "Pocl";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
 std::string decodeAPIVersion( uint32_t apiVersion )
 {
   return std::to_string( VK_VERSION_MAJOR( apiVersion ) ) + "." + std::to_string( VK_VERSION_MINOR( apiVersion ) ) + "." +
@@ -59,7 +261,7 @@ std::string decodeVendorID( uint32_t vendorID )
   else
   {
     // above 0x10000 should be vkVendorIDs
-    return vk::to_string( vk::VendorId( vendorID ) );
+    return to_string( vk::VendorId( vendorID ) );
   }
 }
 
@@ -153,281 +355,190 @@ int main( int /*argc*/, char ** /*argv*/ )
                                            vk::PhysicalDeviceTransformFeedbackPropertiesEXT,
                                            vk::PhysicalDeviceVertexAttributeDivisorPropertiesEXT>();
       vk::PhysicalDeviceProperties const & properties = properties2.get<vk::PhysicalDeviceProperties2>().properties;
-      std::cout << "\t"
-                << "Properties:\n";
-      std::cout << "\t\t"
-                << "apiVersion        = " << decodeAPIVersion( properties.apiVersion ) << "\n";
-      std::cout << "\t\t"
-                << "driverVersion     = " << decodeDriverVersion( properties.driverVersion, properties.vendorID ) << "\n";
-      std::cout << "\t\t"
-                << "vendorID          = " << decodeVendorID( properties.vendorID ) << "\n";
-      std::cout << "\t\t"
-                << "deviceID          = " << properties.deviceID << "\n";
-      std::cout << "\t\t"
-                << "deviceType        = " << vk::to_string( properties.deviceType ) << "\n";
-      std::cout << "\t\t"
-                << "deviceName        = " << properties.deviceName << "\n";
-      std::cout << "\t\t"
-                << "pipelineCacheUUID = " << vk::su::UUID( properties.pipelineCacheUUID ) << "\n";
-      std::cout << "\t\t"
-                << "limits:\n";
-      std::cout << "\t\t\t"
-                << "bufferImageGranularity                          = " << properties.limits.bufferImageGranularity << "\n";
-      std::cout << "\t\t\t"
-                << "discreteQueuePriorities                         = " << properties.limits.discreteQueuePriorities << "\n";
-      std::cout << "\t\t\t"
-                << "framebufferColorSampleCounts                    = " << vk::to_string( properties.limits.framebufferColorSampleCounts ) << "\n";
-      std::cout << "\t\t\t"
-                << "framebufferDepthSampleCounts                    = " << vk::to_string( properties.limits.framebufferDepthSampleCounts ) << "\n";
-      std::cout << "\t\t\t"
-                << "framebufferNoAttachmentsSampleCounts            = " << vk::to_string( properties.limits.framebufferNoAttachmentsSampleCounts ) << "\n";
-      std::cout << "\t\t\t"
-                << "framebufferStencilSampleCounts                  = " << vk::to_string( properties.limits.framebufferStencilSampleCounts ) << "\n";
-      std::cout << "\t\t\t"
-                << "lineWidthGranularity                            = " << properties.limits.lineWidthGranularity << "\n";
-      std::cout << "\t\t\t"
-                << "lineWidthRange                                  = "
+      std::cout << std::string( "\t" ) << "Properties:\n";
+      std::cout << std::string( "\t\t" ) << "apiVersion        = " << decodeAPIVersion( properties.apiVersion ) << "\n";
+      std::cout << std::string( "\t\t" ) << "driverVersion     = " << decodeDriverVersion( properties.driverVersion, properties.vendorID ) << "\n";
+      std::cout << std::string( "\t\t" ) << "vendorID          = " << decodeVendorID( properties.vendorID ) << "\n";
+      std::cout << std::string( "\t\t" ) << "deviceID          = " << properties.deviceID << "\n";
+      std::cout << std::string( "\t\t" ) << "deviceType        = " << to_string( properties.deviceType ) << "\n";
+      std::cout << std::string( "\t\t" ) << "deviceName        = " << properties.deviceName << "\n";
+      std::cout << std::string( "\t\t" ) << "pipelineCacheUUID = " << vk::su::UUID( properties.pipelineCacheUUID ) << "\n";
+      std::cout << std::string( "\t\t" ) << "limits:\n";
+      std::cout << std::string( "\t\t\t" ) << "bufferImageGranularity                          = " << properties.limits.bufferImageGranularity << "\n";
+      std::cout << std::string( "\t\t\t" ) << "discreteQueuePriorities                         = " << properties.limits.discreteQueuePriorities << "\n";
+      std::cout << std::string( "\t\t\t" )
+                << "framebufferColorSampleCounts                    = " << to_string( properties.limits.framebufferColorSampleCounts ) << "\n";
+      std::cout << std::string( "\t\t\t" )
+                << "framebufferDepthSampleCounts                    = " << to_string( properties.limits.framebufferDepthSampleCounts ) << "\n";
+      std::cout << std::string( "\t\t\t" )
+                << "framebufferNoAttachmentsSampleCounts            = " << to_string( properties.limits.framebufferNoAttachmentsSampleCounts ) << "\n";
+      std::cout << std::string( "\t\t\t" )
+                << "framebufferStencilSampleCounts                  = " << to_string( properties.limits.framebufferStencilSampleCounts ) << "\n";
+      std::cout << std::string( "\t\t\t" ) << "lineWidthGranularity                            = " << properties.limits.lineWidthGranularity << "\n";
+      std::cout << std::string( "\t\t\t" ) << "lineWidthRange                                  = "
                 << "[" << properties.limits.lineWidthRange[0] << ", " << properties.limits.lineWidthRange[1] << "]"
                 << "\n";
-      std::cout << "\t\t\t"
-                << "maxBoundDescriptorSets                          = " << properties.limits.maxBoundDescriptorSets << "\n";
-      std::cout << "\t\t\t"
-                << "maxClipDistances                                = " << properties.limits.maxClipDistances << "\n";
-      std::cout << "\t\t\t"
-                << "maxColorAttachments                             = " << properties.limits.maxColorAttachments << "\n";
-      std::cout << "\t\t\t"
-                << "maxCombinedClipAndCullDistances                 = " << properties.limits.maxCombinedClipAndCullDistances << "\n";
-      std::cout << "\t\t\t"
-                << "maxComputeSharedMemorySize                      = " << properties.limits.maxComputeSharedMemorySize << "\n";
-      std::cout << "\t\t\t"
-                << "maxComputeWorkGroupCount                        = "
+      std::cout << std::string( "\t\t\t" ) << "maxBoundDescriptorSets                          = " << properties.limits.maxBoundDescriptorSets << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxClipDistances                                = " << properties.limits.maxClipDistances << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxColorAttachments                             = " << properties.limits.maxColorAttachments << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxCombinedClipAndCullDistances                 = " << properties.limits.maxCombinedClipAndCullDistances << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxComputeSharedMemorySize                      = " << properties.limits.maxComputeSharedMemorySize << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxComputeWorkGroupCount                        = "
                 << "[" << properties.limits.maxComputeWorkGroupCount[0] << ", " << properties.limits.maxComputeWorkGroupCount[1] << ", "
                 << properties.limits.maxComputeWorkGroupCount[2] << "]"
                 << "\n";
-      std::cout << "\t\t\t"
-                << "maxComputeWorkGroupInvocations                  = " << properties.limits.maxComputeWorkGroupInvocations << "\n";
-      std::cout << "\t\t\t"
-                << "maxComputeWorkGroupSize                         = "
+      std::cout << std::string( "\t\t\t" ) << "maxComputeWorkGroupInvocations                  = " << properties.limits.maxComputeWorkGroupInvocations << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxComputeWorkGroupSize                         = "
                 << "[" << properties.limits.maxComputeWorkGroupSize[0] << ", " << properties.limits.maxComputeWorkGroupSize[1] << ", "
                 << properties.limits.maxComputeWorkGroupSize[2] << "]"
                 << "\n";
-      std::cout << "\t\t\t"
-                << "maxCullDistances                                = " << properties.limits.maxCullDistances << "\n";
-      std::cout << "\t\t\t"
-                << "maxDescriptorSetInputAttachments                = " << properties.limits.maxDescriptorSetInputAttachments << "\n";
-      std::cout << "\t\t\t"
-                << "maxDescriptorSetSampledImages                   = " << properties.limits.maxDescriptorSetSampledImages << "\n";
-      std::cout << "\t\t\t"
-                << "maxDescriptorSetSamplers                        = " << properties.limits.maxDescriptorSetSamplers << "\n";
-      std::cout << "\t\t\t"
-                << "maxDescriptorSetStorageBuffers                  = " << properties.limits.maxDescriptorSetStorageBuffers << "\n";
-      std::cout << "\t\t\t"
-                << "maxDescriptorSetStorageBuffersDynamic           = " << properties.limits.maxDescriptorSetStorageBuffersDynamic << "\n";
-      std::cout << "\t\t\t"
-                << "maxDescriptorSetStorageImages                   = " << properties.limits.maxDescriptorSetStorageImages << "\n";
-      std::cout << "\t\t\t"
-                << "maxDescriptorSetUniformBuffers                  = " << properties.limits.maxDescriptorSetUniformBuffers << "\n";
-      std::cout << "\t\t\t"
-                << "maxDescriptorSetUniformBuffersDynamic           = " << properties.limits.maxDescriptorSetUniformBuffersDynamic << "\n";
-      std::cout << "\t\t\t"
-                << "maxDrawIndexedIndexValue                        = " << properties.limits.maxDrawIndexedIndexValue << "\n";
-      std::cout << "\t\t\t"
-                << "maxDrawIndirectCount                            = " << properties.limits.maxDrawIndirectCount << "\n";
-      std::cout << "\t\t\t"
-                << "maxFragmentCombinedOutputResources              = " << properties.limits.maxFragmentCombinedOutputResources << "\n";
-      std::cout << "\t\t\t"
-                << "maxFragmentDualSrcAttachments                   = " << properties.limits.maxFragmentDualSrcAttachments << "\n";
-      std::cout << "\t\t\t"
-                << "maxFragmentInputComponents                      = " << properties.limits.maxFragmentInputComponents << "\n";
-      std::cout << "\t\t\t"
-                << "maxFragmentOutputAttachments                    = " << properties.limits.maxFragmentOutputAttachments << "\n";
-      std::cout << "\t\t\t"
-                << "maxFramebufferHeight                            = " << properties.limits.maxFramebufferHeight << "\n";
-      std::cout << "\t\t\t"
-                << "maxFramebufferLayers                            = " << properties.limits.maxFramebufferLayers << "\n";
-      std::cout << "\t\t\t"
-                << "maxFramebufferWidth                             = " << properties.limits.maxFramebufferWidth << "\n";
-      std::cout << "\t\t\t"
-                << "maxGeometryInputComponents                      = " << properties.limits.maxGeometryInputComponents << "\n";
-      std::cout << "\t\t\t"
-                << "maxGeometryOutputComponents                     = " << properties.limits.maxGeometryOutputComponents << "\n";
-      std::cout << "\t\t\t"
-                << "maxGeometryOutputVertices                       = " << properties.limits.maxGeometryOutputVertices << "\n";
-      std::cout << "\t\t\t"
-                << "maxGeometryShaderInvocations                    = " << properties.limits.maxGeometryShaderInvocations << "\n";
-      std::cout << "\t\t\t"
-                << "maxGeometryTotalOutputComponents                = " << properties.limits.maxGeometryTotalOutputComponents << "\n";
-      std::cout << "\t\t\t"
-                << "maxImageArrayLayers                             = " << properties.limits.maxImageArrayLayers << "\n";
-      std::cout << "\t\t\t"
-                << "maxImageDimension1D                             = " << properties.limits.maxImageDimension1D << "\n";
-      std::cout << "\t\t\t"
-                << "maxImageDimension2D                             = " << properties.limits.maxImageDimension2D << "\n";
-      std::cout << "\t\t\t"
-                << "maxImageDimension3D                             = " << properties.limits.maxImageDimension3D << "\n";
-      std::cout << "\t\t\t"
-                << "maxImageDimensionCube                           = " << properties.limits.maxImageDimensionCube << "\n";
-      std::cout << "\t\t\t"
-                << "maxInterpolationOffset                          = " << properties.limits.maxInterpolationOffset << "\n";
-      std::cout << "\t\t\t"
-                << "maxMemoryAllocationCount                        = " << properties.limits.maxMemoryAllocationCount << "\n";
-      std::cout << "\t\t\t"
-                << "maxPerStageDescriptorInputAttachments           = " << properties.limits.maxPerStageDescriptorInputAttachments << "\n";
-      std::cout << "\t\t\t"
-                << "maxPerStageDescriptorSampledImages              = " << properties.limits.maxPerStageDescriptorSampledImages << "\n";
-      std::cout << "\t\t\t"
-                << "maxPerStageDescriptorSamplers                   = " << properties.limits.maxPerStageDescriptorSamplers << "\n";
-      std::cout << "\t\t\t"
-                << "maxPerStageDescriptorStorageBuffers             = " << properties.limits.maxPerStageDescriptorStorageBuffers << "\n";
-      std::cout << "\t\t\t"
-                << "maxPerStageDescriptorStorageImages              = " << properties.limits.maxPerStageDescriptorStorageImages << "\n";
-      std::cout << "\t\t\t"
-                << "maxPerStageDescriptorUniformBuffers             = " << properties.limits.maxPerStageDescriptorUniformBuffers << "\n";
-      std::cout << "\t\t\t"
-                << "maxPerStageResources                            = " << properties.limits.maxPerStageResources << "\n";
-      std::cout << "\t\t\t"
-                << "maxPushConstantsSize                            = " << properties.limits.maxPushConstantsSize << "\n";
-      std::cout << "\t\t\t"
-                << "maxSampleMaskWords                              = " << properties.limits.maxSampleMaskWords << "\n";
-      std::cout << "\t\t\t"
-                << "maxSamplerAllocationCount                       = " << properties.limits.maxSamplerAllocationCount << "\n";
-      std::cout << "\t\t\t"
-                << "maxSamplerAnisotropy                            = " << properties.limits.maxSamplerAnisotropy << "\n";
-      std::cout << "\t\t\t"
-                << "maxSamplerLodBias                               = " << properties.limits.maxSamplerLodBias << "\n";
-      std::cout << "\t\t\t"
-                << "maxStorageBufferRange                           = " << properties.limits.maxStorageBufferRange << "\n";
-      std::cout << "\t\t\t"
+      std::cout << std::string( "\t\t\t" ) << "maxCullDistances                                = " << properties.limits.maxCullDistances << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDescriptorSetInputAttachments                = " << properties.limits.maxDescriptorSetInputAttachments
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDescriptorSetSampledImages                   = " << properties.limits.maxDescriptorSetSampledImages << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDescriptorSetSamplers                        = " << properties.limits.maxDescriptorSetSamplers << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDescriptorSetStorageBuffers                  = " << properties.limits.maxDescriptorSetStorageBuffers << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDescriptorSetStorageBuffersDynamic           = " << properties.limits.maxDescriptorSetStorageBuffersDynamic
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDescriptorSetStorageImages                   = " << properties.limits.maxDescriptorSetStorageImages << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDescriptorSetUniformBuffers                  = " << properties.limits.maxDescriptorSetUniformBuffers << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDescriptorSetUniformBuffersDynamic           = " << properties.limits.maxDescriptorSetUniformBuffersDynamic
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDrawIndexedIndexValue                        = " << properties.limits.maxDrawIndexedIndexValue << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxDrawIndirectCount                            = " << properties.limits.maxDrawIndirectCount << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxFragmentCombinedOutputResources              = " << properties.limits.maxFragmentCombinedOutputResources
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxFragmentDualSrcAttachments                   = " << properties.limits.maxFragmentDualSrcAttachments << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxFragmentInputComponents                      = " << properties.limits.maxFragmentInputComponents << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxFragmentOutputAttachments                    = " << properties.limits.maxFragmentOutputAttachments << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxFramebufferHeight                            = " << properties.limits.maxFramebufferHeight << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxFramebufferLayers                            = " << properties.limits.maxFramebufferLayers << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxFramebufferWidth                             = " << properties.limits.maxFramebufferWidth << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxGeometryInputComponents                      = " << properties.limits.maxGeometryInputComponents << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxGeometryOutputComponents                     = " << properties.limits.maxGeometryOutputComponents << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxGeometryOutputVertices                       = " << properties.limits.maxGeometryOutputVertices << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxGeometryShaderInvocations                    = " << properties.limits.maxGeometryShaderInvocations << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxGeometryTotalOutputComponents                = " << properties.limits.maxGeometryTotalOutputComponents
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxImageArrayLayers                             = " << properties.limits.maxImageArrayLayers << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxImageDimension1D                             = " << properties.limits.maxImageDimension1D << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxImageDimension2D                             = " << properties.limits.maxImageDimension2D << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxImageDimension3D                             = " << properties.limits.maxImageDimension3D << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxImageDimensionCube                           = " << properties.limits.maxImageDimensionCube << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxInterpolationOffset                          = " << properties.limits.maxInterpolationOffset << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxMemoryAllocationCount                        = " << properties.limits.maxMemoryAllocationCount << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxPerStageDescriptorInputAttachments           = " << properties.limits.maxPerStageDescriptorInputAttachments
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxPerStageDescriptorSampledImages              = " << properties.limits.maxPerStageDescriptorSampledImages
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxPerStageDescriptorSamplers                   = " << properties.limits.maxPerStageDescriptorSamplers << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxPerStageDescriptorStorageBuffers             = " << properties.limits.maxPerStageDescriptorStorageBuffers
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxPerStageDescriptorStorageImages              = " << properties.limits.maxPerStageDescriptorStorageImages
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxPerStageDescriptorUniformBuffers             = " << properties.limits.maxPerStageDescriptorUniformBuffers
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxPerStageResources                            = " << properties.limits.maxPerStageResources << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxPushConstantsSize                            = " << properties.limits.maxPushConstantsSize << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxSampleMaskWords                              = " << properties.limits.maxSampleMaskWords << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxSamplerAllocationCount                       = " << properties.limits.maxSamplerAllocationCount << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxSamplerAnisotropy                            = " << properties.limits.maxSamplerAnisotropy << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxSamplerLodBias                               = " << properties.limits.maxSamplerLodBias << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxStorageBufferRange                           = " << properties.limits.maxStorageBufferRange << "\n";
+      std::cout << std::string( "\t\t\t" )
                 << "maxTessellationControlPerPatchOutputComponents  = " << properties.limits.maxTessellationControlPerPatchOutputComponents << "\n";
-      std::cout << "\t\t\t"
+      std::cout << std::string( "\t\t\t" )
                 << "maxTessellationControlPerVertexInputComponents  = " << properties.limits.maxTessellationControlPerVertexInputComponents << "\n";
-      std::cout << "\t\t\t"
+      std::cout << std::string( "\t\t\t" )
                 << "maxTessellationControlPerVertexOutputComponents = " << properties.limits.maxTessellationControlPerVertexOutputComponents << "\n";
-      std::cout << "\t\t\t"
+      std::cout << std::string( "\t\t\t" )
                 << "maxTessellationControlTotalOutputComponents     = " << properties.limits.maxTessellationControlTotalOutputComponents << "\n";
-      std::cout << "\t\t\t"
-                << "maxTessellationEvaluationInputComponents        = " << properties.limits.maxTessellationEvaluationInputComponents << "\n";
-      std::cout << "\t\t\t"
+      std::cout << std::string( "\t\t\t" ) << "maxTessellationEvaluationInputComponents        = " << properties.limits.maxTessellationEvaluationInputComponents
+                << "\n";
+      std::cout << std::string( "\t\t\t" )
                 << "maxTessellationEvaluationOutputComponents       = " << properties.limits.maxTessellationEvaluationOutputComponents << "\n";
-      std::cout << "\t\t\t"
-                << "maxTessellationGenerationLevel                  = " << properties.limits.maxTessellationGenerationLevel << "\n";
-      std::cout << "\t\t\t"
-                << "maxTessellationPatchSize                        = " << properties.limits.maxTessellationPatchSize << "\n";
-      std::cout << "\t\t\t"
-                << "maxTexelBufferElements                          = " << properties.limits.maxTexelBufferElements << "\n";
-      std::cout << "\t\t\t"
-                << "maxTexelGatherOffset                            = " << properties.limits.maxTexelGatherOffset << "\n";
-      std::cout << "\t\t\t"
-                << "maxTexelOffset                                  = " << properties.limits.maxTexelOffset << "\n";
-      std::cout << "\t\t\t"
-                << "maxUniformBufferRange                           = " << properties.limits.maxUniformBufferRange << "\n";
-      std::cout << "\t\t\t"
-                << "maxVertexInputAttributeOffset                   = " << properties.limits.maxVertexInputAttributeOffset << "\n";
-      std::cout << "\t\t\t"
-                << "maxVertexInputAttributes                        = " << properties.limits.maxVertexInputAttributes << "\n";
-      std::cout << "\t\t\t"
-                << "maxVertexInputBindings                          = " << properties.limits.maxVertexInputBindings << "\n";
-      std::cout << "\t\t\t"
-                << "maxVertexInputBindingStride                     = " << properties.limits.maxVertexInputBindingStride << "\n";
-      std::cout << "\t\t\t"
-                << "maxVertexOutputComponents                       = " << properties.limits.maxVertexOutputComponents << "\n";
-      std::cout << "\t\t\t"
-                << "maxViewportDimensions                           = "
+      std::cout << std::string( "\t\t\t" ) << "maxTessellationGenerationLevel                  = " << properties.limits.maxTessellationGenerationLevel << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxTessellationPatchSize                        = " << properties.limits.maxTessellationPatchSize << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxTexelBufferElements                          = " << properties.limits.maxTexelBufferElements << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxTexelGatherOffset                            = " << properties.limits.maxTexelGatherOffset << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxTexelOffset                                  = " << properties.limits.maxTexelOffset << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxUniformBufferRange                           = " << properties.limits.maxUniformBufferRange << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxVertexInputAttributeOffset                   = " << properties.limits.maxVertexInputAttributeOffset << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxVertexInputAttributes                        = " << properties.limits.maxVertexInputAttributes << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxVertexInputBindings                          = " << properties.limits.maxVertexInputBindings << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxVertexInputBindingStride                     = " << properties.limits.maxVertexInputBindingStride << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxVertexOutputComponents                       = " << properties.limits.maxVertexOutputComponents << "\n";
+      std::cout << std::string( "\t\t\t" ) << "maxViewportDimensions                           = "
                 << "[" << properties.limits.maxViewportDimensions[0] << ", " << properties.limits.maxViewportDimensions[1] << "]"
                 << "\n";
-      std::cout << "\t\t\t"
-                << "maxViewports                                    = " << properties.limits.maxViewports << "\n";
-      std::cout << "\t\t\t"
-                << "minInterpolationOffset                          = " << properties.limits.minInterpolationOffset << "\n";
-      std::cout << "\t\t\t"
-                << "minMemoryMapAlignment                           = " << properties.limits.minMemoryMapAlignment << "\n";
-      std::cout << "\t\t\t"
-                << "minStorageBufferOffsetAlignment                 = " << properties.limits.minStorageBufferOffsetAlignment << "\n";
-      std::cout << "\t\t\t"
-                << "minTexelBufferOffsetAlignment                   = " << properties.limits.minTexelBufferOffsetAlignment << "\n";
-      std::cout << "\t\t\t"
-                << "minTexelGatherOffset                            = " << properties.limits.minTexelGatherOffset << "\n";
-      std::cout << "\t\t\t"
-                << "minTexelOffset                                  = " << properties.limits.minTexelOffset << "\n";
-      std::cout << "\t\t\t"
-                << "minUniformBufferOffsetAlignment                 = " << properties.limits.minUniformBufferOffsetAlignment << "\n";
-      std::cout << "\t\t\t"
-                << "mipmapPrecisionBits                             = " << properties.limits.mipmapPrecisionBits << "\n";
-      std::cout << "\t\t\t"
-                << "nonCoherentAtomSize                             = " << properties.limits.nonCoherentAtomSize << "\n";
-      std::cout << "\t\t\t"
-                << "optimalBufferCopyOffsetAlignment                = " << properties.limits.optimalBufferCopyOffsetAlignment << "\n";
-      std::cout << "\t\t\t"
-                << "optimalBufferCopyRowPitchAlignment              = " << properties.limits.optimalBufferCopyRowPitchAlignment << "\n";
-      std::cout << "\t\t\t"
-                << "pointSizeGranularity                            = " << properties.limits.pointSizeGranularity << "\n";
-      std::cout << "\t\t\t"
-                << "pointSizeRange                                  = "
+      std::cout << std::string( "\t\t\t" ) << "maxViewports                                    = " << properties.limits.maxViewports << "\n";
+      std::cout << std::string( "\t\t\t" ) << "minInterpolationOffset                          = " << properties.limits.minInterpolationOffset << "\n";
+      std::cout << std::string( "\t\t\t" ) << "minMemoryMapAlignment                           = " << properties.limits.minMemoryMapAlignment << "\n";
+      std::cout << std::string( "\t\t\t" ) << "minStorageBufferOffsetAlignment                 = " << properties.limits.minStorageBufferOffsetAlignment << "\n";
+      std::cout << std::string( "\t\t\t" ) << "minTexelBufferOffsetAlignment                   = " << properties.limits.minTexelBufferOffsetAlignment << "\n";
+      std::cout << std::string( "\t\t\t" ) << "minTexelGatherOffset                            = " << properties.limits.minTexelGatherOffset << "\n";
+      std::cout << std::string( "\t\t\t" ) << "minTexelOffset                                  = " << properties.limits.minTexelOffset << "\n";
+      std::cout << std::string( "\t\t\t" ) << "minUniformBufferOffsetAlignment                 = " << properties.limits.minUniformBufferOffsetAlignment << "\n";
+      std::cout << std::string( "\t\t\t" ) << "mipmapPrecisionBits                             = " << properties.limits.mipmapPrecisionBits << "\n";
+      std::cout << std::string( "\t\t\t" ) << "nonCoherentAtomSize                             = " << properties.limits.nonCoherentAtomSize << "\n";
+      std::cout << std::string( "\t\t\t" ) << "optimalBufferCopyOffsetAlignment                = " << properties.limits.optimalBufferCopyOffsetAlignment
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "optimalBufferCopyRowPitchAlignment              = " << properties.limits.optimalBufferCopyRowPitchAlignment
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "pointSizeGranularity                            = " << properties.limits.pointSizeGranularity << "\n";
+      std::cout << std::string( "\t\t\t" ) << "pointSizeRange                                  = "
                 << "[" << properties.limits.pointSizeRange[0] << ", " << properties.limits.pointSizeRange[1] << "]"
                 << "\n";
-      std::cout << "\t\t\t"
-                << "sampledImageColorSampleCounts                   = " << vk::to_string( properties.limits.sampledImageColorSampleCounts ) << "\n";
-      std::cout << "\t\t\t"
-                << "sampledImageDepthSampleCounts                   = " << vk::to_string( properties.limits.sampledImageDepthSampleCounts ) << "\n";
-      std::cout << "\t\t\t"
-                << "sampledImageIntegerSampleCounts                 = " << vk::to_string( properties.limits.sampledImageIntegerSampleCounts ) << "\n";
-      std::cout << "\t\t\t"
-                << "sampledImageStencilSampleCounts                 = " << vk::to_string( properties.limits.sampledImageStencilSampleCounts ) << "\n";
-      std::cout << "\t\t\t"
-                << "sparseAddressSpaceSize                          = " << properties.limits.sparseAddressSpaceSize << "\n";
-      std::cout << "\t\t\t"
-                << "standardSampleLocations                         = " << !!properties.limits.standardSampleLocations << "\n";
-      std::cout << "\t\t\t"
-                << "storageImageSampleCounts                        = " << vk::to_string( properties.limits.storageImageSampleCounts ) << "\n";
-      std::cout << "\t\t\t"
-                << "strictLines                                     = " << !!properties.limits.strictLines << "\n";
-      std::cout << "\t\t\t"
-                << "subPixelInterpolationOffsetBits                 = " << properties.limits.subPixelInterpolationOffsetBits << "\n";
-      std::cout << "\t\t\t"
-                << "subPixelPrecisionBits                           = " << properties.limits.subPixelPrecisionBits << "\n";
-      std::cout << "\t\t\t"
-                << "subTexelPrecisionBits                           = " << properties.limits.subTexelPrecisionBits << "\n";
-      std::cout << "\t\t\t"
-                << "timestampComputeAndGraphics                     = " << !!properties.limits.timestampComputeAndGraphics << "\n";
-      std::cout << "\t\t\t"
-                << "timestampPeriod                                 = " << properties.limits.timestampPeriod << "\n";
-      std::cout << "\t\t\t"
-                << "viewportBoundsRange                             = "
+      std::cout << std::string( "\t\t\t" )
+                << "sampledImageColorSampleCounts                   = " << to_string( properties.limits.sampledImageColorSampleCounts ) << "\n";
+      std::cout << std::string( "\t\t\t" )
+                << "sampledImageDepthSampleCounts                   = " << to_string( properties.limits.sampledImageDepthSampleCounts ) << "\n";
+      std::cout << std::string( "\t\t\t" )
+                << "sampledImageIntegerSampleCounts                 = " << to_string( properties.limits.sampledImageIntegerSampleCounts ) << "\n";
+      std::cout << std::string( "\t\t\t" )
+                << "sampledImageStencilSampleCounts                 = " << to_string( properties.limits.sampledImageStencilSampleCounts ) << "\n";
+      std::cout << std::string( "\t\t\t" ) << "sparseAddressSpaceSize                          = " << properties.limits.sparseAddressSpaceSize << "\n";
+      std::cout << std::string( "\t\t\t" ) << "standardSampleLocations                         = " << !!properties.limits.standardSampleLocations << "\n";
+      std::cout << std::string( "\t\t\t" ) << "storageImageSampleCounts                        = " << to_string( properties.limits.storageImageSampleCounts )
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "strictLines                                     = " << !!properties.limits.strictLines << "\n";
+      std::cout << std::string( "\t\t\t" ) << "subPixelInterpolationOffsetBits                 = " << properties.limits.subPixelInterpolationOffsetBits << "\n";
+      std::cout << std::string( "\t\t\t" ) << "subPixelPrecisionBits                           = " << properties.limits.subPixelPrecisionBits << "\n";
+      std::cout << std::string( "\t\t\t" ) << "subTexelPrecisionBits                           = " << properties.limits.subTexelPrecisionBits << "\n";
+      std::cout << std::string( "\t\t\t" ) << "timestampComputeAndGraphics                     = " << !!properties.limits.timestampComputeAndGraphics << "\n";
+      std::cout << std::string( "\t\t\t" ) << "timestampPeriod                                 = " << properties.limits.timestampPeriod << "\n";
+      std::cout << std::string( "\t\t\t" ) << "viewportBoundsRange                             = "
                 << "[" << properties.limits.viewportBoundsRange[0] << ", " << properties.limits.viewportBoundsRange[1] << "]"
                 << "\n";
-      std::cout << "\t\t\t"
-                << "viewportSubPixelBits                            = " << properties.limits.viewportSubPixelBits << "\n";
-      std::cout << "\t\t"
-                << "sparseProperties:\n";
-      std::cout << "\t\t\t"
-                << "residencyAlignedMipSize                   = " << !!properties.sparseProperties.residencyAlignedMipSize << "\n";
-      std::cout << "\t\t\t"
-                << "residencyNonResidentStrict                = " << !!properties.sparseProperties.residencyNonResidentStrict << "\n";
-      std::cout << "\t\t\t"
-                << "residencyStandard2DBlockShape             = " << !!properties.sparseProperties.residencyStandard2DBlockShape << "\n";
-      std::cout << "\t\t\t"
+      std::cout << std::string( "\t\t\t" ) << "viewportSubPixelBits                            = " << properties.limits.viewportSubPixelBits << "\n";
+      std::cout << std::string( "\t\t" ) << "sparseProperties:\n";
+      std::cout << std::string( "\t\t\t" ) << "residencyAlignedMipSize                   = " << !!properties.sparseProperties.residencyAlignedMipSize << "\n";
+      std::cout << std::string( "\t\t\t" ) << "residencyNonResidentStrict                = " << !!properties.sparseProperties.residencyNonResidentStrict
+                << "\n";
+      std::cout << std::string( "\t\t\t" ) << "residencyStandard2DBlockShape             = " << !!properties.sparseProperties.residencyStandard2DBlockShape
+                << "\n";
+      std::cout << std::string( "\t\t\t" )
                 << "residencyStandard2DMultisampleBlockShape  = " << !!properties.sparseProperties.residencyStandard2DMultisampleBlockShape << "\n";
-      std::cout << "\t\t\t"
-                << "residencyStandard3DBlockShape             = " << !!properties.sparseProperties.residencyStandard3DBlockShape << "\n";
+      std::cout << std::string( "\t\t\t" ) << "residencyStandard3DBlockShape             = " << !!properties.sparseProperties.residencyStandard3DBlockShape
+                << "\n";
       std::cout << "\n";
 
       if ( vk::su::contains( extensionProperties, "VK_EXT_blend_operation_advanced" ) )
       {
         vk::PhysicalDeviceBlendOperationAdvancedPropertiesEXT const & blendOperationAdvancedProperties =
           properties2.get<vk::PhysicalDeviceBlendOperationAdvancedPropertiesEXT>();
-        std::cout << "\t"
-                  << "BlendOperationAdvancedProperties:\n";
-        std::cout << "\t\t"
-                  << "advancedBlendAllOperations            = " << !!blendOperationAdvancedProperties.advancedBlendAllOperations << "\n";
-        std::cout << "\t\t"
-                  << "advancedBlendCorrelatedOverlap        = " << !!blendOperationAdvancedProperties.advancedBlendCorrelatedOverlap << "\n";
-        std::cout << "\t\t"
-                  << "advancedBlendIndependentBlend         = " << !!blendOperationAdvancedProperties.advancedBlendIndependentBlend << "\n";
-        std::cout << "\t\t"
-                  << "advancedBlendMaxColorAttachments      = " << blendOperationAdvancedProperties.advancedBlendMaxColorAttachments << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t" ) << "BlendOperationAdvancedProperties:\n";
+        std::cout << std::string( "\t\t" ) << "advancedBlendAllOperations            = " << !!blendOperationAdvancedProperties.advancedBlendAllOperations
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "advancedBlendCorrelatedOverlap        = " << !!blendOperationAdvancedProperties.advancedBlendCorrelatedOverlap
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "advancedBlendIndependentBlend         = " << !!blendOperationAdvancedProperties.advancedBlendIndependentBlend
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "advancedBlendMaxColorAttachments      = " << blendOperationAdvancedProperties.advancedBlendMaxColorAttachments
+                  << "\n";
+        std::cout << std::string( "\t\t" )
                   << "advancedBlendNonPremultipliedDstColor = " << !!blendOperationAdvancedProperties.advancedBlendNonPremultipliedDstColor << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "advancedBlendNonPremultipliedSrcColor = " << !!blendOperationAdvancedProperties.advancedBlendNonPremultipliedSrcColor << "\n";
         std::cout << "\n";
       }
@@ -436,28 +547,27 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceConservativeRasterizationPropertiesEXT const & conservativeRasterizationProperties =
           properties2.get<vk::PhysicalDeviceConservativeRasterizationPropertiesEXT>();
-        std::cout << "\t"
-                  << "ConservativeRasterizationProperties:\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t" ) << "ConservativeRasterizationProperties:\n";
+        std::cout << std::string( "\t\t" )
                   << "conservativePointAndLineRasterization       = " << !!conservativeRasterizationProperties.conservativePointAndLineRasterization << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "conservativeRasterizationPostDepthCoverage  = " << !!conservativeRasterizationProperties.conservativeRasterizationPostDepthCoverage
                   << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "degenerateLinesRasterized                   = " << !!conservativeRasterizationProperties.degenerateLinesRasterized << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "degenerateTrianglesRasterized               = " << !!conservativeRasterizationProperties.degenerateTrianglesRasterized << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "extraPrimitiveOverestimationSizeGranularity = " << conservativeRasterizationProperties.extraPrimitiveOverestimationSizeGranularity
                   << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "fullyCoveredFragmentShaderInputVariable     = " << !!conservativeRasterizationProperties.fullyCoveredFragmentShaderInputVariable << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxExtraPrimitiveOverestimationSize         = " << conservativeRasterizationProperties.maxExtraPrimitiveOverestimationSize << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "primitiveOverestimationSize                 = " << conservativeRasterizationProperties.primitiveOverestimationSize << "\n";
-        std::cout << "\t\t"
-                  << "primitiveUnderestimation                    = " << !!conservativeRasterizationProperties.primitiveUnderestimation << "\n";
+        std::cout << std::string( "\t\t" ) << "primitiveUnderestimation                    = " << !!conservativeRasterizationProperties.primitiveUnderestimation
+                  << "\n";
         std::cout << "\n";
       }
 
@@ -465,10 +575,9 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceCooperativeMatrixPropertiesNV const & cooperativeMatrixProperties =
           properties2.get<vk::PhysicalDeviceCooperativeMatrixPropertiesNV>();
-        std::cout << "\t"
-                  << "CooperativeMatrixProperties:\n";
-        std::cout << "\t\t"
-                  << "cooperativeMatrixSupportedStages  = " << vk::to_string( cooperativeMatrixProperties.cooperativeMatrixSupportedStages ) << "\n";
+        std::cout << std::string( "\t" ) << "CooperativeMatrixProperties:\n";
+        std::cout << std::string( "\t\t" )
+                  << "cooperativeMatrixSupportedStages  = " << to_string( cooperativeMatrixProperties.cooperativeMatrixSupportedStages ) << "\n";
         std::cout << "\n";
       }
 
@@ -476,16 +585,13 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceDepthStencilResolvePropertiesKHR const & depthStencilResolveProperties =
           properties2.get<vk::PhysicalDeviceDepthStencilResolvePropertiesKHR>();
-        std::cout << "\t"
-                  << "DepthStencilResolveProperties:\n";
-        std::cout << "\t\t"
-                  << "independentResolve            = " << !!depthStencilResolveProperties.independentResolve << "\n";
-        std::cout << "\t\t"
-                  << "independentResolveNone        = " << !!depthStencilResolveProperties.independentResolveNone << "\n";
-        std::cout << "\t\t"
-                  << "supportedDepthResolveModes    = " << vk::to_string( depthStencilResolveProperties.supportedDepthResolveModes ) << "\n";
-        std::cout << "\t\t"
-                  << "supportedStencilResolveModes  = " << vk::to_string( depthStencilResolveProperties.supportedStencilResolveModes ) << "\n";
+        std::cout << std::string( "\t" ) << "DepthStencilResolveProperties:\n";
+        std::cout << std::string( "\t\t" ) << "independentResolve            = " << !!depthStencilResolveProperties.independentResolve << "\n";
+        std::cout << std::string( "\t\t" ) << "independentResolveNone        = " << !!depthStencilResolveProperties.independentResolveNone << "\n";
+        std::cout << std::string( "\t\t" ) << "supportedDepthResolveModes    = " << to_string( depthStencilResolveProperties.supportedDepthResolveModes )
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "supportedStencilResolveModes  = " << to_string( depthStencilResolveProperties.supportedStencilResolveModes )
+                  << "\n";
         std::cout << "\n";
       }
 
@@ -493,71 +599,58 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceDescriptorIndexingPropertiesEXT const & descriptorIndexingProperties =
           properties2.get<vk::PhysicalDeviceDescriptorIndexingPropertiesEXT>();
-        std::cout << "\t"
-                  << "DescriptorIndexingProperties:\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t" ) << "DescriptorIndexingProperties:\n";
+        std::cout << std::string( "\t\t" )
                   << "maxDescriptorSetUpdateAfterBindInputAttachments       = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindInputAttachments
                   << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxDescriptorSetUpdateAfterBindSampledImages          = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindSampledImages
                   << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxDescriptorSetUpdateAfterBindSamplers               = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindSamplers << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxDescriptorSetUpdateAfterBindStorageBuffers         = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindStorageBuffers
                   << "\n";
-        std::cout << "\t\t"
-                  << "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic  = "
+        std::cout << std::string( "\t\t" ) << "maxDescriptorSetUpdateAfterBindStorageBuffersDynamic  = "
                   << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindStorageBuffersDynamic << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxDescriptorSetUpdateAfterBindStorageImages          = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindStorageImages
                   << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxDescriptorSetUpdateAfterBindUniformBuffers         = " << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindUniformBuffers
                   << "\n";
-        std::cout << "\t\t"
-                  << "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic  = "
+        std::cout << std::string( "\t\t" ) << "maxDescriptorSetUpdateAfterBindUniformBuffersDynamic  = "
                   << descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindUniformBuffersDynamic << "\n";
-        std::cout << "\t\t"
-                  << "maxPerStageDescriptorUpdateAfterBindInputAttachments  = "
+        std::cout << std::string( "\t\t" ) << "maxPerStageDescriptorUpdateAfterBindInputAttachments  = "
                   << descriptorIndexingProperties.maxPerStageDescriptorUpdateAfterBindInputAttachments << "\n";
-        std::cout << "\t\t"
-                  << "maxPerStageDescriptorUpdateAfterBindSampledImages     = "
+        std::cout << std::string( "\t\t" ) << "maxPerStageDescriptorUpdateAfterBindSampledImages     = "
                   << descriptorIndexingProperties.maxPerStageDescriptorUpdateAfterBindSampledImages << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxPerStageDescriptorUpdateAfterBindSamplers          = " << descriptorIndexingProperties.maxPerStageDescriptorUpdateAfterBindSamplers
                   << "\n";
-        std::cout << "\t\t"
-                  << "maxPerStageDescriptorUpdateAfterBindStorageBuffers    = "
+        std::cout << std::string( "\t\t" ) << "maxPerStageDescriptorUpdateAfterBindStorageBuffers    = "
                   << descriptorIndexingProperties.maxPerStageDescriptorUpdateAfterBindStorageBuffers << "\n";
-        std::cout << "\t\t"
-                  << "maxPerStageDescriptorUpdateAfterBindStorageImages     = "
+        std::cout << std::string( "\t\t" ) << "maxPerStageDescriptorUpdateAfterBindStorageImages     = "
                   << descriptorIndexingProperties.maxPerStageDescriptorUpdateAfterBindStorageImages << "\n";
-        std::cout << "\t\t"
-                  << "maxPerStageDescriptorUpdateAfterBindUniformBuffers    = "
+        std::cout << std::string( "\t\t" ) << "maxPerStageDescriptorUpdateAfterBindUniformBuffers    = "
                   << descriptorIndexingProperties.maxPerStageDescriptorUpdateAfterBindUniformBuffers << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxPerStageUpdateAfterBindResources                   = " << descriptorIndexingProperties.maxPerStageUpdateAfterBindResources << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxUpdateAfterBindDescriptorsInAllPools               = " << descriptorIndexingProperties.maxUpdateAfterBindDescriptorsInAllPools << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "quadDivergentImplicitLod                              = " << !!descriptorIndexingProperties.quadDivergentImplicitLod << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "robustBufferAccessUpdateAfterBind                     = " << !!descriptorIndexingProperties.robustBufferAccessUpdateAfterBind << "\n";
-        std::cout << "\t\t"
-                  << "shaderInputAttachmentArrayNonUniformIndexingNative    = "
+        std::cout << std::string( "\t\t" ) << "shaderInputAttachmentArrayNonUniformIndexingNative    = "
                   << !!descriptorIndexingProperties.shaderInputAttachmentArrayNonUniformIndexingNative << "\n";
-        std::cout << "\t\t"
-                  << "shaderSampledImageArrayNonUniformIndexingNative       = "
+        std::cout << std::string( "\t\t" ) << "shaderSampledImageArrayNonUniformIndexingNative       = "
                   << !!descriptorIndexingProperties.shaderSampledImageArrayNonUniformIndexingNative << "\n";
-        std::cout << "\t\t"
-                  << "shaderStorageBufferArrayNonUniformIndexingNative      = "
+        std::cout << std::string( "\t\t" ) << "shaderStorageBufferArrayNonUniformIndexingNative      = "
                   << !!descriptorIndexingProperties.shaderStorageBufferArrayNonUniformIndexingNative << "\n";
-        std::cout << "\t\t"
-                  << "shaderStorageImageArrayNonUniformIndexingNative       = "
+        std::cout << std::string( "\t\t" ) << "shaderStorageImageArrayNonUniformIndexingNative       = "
                   << !!descriptorIndexingProperties.shaderStorageImageArrayNonUniformIndexingNative << "\n";
-        std::cout << "\t\t"
-                  << "shaderUniformBufferArrayNonUniformIndexingNative      = "
+        std::cout << std::string( "\t\t" ) << "shaderUniformBufferArrayNonUniformIndexingNative      = "
                   << !!descriptorIndexingProperties.shaderUniformBufferArrayNonUniformIndexingNative << "\n";
         std::cout << "\n";
       }
@@ -565,26 +658,19 @@ int main( int /*argc*/, char ** /*argv*/ )
       if ( vk::su::contains( extensionProperties, "VK_EXT_discard_rectangles" ) )
       {
         vk::PhysicalDeviceDiscardRectanglePropertiesEXT const & discardRectangleProperties = properties2.get<vk::PhysicalDeviceDiscardRectanglePropertiesEXT>();
-        std::cout << "\t"
-                  << "DiscardRectangleProperties:\n";
-        std::cout << "\t\t"
-                  << "maxDiscardRectangles  = " << discardRectangleProperties.maxDiscardRectangles << "\n";
+        std::cout << std::string( "\t" ) << "DiscardRectangleProperties:\n";
+        std::cout << std::string( "\t\t" ) << "maxDiscardRectangles  = " << discardRectangleProperties.maxDiscardRectangles << "\n";
         std::cout << "\n";
       }
 
       if ( vk::su::contains( extensionProperties, "VK_KHR_driver_properties" ) )
       {
         vk::PhysicalDeviceDriverPropertiesKHR const & driverProperties = properties2.get<vk::PhysicalDeviceDriverPropertiesKHR>();
-        std::cout << "\t"
-                  << "DriverProperties:\n";
-        std::cout << "\t\t"
-                  << "driverID            = " << vk::to_string( driverProperties.driverID ) << "\n";
-        std::cout << "\t\t"
-                  << "driverName          = " << driverProperties.driverName << "\n";
-        std::cout << "\t\t"
-                  << "driverInfo          = " << driverProperties.driverInfo << "\n";
-        std::cout << "\t\t"
-                  << "conformanceVersion  = " << static_cast<uint32_t>( driverProperties.conformanceVersion.major ) << "."
+        std::cout << std::string( "\t" ) << "DriverProperties:\n";
+        std::cout << std::string( "\t\t" ) << "driverID            = " << to_string( driverProperties.driverID ) << "\n";
+        std::cout << std::string( "\t\t" ) << "driverName          = " << driverProperties.driverName << "\n";
+        std::cout << std::string( "\t\t" ) << "driverInfo          = " << driverProperties.driverInfo << "\n";
+        std::cout << std::string( "\t\t" ) << "conformanceVersion  = " << static_cast<uint32_t>( driverProperties.conformanceVersion.major ) << "."
                   << static_cast<uint32_t>( driverProperties.conformanceVersion.minor ) << "."
                   << static_cast<uint32_t>( driverProperties.conformanceVersion.subminor ) << "."
                   << static_cast<uint32_t>( driverProperties.conformanceVersion.patch ) << std::dec << "\n";
@@ -595,52 +681,37 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceExternalMemoryHostPropertiesEXT const & externalMemoryHostProperties =
           properties2.get<vk::PhysicalDeviceExternalMemoryHostPropertiesEXT>();
-        std::cout << "\t"
-                  << "ExternalMemoryHostProperties:\n";
-        std::cout << "\t\t"
-                  << "minImportedHostPointerAlignment = " << externalMemoryHostProperties.minImportedHostPointerAlignment << "\n";
+        std::cout << std::string( "\t" ) << "ExternalMemoryHostProperties:\n";
+        std::cout << std::string( "\t\t" ) << "minImportedHostPointerAlignment = " << externalMemoryHostProperties.minImportedHostPointerAlignment << "\n";
         std::cout << "\n";
       }
 
       if ( vk::su::contains( extensionProperties, "VK_KHR_shader_float_controls" ) )
       {
         vk::PhysicalDeviceFloatControlsPropertiesKHR const & floatControlsProperties = properties2.get<vk::PhysicalDeviceFloatControlsPropertiesKHR>();
-        std::cout << "\t"
-                  << "FloatControlsProperties:\n";
-        std::cout << "\t\t"
-                  << "denormBehaviorIndependence            = " << vk::to_string( floatControlsProperties.denormBehaviorIndependence ) << "\n";
-        std::cout << "\t\t"
-                  << "roundingModeIndependence              = " << vk::to_string( floatControlsProperties.roundingModeIndependence ) << "\n";
-        std::cout << "\t\t"
-                  << "shaderDenormFlushToZeroFloat16        = " << !!floatControlsProperties.shaderDenormFlushToZeroFloat16 << "\n";
-        std::cout << "\t\t"
-                  << "shaderDenormFlushToZeroFloat32        = " << !!floatControlsProperties.shaderDenormFlushToZeroFloat32 << "\n";
-        std::cout << "\t\t"
-                  << "shaderDenormFlushToZeroFloat64        = " << !!floatControlsProperties.shaderDenormFlushToZeroFloat64 << "\n";
-        std::cout << "\t\t"
-                  << "shaderDenormPreserveFloat16           = " << !!floatControlsProperties.shaderDenormPreserveFloat16 << "\n";
-        std::cout << "\t\t"
-                  << "shaderDenormPreserveFloat32           = " << !!floatControlsProperties.shaderDenormPreserveFloat32 << "\n";
-        std::cout << "\t\t"
-                  << "shaderDenormPreserveFloat64           = " << !!floatControlsProperties.shaderDenormPreserveFloat64 << "\n";
-        std::cout << "\t\t"
-                  << "shaderRoundingModeRTEFloat16          = " << !!floatControlsProperties.shaderRoundingModeRTEFloat16 << "\n";
-        std::cout << "\t\t"
-                  << "shaderRoundingModeRTEFloat32          = " << !!floatControlsProperties.shaderRoundingModeRTEFloat32 << "\n";
-        std::cout << "\t\t"
-                  << "shaderRoundingModeRTEFloat64          = " << !!floatControlsProperties.shaderRoundingModeRTEFloat64 << "\n";
-        std::cout << "\t\t"
-                  << "shaderRoundingModeRTZFloat16          = " << !!floatControlsProperties.shaderRoundingModeRTZFloat16 << "\n";
-        std::cout << "\t\t"
-                  << "shaderRoundingModeRTZFloat32          = " << !!floatControlsProperties.shaderRoundingModeRTZFloat32 << "\n";
-        std::cout << "\t\t"
-                  << "shaderRoundingModeRTZFloat64          = " << !!floatControlsProperties.shaderRoundingModeRTZFloat64 << "\n";
-        std::cout << "\t\t"
-                  << "shaderSignedZeroInfNanPreserveFloat16 = " << !!floatControlsProperties.shaderSignedZeroInfNanPreserveFloat16 << "\n";
-        std::cout << "\t\t"
-                  << "shaderSignedZeroInfNanPreserveFloat32 = " << !!floatControlsProperties.shaderSignedZeroInfNanPreserveFloat32 << "\n";
-        std::cout << "\t\t"
-                  << "shaderSignedZeroInfNanPreserveFloat64 = " << !!floatControlsProperties.shaderSignedZeroInfNanPreserveFloat64 << "\n";
+        std::cout << std::string( "\t" ) << "FloatControlsProperties:\n";
+        std::cout << std::string( "\t\t" ) << "denormBehaviorIndependence            = " << to_string( floatControlsProperties.denormBehaviorIndependence )
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "roundingModeIndependence              = " << to_string( floatControlsProperties.roundingModeIndependence )
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderDenormFlushToZeroFloat16        = " << !!floatControlsProperties.shaderDenormFlushToZeroFloat16 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderDenormFlushToZeroFloat32        = " << !!floatControlsProperties.shaderDenormFlushToZeroFloat32 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderDenormFlushToZeroFloat64        = " << !!floatControlsProperties.shaderDenormFlushToZeroFloat64 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderDenormPreserveFloat16           = " << !!floatControlsProperties.shaderDenormPreserveFloat16 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderDenormPreserveFloat32           = " << !!floatControlsProperties.shaderDenormPreserveFloat32 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderDenormPreserveFloat64           = " << !!floatControlsProperties.shaderDenormPreserveFloat64 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderRoundingModeRTEFloat16          = " << !!floatControlsProperties.shaderRoundingModeRTEFloat16 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderRoundingModeRTEFloat32          = " << !!floatControlsProperties.shaderRoundingModeRTEFloat32 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderRoundingModeRTEFloat64          = " << !!floatControlsProperties.shaderRoundingModeRTEFloat64 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderRoundingModeRTZFloat16          = " << !!floatControlsProperties.shaderRoundingModeRTZFloat16 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderRoundingModeRTZFloat32          = " << !!floatControlsProperties.shaderRoundingModeRTZFloat32 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderRoundingModeRTZFloat64          = " << !!floatControlsProperties.shaderRoundingModeRTZFloat64 << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderSignedZeroInfNanPreserveFloat16 = " << !!floatControlsProperties.shaderSignedZeroInfNanPreserveFloat16
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderSignedZeroInfNanPreserveFloat32 = " << !!floatControlsProperties.shaderSignedZeroInfNanPreserveFloat32
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderSignedZeroInfNanPreserveFloat64 = " << !!floatControlsProperties.shaderSignedZeroInfNanPreserveFloat64
+                  << "\n";
         std::cout << "\n";
       }
 
@@ -648,52 +719,39 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceFragmentDensityMapPropertiesEXT const & fragmentDensityMapProperties =
           properties2.get<vk::PhysicalDeviceFragmentDensityMapPropertiesEXT>();
-        std::cout << "\t"
-                  << "FragmentDensityProperties:\n";
-        std::cout << "\t\t"
-                  << "fragmentDensityInvocations  = " << !!fragmentDensityMapProperties.fragmentDensityInvocations << "\n";
-        std::cout << "\t\t"
-                  << "maxFragmentDensityTexelSize = " << fragmentDensityMapProperties.maxFragmentDensityTexelSize.width << " x "
+        std::cout << std::string( "\t" ) << "FragmentDensityProperties:\n";
+        std::cout << std::string( "\t\t" ) << "fragmentDensityInvocations  = " << !!fragmentDensityMapProperties.fragmentDensityInvocations << "\n";
+        std::cout << std::string( "\t\t" ) << "maxFragmentDensityTexelSize = " << fragmentDensityMapProperties.maxFragmentDensityTexelSize.width << " x "
                   << fragmentDensityMapProperties.maxFragmentDensityTexelSize.height << "\n";
-        std::cout << "\t\t"
-                  << "minFragmentDensityTexelSize = " << fragmentDensityMapProperties.minFragmentDensityTexelSize.width << " x "
+        std::cout << std::string( "\t\t" ) << "minFragmentDensityTexelSize = " << fragmentDensityMapProperties.minFragmentDensityTexelSize.width << " x "
                   << fragmentDensityMapProperties.minFragmentDensityTexelSize.height << "\n";
         std::cout << "\n";
       }
 
       vk::PhysicalDeviceIDProperties const & idProperties = properties2.get<vk::PhysicalDeviceIDProperties>();
-      std::cout << "\t"
-                << "IDProperties:\n";
-      std::cout << "\t\t"
-                << "deviceUUID      = " << vk::su::UUID( idProperties.deviceUUID ) << "\n";
-      std::cout << "\t\t"
-                << "driverUUID      = " << vk::su::UUID( idProperties.driverUUID ) << "\n";
-      std::cout << "\t\t"
-                << "deviceLUID      = " << vk::su::LUID( idProperties.deviceLUID ) << "\n";
-      std::cout << "\t\t"
-                << "deviceNodeMask  = " << std::hex << idProperties.deviceNodeMask << std::dec << "\n";
-      std::cout << "\t\t"
-                << "deviceLUIDValid = " << !!idProperties.deviceLUIDValid << "\n";
+      std::cout << std::string( "\t" ) << "IDProperties:\n";
+      std::cout << std::string( "\t\t" ) << "deviceUUID      = " << vk::su::UUID( idProperties.deviceUUID ) << "\n";
+      std::cout << std::string( "\t\t" ) << "driverUUID      = " << vk::su::UUID( idProperties.driverUUID ) << "\n";
+      std::cout << std::string( "\t\t" ) << "deviceLUID      = " << vk::su::LUID( idProperties.deviceLUID ) << "\n";
+      std::cout << std::string( "\t\t" ) << "deviceNodeMask  = " << std::hex << idProperties.deviceNodeMask << std::dec << "\n";
+      std::cout << std::string( "\t\t" ) << "deviceLUIDValid = " << !!idProperties.deviceLUIDValid << "\n";
       std::cout << "\n";
 
       if ( vk::su::contains( extensionProperties, "VK_EXT_inline_uniform_block" ) )
       {
         vk::PhysicalDeviceInlineUniformBlockPropertiesEXT const & inlineUniformBlockProperties =
           properties2.get<vk::PhysicalDeviceInlineUniformBlockPropertiesEXT>();
-        std::cout << "\t"
-                  << "InlineUniformBlockProperties:\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t" ) << "InlineUniformBlockProperties:\n";
+        std::cout << std::string( "\t\t" )
                   << "maxDescriptorSetInlineUniformBlocks                     = " << inlineUniformBlockProperties.maxDescriptorSetInlineUniformBlocks << "\n";
-        std::cout << "\t\t"
-                  << "maxDescriptorSetUpdateAfterBindInlineUniformBlocks      = "
+        std::cout << std::string( "\t\t" ) << "maxDescriptorSetUpdateAfterBindInlineUniformBlocks      = "
                   << inlineUniformBlockProperties.maxDescriptorSetUpdateAfterBindInlineUniformBlocks << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxInlineUniformBlockSize                               = " << inlineUniformBlockProperties.maxInlineUniformBlockSize << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "maxPerStageDescriptorInlineUniformBlocks                = " << inlineUniformBlockProperties.maxPerStageDescriptorInlineUniformBlocks
                   << "\n";
-        std::cout << "\t\t"
-                  << "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks = "
+        std::cout << std::string( "\t\t" ) << "maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks = "
                   << inlineUniformBlockProperties.maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks << "\n";
         std::cout << "\n";
       }
@@ -702,59 +760,40 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceLineRasterizationPropertiesEXT const & lineRasterizationProperties =
           properties2.get<vk::PhysicalDeviceLineRasterizationPropertiesEXT>();
-        std::cout << "\t"
-                  << "LineRasterizationProperties:\n";
-        std::cout << "\t\t"
-                  << "lineSubPixelPrecisionBits = " << lineRasterizationProperties.lineSubPixelPrecisionBits << "\n";
+        std::cout << std::string( "\t" ) << "LineRasterizationProperties:\n";
+        std::cout << std::string( "\t\t" ) << "lineSubPixelPrecisionBits = " << lineRasterizationProperties.lineSubPixelPrecisionBits << "\n";
         std::cout << "\n";
       }
 
       vk::PhysicalDeviceMaintenance3Properties const & maintenance3Properties = properties2.get<vk::PhysicalDeviceMaintenance3Properties>();
-      std::cout << "\t"
-                << "Maintenance3Properties:\n";
-      std::cout << "\t\t"
-                << "maxMemoryAllocationSize = " << maintenance3Properties.maxMemoryAllocationSize << "\n";
-      std::cout << "\t\t"
-                << "maxPerSetDescriptors    = " << maintenance3Properties.maxPerSetDescriptors << "\n";
+      std::cout << std::string( "\t" ) << "Maintenance3Properties:\n";
+      std::cout << std::string( "\t\t" ) << "maxMemoryAllocationSize = " << maintenance3Properties.maxMemoryAllocationSize << "\n";
+      std::cout << std::string( "\t\t" ) << "maxPerSetDescriptors    = " << maintenance3Properties.maxPerSetDescriptors << "\n";
       std::cout << "\n";
 
       if ( vk::su::contains( extensionProperties, "VK_NV_mesh_shader" ) )
       {
         vk::PhysicalDeviceMeshShaderPropertiesNV const & meshShaderProperties = properties2.get<vk::PhysicalDeviceMeshShaderPropertiesNV>();
-        std::cout << "\t"
-                  << "MeshShaderProperties:\n";
-        std::cout << "\t\t"
-                  << "maxDrawMeshTasksCount             = " << meshShaderProperties.maxDrawMeshTasksCount << "\n";
-        std::cout << "\t\t"
-                  << "maxMeshMultiviewViewCount         = " << meshShaderProperties.maxMeshMultiviewViewCount << "\n";
-        std::cout << "\t\t"
-                  << "maxMeshOutputPrimitives           = " << meshShaderProperties.maxMeshOutputPrimitives << "\n";
-        std::cout << "\t\t"
-                  << "maxMeshOutputVertices             = " << meshShaderProperties.maxMeshOutputVertices << "\n";
-        std::cout << "\t\t"
-                  << "maxMeshTotalMemorySize            = " << meshShaderProperties.maxMeshTotalMemorySize << "\n";
-        std::cout << "\t\t"
-                  << "maxMeshWorkGroupInvocations       = " << meshShaderProperties.maxMeshWorkGroupInvocations << "\n";
-        std::cout << "\t\t"
-                  << "maxMeshWorkGroupSize              = "
+        std::cout << std::string( "\t" ) << "MeshShaderProperties:\n";
+        std::cout << std::string( "\t\t" ) << "maxDrawMeshTasksCount             = " << meshShaderProperties.maxDrawMeshTasksCount << "\n";
+        std::cout << std::string( "\t\t" ) << "maxMeshMultiviewViewCount         = " << meshShaderProperties.maxMeshMultiviewViewCount << "\n";
+        std::cout << std::string( "\t\t" ) << "maxMeshOutputPrimitives           = " << meshShaderProperties.maxMeshOutputPrimitives << "\n";
+        std::cout << std::string( "\t\t" ) << "maxMeshOutputVertices             = " << meshShaderProperties.maxMeshOutputVertices << "\n";
+        std::cout << std::string( "\t\t" ) << "maxMeshTotalMemorySize            = " << meshShaderProperties.maxMeshTotalMemorySize << "\n";
+        std::cout << std::string( "\t\t" ) << "maxMeshWorkGroupInvocations       = " << meshShaderProperties.maxMeshWorkGroupInvocations << "\n";
+        std::cout << std::string( "\t\t" ) << "maxMeshWorkGroupSize              = "
                   << "[" << meshShaderProperties.maxMeshWorkGroupSize[0] << ", " << meshShaderProperties.maxMeshWorkGroupSize[1] << ", "
                   << meshShaderProperties.maxMeshWorkGroupSize[2] << "]"
                   << "\n";
-        std::cout << "\t\t"
-                  << "maxTaskOutputCount                = " << meshShaderProperties.maxTaskOutputCount << "\n";
-        std::cout << "\t\t"
-                  << "maxTaskTotalMemorySize            = " << meshShaderProperties.maxTaskTotalMemorySize << "\n";
-        std::cout << "\t\t"
-                  << "maxTaskWorkGroupInvocations       = " << meshShaderProperties.maxTaskWorkGroupInvocations << "\n";
-        std::cout << "\t\t"
-                  << "maxTaskWorkGroupSize              = "
+        std::cout << std::string( "\t\t" ) << "maxTaskOutputCount                = " << meshShaderProperties.maxTaskOutputCount << "\n";
+        std::cout << std::string( "\t\t" ) << "maxTaskTotalMemorySize            = " << meshShaderProperties.maxTaskTotalMemorySize << "\n";
+        std::cout << std::string( "\t\t" ) << "maxTaskWorkGroupInvocations       = " << meshShaderProperties.maxTaskWorkGroupInvocations << "\n";
+        std::cout << std::string( "\t\t" ) << "maxTaskWorkGroupSize              = "
                   << "[" << meshShaderProperties.maxTaskWorkGroupSize[0] << ", " << meshShaderProperties.maxTaskWorkGroupSize[1] << ", "
                   << meshShaderProperties.maxTaskWorkGroupSize[2] << "]"
                   << "\n";
-        std::cout << "\t\t"
-                  << "meshOutputPerPrimitiveGranularity = " << meshShaderProperties.meshOutputPerPrimitiveGranularity << "\n";
-        std::cout << "\t\t"
-                  << "meshOutputPerVertexGranularity    = " << meshShaderProperties.meshOutputPerVertexGranularity << "\n";
+        std::cout << std::string( "\t\t" ) << "meshOutputPerPrimitiveGranularity = " << meshShaderProperties.meshOutputPerPrimitiveGranularity << "\n";
+        std::cout << std::string( "\t\t" ) << "meshOutputPerVertexGranularity    = " << meshShaderProperties.meshOutputPerVertexGranularity << "\n";
         std::cout << "\n";
       }
 
@@ -762,108 +801,78 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceMultiviewPerViewAttributesPropertiesNVX const & multiviewPerViewAttributesProperties =
           properties2.get<vk::PhysicalDeviceMultiviewPerViewAttributesPropertiesNVX>();
-        std::cout << "\t"
-                  << "MultiviewPerViewAttributesProperties:\n";
-        std::cout << "\t\t"
-                  << "perViewPositionAllComponents  = " << !!multiviewPerViewAttributesProperties.perViewPositionAllComponents << "\n";
+        std::cout << std::string( "\t" ) << "MultiviewPerViewAttributesProperties:\n";
+        std::cout << std::string( "\t\t" ) << "perViewPositionAllComponents  = " << !!multiviewPerViewAttributesProperties.perViewPositionAllComponents << "\n";
         std::cout << "\n";
       }
 
       vk::PhysicalDeviceMultiviewProperties const & multiviewProperties = properties2.get<vk::PhysicalDeviceMultiviewProperties>();
-      std::cout << "\t"
-                << "MultiviewProperties:\n";
-      std::cout << "\t\t"
-                << "maxMultiviewInstanceIndex = " << multiviewProperties.maxMultiviewInstanceIndex << "\n";
-      std::cout << "\t\t"
-                << "maxMultiviewViewCount     = " << multiviewProperties.maxMultiviewViewCount << "\n";
+      std::cout << std::string( "\t" ) << "MultiviewProperties:\n";
+      std::cout << std::string( "\t\t" ) << "maxMultiviewInstanceIndex = " << multiviewProperties.maxMultiviewInstanceIndex << "\n";
+      std::cout << std::string( "\t\t" ) << "maxMultiviewViewCount     = " << multiviewProperties.maxMultiviewViewCount << "\n";
       std::cout << "\n";
 
       if ( vk::su::contains( extensionProperties, "VK_EXT_pci_bus_info" ) )
       {
         vk::PhysicalDevicePCIBusInfoPropertiesEXT const & pciBusInfoProperties = properties2.get<vk::PhysicalDevicePCIBusInfoPropertiesEXT>();
-        std::cout << "\t"
-                  << "PCIBusInfoProperties:\n";
-        std::cout << "\t\t"
-                  << "pciDomain   = " << pciBusInfoProperties.pciDomain << "\n";
-        std::cout << "\t\t"
-                  << "pciBus      = " << pciBusInfoProperties.pciBus << "\n";
-        std::cout << "\t\t"
-                  << "pciDevice   = " << pciBusInfoProperties.pciDevice << "\n";
-        std::cout << "\t\t"
-                  << "pciFunction = " << pciBusInfoProperties.pciFunction << "\n";
+        std::cout << std::string( "\t" ) << "PCIBusInfoProperties:\n";
+        std::cout << std::string( "\t\t" ) << "pciDomain   = " << pciBusInfoProperties.pciDomain << "\n";
+        std::cout << std::string( "\t\t" ) << "pciBus      = " << pciBusInfoProperties.pciBus << "\n";
+        std::cout << std::string( "\t\t" ) << "pciDevice   = " << pciBusInfoProperties.pciDevice << "\n";
+        std::cout << std::string( "\t\t" ) << "pciFunction = " << pciBusInfoProperties.pciFunction << "\n";
         std::cout << "\n";
       }
 
       if ( vk::su::contains( extensionProperties, "VK_KHR_maintenance2" ) )
       {
         vk::PhysicalDevicePointClippingProperties const & pointClippingProperties = properties2.get<vk::PhysicalDevicePointClippingProperties>();
-        std::cout << "\t"
-                  << "PointClippingProperties:\n";
-        std::cout << "\t\t"
-                  << "pointClippingBehavior = " << vk::to_string( pointClippingProperties.pointClippingBehavior ) << "\n";
+        std::cout << std::string( "\t" ) << "PointClippingProperties:\n";
+        std::cout << std::string( "\t\t" ) << "pointClippingBehavior = " << to_string( pointClippingProperties.pointClippingBehavior ) << "\n";
         std::cout << "\n";
       }
 
       vk::PhysicalDeviceProtectedMemoryProperties const & protectedMemoryProperties = properties2.get<vk::PhysicalDeviceProtectedMemoryProperties>();
-      std::cout << "\t"
-                << "ProtectedMemoryProperties:\n";
-      std::cout << "\t\t"
-                << "protectedNoFault  = " << !!protectedMemoryProperties.protectedNoFault << "\n";
+      std::cout << std::string( "\t" ) << "ProtectedMemoryProperties:\n";
+      std::cout << std::string( "\t\t" ) << "protectedNoFault  = " << !!protectedMemoryProperties.protectedNoFault << "\n";
       std::cout << "\n";
 
       if ( vk::su::contains( extensionProperties, "VK_KHR_push_descriptor" ) )
       {
         vk::PhysicalDevicePushDescriptorPropertiesKHR const & pushDescriptorProperties = properties2.get<vk::PhysicalDevicePushDescriptorPropertiesKHR>();
-        std::cout << "\t"
-                  << "PushDescriptorProperties:\n";
-        std::cout << "\t\t"
-                  << "maxPushDescriptors  = " << pushDescriptorProperties.maxPushDescriptors << "\n";
+        std::cout << std::string( "\t" ) << "PushDescriptorProperties:\n";
+        std::cout << std::string( "\t\t" ) << "maxPushDescriptors  = " << pushDescriptorProperties.maxPushDescriptors << "\n";
         std::cout << "\n";
       }
 
       if ( vk::su::contains( extensionProperties, "VK_NV_ray_tracing" ) )
       {
         vk::PhysicalDeviceRayTracingPropertiesNV const & rayTracingProperties = properties2.get<vk::PhysicalDeviceRayTracingPropertiesNV>();
-        std::cout << "\t"
-                  << "RayTracingProperties:\n";
-        std::cout << "\t\t"
-                  << "maxDescriptorSetAccelerationStructures  = " << rayTracingProperties.maxDescriptorSetAccelerationStructures << "\n";
-        std::cout << "\t\t"
-                  << "maxGeometryCount                        = " << rayTracingProperties.maxGeometryCount << "\n";
-        std::cout << "\t\t"
-                  << "maxInstanceCount                        = " << rayTracingProperties.maxInstanceCount << "\n";
-        std::cout << "\t\t"
-                  << "maxRecursionDepth                       = " << rayTracingProperties.maxRecursionDepth << "\n";
-        std::cout << "\t\t"
-                  << "maxShaderGroupStride                    = " << rayTracingProperties.maxShaderGroupStride << "\n";
-        std::cout << "\t\t"
-                  << "maxTriangleCount                        = " << rayTracingProperties.maxTriangleCount << "\n";
-        std::cout << "\t\t"
-                  << "shaderGroupBaseAlignment                = " << rayTracingProperties.shaderGroupBaseAlignment << "\n";
-        std::cout << "\t\t"
-                  << "shaderGroupHandleSize                   = " << rayTracingProperties.shaderGroupHandleSize << "\n";
+        std::cout << std::string( "\t" ) << "RayTracingProperties:\n";
+        std::cout << std::string( "\t\t" ) << "maxDescriptorSetAccelerationStructures  = " << rayTracingProperties.maxDescriptorSetAccelerationStructures
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "maxGeometryCount                        = " << rayTracingProperties.maxGeometryCount << "\n";
+        std::cout << std::string( "\t\t" ) << "maxInstanceCount                        = " << rayTracingProperties.maxInstanceCount << "\n";
+        std::cout << std::string( "\t\t" ) << "maxRecursionDepth                       = " << rayTracingProperties.maxRecursionDepth << "\n";
+        std::cout << std::string( "\t\t" ) << "maxShaderGroupStride                    = " << rayTracingProperties.maxShaderGroupStride << "\n";
+        std::cout << std::string( "\t\t" ) << "maxTriangleCount                        = " << rayTracingProperties.maxTriangleCount << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderGroupBaseAlignment                = " << rayTracingProperties.shaderGroupBaseAlignment << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderGroupHandleSize                   = " << rayTracingProperties.shaderGroupHandleSize << "\n";
         std::cout << "\n";
       }
 
       if ( vk::su::contains( extensionProperties, "VK_EXT_sample_locations" ) )
       {
         vk::PhysicalDeviceSampleLocationsPropertiesEXT const & sampleLocationProperties = properties2.get<vk::PhysicalDeviceSampleLocationsPropertiesEXT>();
-        std::cout << "\t"
-                  << "SampleLocationProperties:\n";
-        std::cout << "\t\t"
-                  << "maxSampleLocationGridSize     = " << sampleLocationProperties.maxSampleLocationGridSize.width << " x "
+        std::cout << std::string( "\t" ) << "SampleLocationProperties:\n";
+        std::cout << std::string( "\t\t" ) << "maxSampleLocationGridSize     = " << sampleLocationProperties.maxSampleLocationGridSize.width << " x "
                   << sampleLocationProperties.maxSampleLocationGridSize.height << "\n";
-        std::cout << "\t\t"
-                  << "sampleLocationCoordinateRange = "
+        std::cout << std::string( "\t\t" ) << "sampleLocationCoordinateRange = "
                   << "[" << sampleLocationProperties.sampleLocationCoordinateRange[0] << ", " << sampleLocationProperties.sampleLocationCoordinateRange[1]
                   << "]"
                   << "\n";
-        std::cout << "\t\t"
-                  << "sampleLocationSampleCounts    = " << vk::to_string( sampleLocationProperties.sampleLocationSampleCounts ) << "\n";
-        std::cout << "\t\t"
-                  << "sampleLocationSubPixelBits    = " << sampleLocationProperties.sampleLocationSubPixelBits << "\n";
-        std::cout << "\t\t"
-                  << "variableSampleLocations       = " << !!sampleLocationProperties.variableSampleLocations << "\n";
+        std::cout << std::string( "\t\t" ) << "sampleLocationSampleCounts    = " << to_string( sampleLocationProperties.sampleLocationSampleCounts ) << "\n";
+        std::cout << std::string( "\t\t" ) << "sampleLocationSubPixelBits    = " << sampleLocationProperties.sampleLocationSubPixelBits << "\n";
+        std::cout << std::string( "\t\t" ) << "variableSampleLocations       = " << !!sampleLocationProperties.variableSampleLocations << "\n";
         std::cout << "\n";
       }
 
@@ -871,118 +880,83 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceSamplerFilterMinmaxPropertiesEXT const & samplerFilterMinmaxProperties =
           properties2.get<vk::PhysicalDeviceSamplerFilterMinmaxPropertiesEXT>();
-        std::cout << "\t"
-                  << "SamplerFilterMinmaxProperties:\n";
-        std::cout << "\t\t"
-                  << "filterMinmaxImageComponentMapping   = " << !!samplerFilterMinmaxProperties.filterMinmaxImageComponentMapping << "\n";
-        std::cout << "\t\t"
-                  << "filterMinmaxSingleComponentFormats  = " << !!samplerFilterMinmaxProperties.filterMinmaxSingleComponentFormats << "\n";
+        std::cout << std::string( "\t" ) << "SamplerFilterMinmaxProperties:\n";
+        std::cout << std::string( "\t\t" ) << "filterMinmaxImageComponentMapping   = " << !!samplerFilterMinmaxProperties.filterMinmaxImageComponentMapping
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "filterMinmaxSingleComponentFormats  = " << !!samplerFilterMinmaxProperties.filterMinmaxSingleComponentFormats
+                  << "\n";
         std::cout << "\n";
       }
 
       if ( vk::su::contains( extensionProperties, "VK_AMD_shader_core_properties2" ) )
       {
         vk::PhysicalDeviceShaderCoreProperties2AMD const & shaderCoreProperties2 = properties2.get<vk::PhysicalDeviceShaderCoreProperties2AMD>();
-        std::cout << "\t"
-                  << "ShaderCoreProperties2:\n";
-        std::cout << "\t\t"
-                  << "activeComputeUnitCount  = " << shaderCoreProperties2.activeComputeUnitCount << "\n";
-        std::cout << "\t\t"
-                  << "shaderCoreFeatures      = " << vk::to_string( shaderCoreProperties2.shaderCoreFeatures ) << "\n";
+        std::cout << std::string( "\t" ) << "ShaderCoreProperties2:\n";
+        std::cout << std::string( "\t\t" ) << "activeComputeUnitCount  = " << shaderCoreProperties2.activeComputeUnitCount << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderCoreFeatures      = " << to_string( shaderCoreProperties2.shaderCoreFeatures ) << "\n";
         std::cout << "\n";
       }
 
       if ( vk::su::contains( extensionProperties, "VK_AMD_shader_core_properties2" ) )
       {
         vk::PhysicalDeviceShaderCorePropertiesAMD const & shaderCoreProperties = properties2.get<vk::PhysicalDeviceShaderCorePropertiesAMD>();
-        std::cout << "\t"
-                  << "ShaderCoreProperties:\n";
-        std::cout << "\t\t"
-                  << "computeUnitsPerShaderArray  = " << shaderCoreProperties.computeUnitsPerShaderArray << "\n";
-        std::cout << "\t\t"
-                  << "maxSgprAllocation           = " << shaderCoreProperties.maxSgprAllocation << "\n";
-        std::cout << "\t\t"
-                  << "maxVgprAllocation           = " << shaderCoreProperties.maxVgprAllocation << "\n";
-        std::cout << "\t\t"
-                  << "minSgprAllocation           = " << shaderCoreProperties.minSgprAllocation << "\n";
-        std::cout << "\t\t"
-                  << "minVgprAllocation           = " << shaderCoreProperties.minVgprAllocation << "\n";
-        std::cout << "\t\t"
-                  << "sgprAllocationGranularity   = " << shaderCoreProperties.sgprAllocationGranularity << "\n";
-        std::cout << "\t\t"
-                  << "sgprsPerSimd                = " << shaderCoreProperties.sgprsPerSimd << "\n";
-        std::cout << "\t\t"
-                  << "shaderArraysPerEngineCount  = " << shaderCoreProperties.shaderArraysPerEngineCount << "\n";
-        std::cout << "\t\t"
-                  << "shaderEngineCount           = " << shaderCoreProperties.shaderEngineCount << "\n";
-        std::cout << "\t\t"
-                  << "simdPerComputeUnit          = " << shaderCoreProperties.simdPerComputeUnit << "\n";
-        std::cout << "\t\t"
-                  << "vgprAllocationGranularity   = " << shaderCoreProperties.vgprAllocationGranularity << "\n";
-        std::cout << "\t\t"
-                  << "vgprsPerSimd                = " << shaderCoreProperties.vgprsPerSimd << "\n";
-        std::cout << "\t\t"
-                  << "wavefrontSize               = " << shaderCoreProperties.wavefrontSize << "\n";
-        std::cout << "\t\t"
-                  << "wavefrontsPerSimd           = " << shaderCoreProperties.wavefrontsPerSimd << "\n";
+        std::cout << std::string( "\t" ) << "ShaderCoreProperties:\n";
+        std::cout << std::string( "\t\t" ) << "computeUnitsPerShaderArray  = " << shaderCoreProperties.computeUnitsPerShaderArray << "\n";
+        std::cout << std::string( "\t\t" ) << "maxSgprAllocation           = " << shaderCoreProperties.maxSgprAllocation << "\n";
+        std::cout << std::string( "\t\t" ) << "maxVgprAllocation           = " << shaderCoreProperties.maxVgprAllocation << "\n";
+        std::cout << std::string( "\t\t" ) << "minSgprAllocation           = " << shaderCoreProperties.minSgprAllocation << "\n";
+        std::cout << std::string( "\t\t" ) << "minVgprAllocation           = " << shaderCoreProperties.minVgprAllocation << "\n";
+        std::cout << std::string( "\t\t" ) << "sgprAllocationGranularity   = " << shaderCoreProperties.sgprAllocationGranularity << "\n";
+        std::cout << std::string( "\t\t" ) << "sgprsPerSimd                = " << shaderCoreProperties.sgprsPerSimd << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderArraysPerEngineCount  = " << shaderCoreProperties.shaderArraysPerEngineCount << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderEngineCount           = " << shaderCoreProperties.shaderEngineCount << "\n";
+        std::cout << std::string( "\t\t" ) << "simdPerComputeUnit          = " << shaderCoreProperties.simdPerComputeUnit << "\n";
+        std::cout << std::string( "\t\t" ) << "vgprAllocationGranularity   = " << shaderCoreProperties.vgprAllocationGranularity << "\n";
+        std::cout << std::string( "\t\t" ) << "vgprsPerSimd                = " << shaderCoreProperties.vgprsPerSimd << "\n";
+        std::cout << std::string( "\t\t" ) << "wavefrontSize               = " << shaderCoreProperties.wavefrontSize << "\n";
+        std::cout << std::string( "\t\t" ) << "wavefrontsPerSimd           = " << shaderCoreProperties.wavefrontsPerSimd << "\n";
         std::cout << "\n";
       }
 
       if ( vk::su::contains( extensionProperties, "VK_NV_shader_sm_builtins" ) )
       {
         vk::PhysicalDeviceShaderSMBuiltinsPropertiesNV const & shaderSMBuiltinsProperties = properties2.get<vk::PhysicalDeviceShaderSMBuiltinsPropertiesNV>();
-        std::cout << "\t"
-                  << "ShaderSMBuiltinsProperties:\n";
-        std::cout << "\t\t"
-                  << "shaderSMCount     = " << shaderSMBuiltinsProperties.shaderSMCount << "\n";
-        std::cout << "\t\t"
-                  << "shaderWarpsPerSM  = " << shaderSMBuiltinsProperties.shaderWarpsPerSM << "\n";
+        std::cout << std::string( "\t" ) << "ShaderSMBuiltinsProperties:\n";
+        std::cout << std::string( "\t\t" ) << "shaderSMCount     = " << shaderSMBuiltinsProperties.shaderSMCount << "\n";
+        std::cout << std::string( "\t\t" ) << "shaderWarpsPerSM  = " << shaderSMBuiltinsProperties.shaderWarpsPerSM << "\n";
         std::cout << "\n";
       }
 
       if ( vk::su::contains( extensionProperties, "VK_NV_shading_rate_image" ) )
       {
         vk::PhysicalDeviceShadingRateImagePropertiesNV const & shadingRageImageProperties = properties2.get<vk::PhysicalDeviceShadingRateImagePropertiesNV>();
-        std::cout << "\t"
-                  << "ShadingRateImageProperties:\n";
-        std::cout << "\t\t"
-                  << "shadingRateMaxCoarseSamples = " << shadingRageImageProperties.shadingRateMaxCoarseSamples << "\n";
-        std::cout << "\t\t"
-                  << "shadingRatePaletteSize      = " << shadingRageImageProperties.shadingRatePaletteSize << "\n";
-        std::cout << "\t\t"
-                  << "shadingRatePaletteSize      = "
+        std::cout << std::string( "\t" ) << "ShadingRateImageProperties:\n";
+        std::cout << std::string( "\t\t" ) << "shadingRateMaxCoarseSamples = " << shadingRageImageProperties.shadingRateMaxCoarseSamples << "\n";
+        std::cout << std::string( "\t\t" ) << "shadingRatePaletteSize      = " << shadingRageImageProperties.shadingRatePaletteSize << "\n";
+        std::cout << std::string( "\t\t" ) << "shadingRatePaletteSize      = "
                   << "[" << shadingRageImageProperties.shadingRateTexelSize.width << " x " << shadingRageImageProperties.shadingRateTexelSize.height << "]"
                   << "\n";
         std::cout << "\n";
       }
 
       vk::PhysicalDeviceSubgroupProperties const & subgroupProperties = properties2.get<vk::PhysicalDeviceSubgroupProperties>();
-      std::cout << "\t"
-                << "SubgroupProperties:\n";
-      std::cout << "\t\t"
-                << "quadOperationsInAllStages = " << !!subgroupProperties.quadOperationsInAllStages << "\n";
-      std::cout << "\t\t"
-                << "subgroupSize              = " << subgroupProperties.subgroupSize << "\n";
-      std::cout << "\t\t"
-                << "supportedOperations       = " << vk::to_string( subgroupProperties.supportedOperations ) << "\n";
-      std::cout << "\t\t"
-                << "supportedStages           = " << vk::to_string( subgroupProperties.supportedStages ) << "\n";
+      std::cout << std::string( "\t" ) << "SubgroupProperties:\n";
+      std::cout << std::string( "\t\t" ) << "quadOperationsInAllStages = " << !!subgroupProperties.quadOperationsInAllStages << "\n";
+      std::cout << std::string( "\t\t" ) << "subgroupSize              = " << subgroupProperties.subgroupSize << "\n";
+      std::cout << std::string( "\t\t" ) << "supportedOperations       = " << to_string( subgroupProperties.supportedOperations ) << "\n";
+      std::cout << std::string( "\t\t" ) << "supportedStages           = " << to_string( subgroupProperties.supportedStages ) << "\n";
       std::cout << "\n";
 
       if ( vk::su::contains( extensionProperties, "VK_EXT_subgroup_size_control" ) )
       {
         vk::PhysicalDeviceSubgroupSizeControlPropertiesEXT const & subgroupSizeControlProperties =
           properties2.get<vk::PhysicalDeviceSubgroupSizeControlPropertiesEXT>();
-        std::cout << "\t"
-                  << "SubgroupSizeControlProperties:\n";
-        std::cout << "\t\t"
-                  << "maxComputeWorkgroupSubgroups  = " << subgroupSizeControlProperties.maxComputeWorkgroupSubgroups << "\n";
-        std::cout << "\t\t"
-                  << "maxSubgroupSize               = " << subgroupSizeControlProperties.maxSubgroupSize << "\n";
-        std::cout << "\t\t"
-                  << "minSubgroupSize               = " << subgroupSizeControlProperties.minSubgroupSize << "\n";
-        std::cout << "\t\t"
-                  << "requiredSubgroupSizeStages    = " << vk::to_string( subgroupSizeControlProperties.requiredSubgroupSizeStages ) << "\n";
+        std::cout << std::string( "\t" ) << "SubgroupSizeControlProperties:\n";
+        std::cout << std::string( "\t\t" ) << "maxComputeWorkgroupSubgroups  = " << subgroupSizeControlProperties.maxComputeWorkgroupSubgroups << "\n";
+        std::cout << std::string( "\t\t" ) << "maxSubgroupSize               = " << subgroupSizeControlProperties.maxSubgroupSize << "\n";
+        std::cout << std::string( "\t\t" ) << "minSubgroupSize               = " << subgroupSizeControlProperties.minSubgroupSize << "\n";
+        std::cout << std::string( "\t\t" ) << "requiredSubgroupSizeStages    = " << to_string( subgroupSizeControlProperties.requiredSubgroupSizeStages )
+                  << "\n";
         std::cout << "\n";
       }
 
@@ -990,10 +964,9 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceTimelineSemaphorePropertiesKHR const & timelineSemaphoreProperties =
           properties2.get<vk::PhysicalDeviceTimelineSemaphorePropertiesKHR>();
-        std::cout << "\t"
-                  << "TimelineSemaphoreProperties:\n";
-        std::cout << "\t\t"
-                  << "maxTimelineSemaphoreValueDifference = " << timelineSemaphoreProperties.maxTimelineSemaphoreValueDifference << "\n";
+        std::cout << std::string( "\t" ) << "TimelineSemaphoreProperties:\n";
+        std::cout << std::string( "\t\t" ) << "maxTimelineSemaphoreValueDifference = " << timelineSemaphoreProperties.maxTimelineSemaphoreValueDifference
+                  << "\n";
         std::cout << "\n";
       }
 
@@ -1001,16 +974,15 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceTexelBufferAlignmentPropertiesEXT const & texelBufferAlignmentProperties =
           properties2.get<vk::PhysicalDeviceTexelBufferAlignmentPropertiesEXT>();
-        std::cout << "\t"
-                  << "TexelBufferAlignmentProperties:\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t" ) << "TexelBufferAlignmentProperties:\n";
+        std::cout << std::string( "\t\t" )
                   << "storageTexelBufferOffsetAlignmentBytes        = " << texelBufferAlignmentProperties.storageTexelBufferOffsetAlignmentBytes << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "storageTexelBufferOffsetSingleTexelAlignment  = " << !!texelBufferAlignmentProperties.storageTexelBufferOffsetSingleTexelAlignment
                   << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "uniformTexelBufferOffsetAlignmentBytes        = " << texelBufferAlignmentProperties.uniformTexelBufferOffsetAlignmentBytes << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "uniformTexelBufferOffsetSingleTexelAlignment  = " << !!texelBufferAlignmentProperties.uniformTexelBufferOffsetSingleTexelAlignment
                   << "\n";
         std::cout << "\n";
@@ -1020,27 +992,25 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceTransformFeedbackPropertiesEXT const & transformFeedbackProperties =
           properties2.get<vk::PhysicalDeviceTransformFeedbackPropertiesEXT>();
-        std::cout << "\t"
-                  << "TransformFeedbackProperties:\n";
-        std::cout << "\t\t"
-                  << "maxTransformFeedbackBufferDataSize          = " << transformFeedbackProperties.maxTransformFeedbackBufferDataSize << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t" ) << "TransformFeedbackProperties:\n";
+        std::cout << std::string( "\t\t" ) << "maxTransformFeedbackBufferDataSize          = " << transformFeedbackProperties.maxTransformFeedbackBufferDataSize
+                  << "\n";
+        std::cout << std::string( "\t\t" )
                   << "maxTransformFeedbackBufferDataStride        = " << transformFeedbackProperties.maxTransformFeedbackBufferDataStride << "\n";
-        std::cout << "\t\t"
-                  << "maxTransformFeedbackBuffers                 = " << transformFeedbackProperties.maxTransformFeedbackBuffers << "\n";
-        std::cout << "\t\t"
-                  << "maxTransformFeedbackBufferSize              = " << transformFeedbackProperties.maxTransformFeedbackBufferSize << "\n";
-        std::cout << "\t\t"
-                  << "maxTransformFeedbackStreamDataSize          = " << transformFeedbackProperties.maxTransformFeedbackStreamDataSize << "\n";
-        std::cout << "\t\t"
-                  << "maxTransformFeedbackStreams                 = " << transformFeedbackProperties.maxTransformFeedbackStreams << "\n";
-        std::cout << "\t\t"
-                  << "transformFeedbackDraw                       = " << !!transformFeedbackProperties.transformFeedbackDraw << "\n";
-        std::cout << "\t\t"
-                  << "transformFeedbackQueries                    = " << !!transformFeedbackProperties.transformFeedbackQueries << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" ) << "maxTransformFeedbackBuffers                 = " << transformFeedbackProperties.maxTransformFeedbackBuffers
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "maxTransformFeedbackBufferSize              = " << transformFeedbackProperties.maxTransformFeedbackBufferSize
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "maxTransformFeedbackStreamDataSize          = " << transformFeedbackProperties.maxTransformFeedbackStreamDataSize
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "maxTransformFeedbackStreams                 = " << transformFeedbackProperties.maxTransformFeedbackStreams
+                  << "\n";
+        std::cout << std::string( "\t\t" ) << "transformFeedbackDraw                       = " << !!transformFeedbackProperties.transformFeedbackDraw << "\n";
+        std::cout << std::string( "\t\t" ) << "transformFeedbackQueries                    = " << !!transformFeedbackProperties.transformFeedbackQueries
+                  << "\n";
+        std::cout << std::string( "\t\t" )
                   << "transformFeedbackRasterizationStreamSelect  = " << !!transformFeedbackProperties.transformFeedbackRasterizationStreamSelect << "\n";
-        std::cout << "\t\t"
+        std::cout << std::string( "\t\t" )
                   << "transformFeedbackStreamsLinesTriangles      = " << !!transformFeedbackProperties.transformFeedbackStreamsLinesTriangles << "\n";
         std::cout << "\n";
       }
@@ -1049,10 +1019,8 @@ int main( int /*argc*/, char ** /*argv*/ )
       {
         vk::PhysicalDeviceVertexAttributeDivisorPropertiesEXT const & vertexAttributeDivisorProperties =
           properties2.get<vk::PhysicalDeviceVertexAttributeDivisorPropertiesEXT>();
-        std::cout << "\t"
-                  << "VertexAttributeDivisorProperties:\n";
-        std::cout << "\t\t"
-                  << "maxVertexAttribDivisor  = " << vertexAttributeDivisorProperties.maxVertexAttribDivisor << "\n";
+        std::cout << std::string( "\t" ) << "VertexAttributeDivisorProperties:\n";
+        std::cout << std::string( "\t\t" ) << "maxVertexAttribDivisor  = " << vertexAttributeDivisorProperties.maxVertexAttribDivisor << "\n";
         std::cout << "\n";
       }
     }

--- a/samples/PhysicalDeviceQueueFamilyProperties/PhysicalDeviceQueueFamilyProperties.cpp
+++ b/samples/PhysicalDeviceQueueFamilyProperties/PhysicalDeviceQueueFamilyProperties.cpp
@@ -25,6 +25,102 @@
 static char const * AppName    = "PhysicalDeviceQueueFamilyProperties";
 static char const * EngineName = "Vulkan.hpp";
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::PipelineStageFlags value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::PipelineStageFlagBits::eTopOfPipe )
+      result += "TopOfPipe | ";
+    if ( value & vk::PipelineStageFlagBits::eDrawIndirect )
+      result += "DrawIndirect | ";
+    if ( value & vk::PipelineStageFlagBits::eVertexInput )
+      result += "VertexInput | ";
+    if ( value & vk::PipelineStageFlagBits::eVertexShader )
+      result += "VertexShader | ";
+    if ( value & vk::PipelineStageFlagBits::eTessellationControlShader )
+      result += "TessellationControlShader | ";
+    if ( value & vk::PipelineStageFlagBits::eTessellationEvaluationShader )
+      result += "TessellationEvaluationShader | ";
+    if ( value & vk::PipelineStageFlagBits::eGeometryShader )
+      result += "GeometryShader | ";
+    if ( value & vk::PipelineStageFlagBits::eFragmentShader )
+      result += "FragmentShader | ";
+    if ( value & vk::PipelineStageFlagBits::eEarlyFragmentTests )
+      result += "EarlyFragmentTests | ";
+    if ( value & vk::PipelineStageFlagBits::eLateFragmentTests )
+      result += "LateFragmentTests | ";
+    if ( value & vk::PipelineStageFlagBits::eColorAttachmentOutput )
+      result += "ColorAttachmentOutput | ";
+    if ( value & vk::PipelineStageFlagBits::eComputeShader )
+      result += "ComputeShader | ";
+    if ( value & vk::PipelineStageFlagBits::eTransfer )
+      result += "Transfer | ";
+    if ( value & vk::PipelineStageFlagBits::eBottomOfPipe )
+      result += "BottomOfPipe | ";
+    if ( value & vk::PipelineStageFlagBits::eHost )
+      result += "Host | ";
+    if ( value & vk::PipelineStageFlagBits::eAllGraphics )
+      result += "AllGraphics | ";
+    if ( value & vk::PipelineStageFlagBits::eAllCommands )
+      result += "AllCommands | ";
+    if ( value & vk::PipelineStageFlagBits::eTransformFeedbackEXT )
+      result += "TransformFeedbackEXT | ";
+    if ( value & vk::PipelineStageFlagBits::eConditionalRenderingEXT )
+      result += "ConditionalRenderingEXT | ";
+    if ( value & vk::PipelineStageFlagBits::eAccelerationStructureBuildKHR )
+      result += "AccelerationStructureBuildKHR | ";
+    if ( value & vk::PipelineStageFlagBits::eRayTracingShaderKHR )
+      result += "RayTracingShaderKHR | ";
+    if ( value & vk::PipelineStageFlagBits::eTaskShaderNV )
+      result += "TaskShaderNV | ";
+    if ( value & vk::PipelineStageFlagBits::eMeshShaderNV )
+      result += "MeshShaderNV | ";
+    if ( value & vk::PipelineStageFlagBits::eFragmentDensityProcessEXT )
+      result += "FragmentDensityProcessEXT | ";
+    if ( value & vk::PipelineStageFlagBits::eFragmentShadingRateAttachmentKHR )
+      result += "FragmentShadingRateAttachmentKHR | ";
+    if ( value & vk::PipelineStageFlagBits::eCommandPreprocessNV )
+      result += "CommandPreprocessNV | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::QueueFlags value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::QueueFlagBits::eGraphics )
+      result += "Graphics | ";
+    if ( value & vk::QueueFlagBits::eCompute )
+      result += "Compute | ";
+    if ( value & vk::QueueFlagBits::eTransfer )
+      result += "Transfer | ";
+    if ( value & vk::QueueFlagBits::eSparseBinding )
+      result += "SparseBinding | ";
+    if ( value & vk::QueueFlagBits::eProtected )
+      result += "Protected | ";
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
+    if ( value & vk::QueueFlagBits::eVideoDecodeKHR )
+      result += "VideoDecodeKHR | ";
+    if ( value & vk::QueueFlagBits::eVideoEncodeKHR )
+      result += "VideoEncodeKHR | ";
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
 int main( int /*argc*/, char ** /*argv*/ )
 {
   try
@@ -52,29 +148,21 @@ int main( int /*argc*/, char ** /*argv*/ )
       auto queueFamilyProperties2 = physicalDevices[i].getQueueFamilyProperties2<Chain, std::allocator<Chain>, vk::DispatchLoaderDynamic>();
       for ( size_t j = 0; j < queueFamilyProperties2.size(); j++ )
       {
-        std::cout << "\t"
-                  << "QueueFamily " << j << "\n";
+        std::cout << std::string( "\t" ) << "QueueFamily " << j << "\n";
         vk::QueueFamilyProperties const & properties = queueFamilyProperties2[j].get<vk::QueueFamilyProperties2>().queueFamilyProperties;
-        std::cout << "\t\t"
-                  << "QueueFamilyProperties:\n";
-        std::cout << "\t\t\t"
-                  << "queueFlags                  = " << vk::to_string( properties.queueFlags ) << "\n";
-        std::cout << "\t\t\t"
-                  << "queueCount                  = " << properties.queueCount << "\n";
-        std::cout << "\t\t\t"
-                  << "timestampValidBits          = " << properties.timestampValidBits << "\n";
-        std::cout << "\t\t\t"
-                  << "minImageTransferGranularity = " << properties.minImageTransferGranularity.width << " x " << properties.minImageTransferGranularity.height
-                  << " x " << properties.minImageTransferGranularity.depth << "\n";
+        std::cout << std::string( "\t\t" ) << "QueueFamilyProperties:\n";
+        std::cout << std::string( "\t\t\t" ) << "queueFlags                  = " << to_string( properties.queueFlags ) << "\n";
+        std::cout << std::string( "\t\t\t" ) << "queueCount                  = " << properties.queueCount << "\n";
+        std::cout << std::string( "\t\t\t" ) << "timestampValidBits          = " << properties.timestampValidBits << "\n";
+        std::cout << std::string( "\t\t\t" ) << "minImageTransferGranularity = " << properties.minImageTransferGranularity.width << " x "
+                  << properties.minImageTransferGranularity.height << " x " << properties.minImageTransferGranularity.depth << "\n";
         std::cout << "\n";
 
         if ( vk::su::contains( extensionProperties, "VK_NV_device_diagnostic_checkpoints" ) )
         {
           vk::QueueFamilyCheckpointPropertiesNV const & checkpointProperties = queueFamilyProperties2[j].get<vk::QueueFamilyCheckpointPropertiesNV>();
-          std::cout << "\t\t"
-                    << "CheckPointPropertiesNV:\n";
-          std::cout << "\t\t\t"
-                    << "checkpointExecutionStageMask  = " << vk::to_string( checkpointProperties.checkpointExecutionStageMask ) << "\n";
+          std::cout << std::string( "\t\t" ) << "CheckPointPropertiesNV:\n";
+          std::cout << std::string( "\t\t\t" ) << "checkpointExecutionStageMask  = " << to_string( checkpointProperties.checkpointExecutionStageMask ) << "\n";
           std::cout << "\n";
         }
       }

--- a/samples/RayTracing/RayTracing.cpp
+++ b/samples/RayTracing/RayTracing.cpp
@@ -52,6 +52,71 @@
 static char const * AppName    = "RayTracing";
 static char const * EngineName = "Vulkan.hpp";
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::Result value )
+  {
+    switch ( value )
+    {
+      case vk::Result::eSuccess: return "Success";
+      case vk::Result::eNotReady: return "NotReady";
+      case vk::Result::eTimeout: return "Timeout";
+      case vk::Result::eEventSet: return "EventSet";
+      case vk::Result::eEventReset: return "EventReset";
+      case vk::Result::eIncomplete: return "Incomplete";
+      case vk::Result::eErrorOutOfHostMemory: return "ErrorOutOfHostMemory";
+      case vk::Result::eErrorOutOfDeviceMemory: return "ErrorOutOfDeviceMemory";
+      case vk::Result::eErrorInitializationFailed: return "ErrorInitializationFailed";
+      case vk::Result::eErrorDeviceLost: return "ErrorDeviceLost";
+      case vk::Result::eErrorMemoryMapFailed: return "ErrorMemoryMapFailed";
+      case vk::Result::eErrorLayerNotPresent: return "ErrorLayerNotPresent";
+      case vk::Result::eErrorExtensionNotPresent: return "ErrorExtensionNotPresent";
+      case vk::Result::eErrorFeatureNotPresent: return "ErrorFeatureNotPresent";
+      case vk::Result::eErrorIncompatibleDriver: return "ErrorIncompatibleDriver";
+      case vk::Result::eErrorTooManyObjects: return "ErrorTooManyObjects";
+      case vk::Result::eErrorFormatNotSupported: return "ErrorFormatNotSupported";
+      case vk::Result::eErrorFragmentedPool: return "ErrorFragmentedPool";
+      case vk::Result::eErrorUnknown: return "ErrorUnknown";
+      case vk::Result::eErrorOutOfPoolMemory: return "ErrorOutOfPoolMemory";
+      case vk::Result::eErrorInvalidExternalHandle: return "ErrorInvalidExternalHandle";
+      case vk::Result::eErrorFragmentation: return "ErrorFragmentation";
+      case vk::Result::eErrorInvalidOpaqueCaptureAddress: return "ErrorInvalidOpaqueCaptureAddress";
+      case vk::Result::ePipelineCompileRequired: return "PipelineCompileRequired";
+      case vk::Result::eErrorSurfaceLostKHR: return "ErrorSurfaceLostKHR";
+      case vk::Result::eErrorNativeWindowInUseKHR: return "ErrorNativeWindowInUseKHR";
+      case vk::Result::eSuboptimalKHR: return "SuboptimalKHR";
+      case vk::Result::eErrorOutOfDateKHR: return "ErrorOutOfDateKHR";
+      case vk::Result::eErrorIncompatibleDisplayKHR: return "ErrorIncompatibleDisplayKHR";
+      case vk::Result::eErrorValidationFailedEXT: return "ErrorValidationFailedEXT";
+      case vk::Result::eErrorInvalidShaderNV: return "ErrorInvalidShaderNV";
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
+      case vk::Result::eErrorImageUsageNotSupportedKHR: return "ErrorImageUsageNotSupportedKHR";
+      case vk::Result::eErrorVideoPictureLayoutNotSupportedKHR: return "ErrorVideoPictureLayoutNotSupportedKHR";
+      case vk::Result::eErrorVideoProfileOperationNotSupportedKHR: return "ErrorVideoProfileOperationNotSupportedKHR";
+      case vk::Result::eErrorVideoProfileFormatNotSupportedKHR: return "ErrorVideoProfileFormatNotSupportedKHR";
+      case vk::Result::eErrorVideoProfileCodecNotSupportedKHR: return "ErrorVideoProfileCodecNotSupportedKHR";
+      case vk::Result::eErrorVideoStdVersionNotSupportedKHR: return "ErrorVideoStdVersionNotSupportedKHR";
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
+      case vk::Result::eErrorInvalidDrmFormatModifierPlaneLayoutEXT: return "ErrorInvalidDrmFormatModifierPlaneLayoutEXT";
+      case vk::Result::eErrorNotPermittedKHR: return "ErrorNotPermittedKHR";
+#  if defined( VK_USE_PLATFORM_WIN32_KHR )
+      case vk::Result::eErrorFullScreenExclusiveModeLostEXT: return "ErrorFullScreenExclusiveModeLostEXT";
+#  endif /*VK_USE_PLATFORM_WIN32_KHR*/
+      case vk::Result::eThreadIdleKHR: return "ThreadIdleKHR";
+      case vk::Result::eThreadDoneKHR: return "ThreadDoneKHR";
+      case vk::Result::eOperationDeferredKHR: return "OperationDeferredKHR";
+      case vk::Result::eOperationNotDeferredKHR: return "OperationNotDeferredKHR";
+      case vk::Result::eErrorCompressionExhaustedEXT: return "ErrorCompressionExhaustedEXT";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
 struct GeometryInstanceData
 {
   GeometryInstanceData(
@@ -536,7 +601,7 @@ static void check_vk_result( VkResult err )
 {
   if ( err != 0 )
   {
-    std::cerr << AppName << ": Vulkan error " << vk::to_string( static_cast<vk::Result>( err ) );
+    std::cerr << AppName << ": Vulkan error " << to_string( static_cast<vk::Result>( err ) );
     if ( err < 0 )
     {
       abort();

--- a/samples/SurfaceCapabilities/SurfaceCapabilities.cpp
+++ b/samples/SurfaceCapabilities/SurfaceCapabilities.cpp
@@ -25,29 +25,145 @@
 static char const * AppName    = "SurfaceCapabilities";
 static char const * EngineName = "Vulkan.hpp";
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::CompositeAlphaFlagsKHR value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::CompositeAlphaFlagBitsKHR::eOpaque )
+      result += "Opaque | ";
+    if ( value & vk::CompositeAlphaFlagBitsKHR::ePreMultiplied )
+      result += "PreMultiplied | ";
+    if ( value & vk::CompositeAlphaFlagBitsKHR::ePostMultiplied )
+      result += "PostMultiplied | ";
+    if ( value & vk::CompositeAlphaFlagBitsKHR::eInherit )
+      result += "Inherit | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::ImageUsageFlags value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::ImageUsageFlagBits::eTransferSrc )
+      result += "TransferSrc | ";
+    if ( value & vk::ImageUsageFlagBits::eTransferDst )
+      result += "TransferDst | ";
+    if ( value & vk::ImageUsageFlagBits::eSampled )
+      result += "Sampled | ";
+    if ( value & vk::ImageUsageFlagBits::eStorage )
+      result += "Storage | ";
+    if ( value & vk::ImageUsageFlagBits::eColorAttachment )
+      result += "ColorAttachment | ";
+    if ( value & vk::ImageUsageFlagBits::eDepthStencilAttachment )
+      result += "DepthStencilAttachment | ";
+    if ( value & vk::ImageUsageFlagBits::eTransientAttachment )
+      result += "TransientAttachment | ";
+    if ( value & vk::ImageUsageFlagBits::eInputAttachment )
+      result += "InputAttachment | ";
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
+    if ( value & vk::ImageUsageFlagBits::eVideoDecodeDstKHR )
+      result += "VideoDecodeDstKHR | ";
+    if ( value & vk::ImageUsageFlagBits::eVideoDecodeSrcKHR )
+      result += "VideoDecodeSrcKHR | ";
+    if ( value & vk::ImageUsageFlagBits::eVideoDecodeDpbKHR )
+      result += "VideoDecodeDpbKHR | ";
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
+    if ( value & vk::ImageUsageFlagBits::eFragmentDensityMapEXT )
+      result += "FragmentDensityMapEXT | ";
+    if ( value & vk::ImageUsageFlagBits::eFragmentShadingRateAttachmentKHR )
+      result += "FragmentShadingRateAttachmentKHR | ";
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
+    if ( value & vk::ImageUsageFlagBits::eVideoEncodeDstKHR )
+      result += "VideoEncodeDstKHR | ";
+    if ( value & vk::ImageUsageFlagBits::eVideoEncodeSrcKHR )
+      result += "VideoEncodeSrcKHR | ";
+    if ( value & vk::ImageUsageFlagBits::eVideoEncodeDpbKHR )
+      result += "VideoEncodeDpbKHR | ";
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
+    if ( value & vk::ImageUsageFlagBits::eInvocationMaskHUAWEI )
+      result += "InvocationMaskHUAWEI | ";
+    if ( value & vk::ImageUsageFlagBits::eSampleWeightQCOM )
+      result += "SampleWeightQCOM | ";
+    if ( value & vk::ImageUsageFlagBits::eSampleBlockMatchQCOM )
+      result += "SampleBlockMatchQCOM | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+
+  std::string to_string( vk::SurfaceTransformFlagBitsKHR value )
+  {
+    switch ( value )
+    {
+      case vk::SurfaceTransformFlagBitsKHR::eIdentity: return "Identity";
+      case vk::SurfaceTransformFlagBitsKHR::eRotate90: return "Rotate90";
+      case vk::SurfaceTransformFlagBitsKHR::eRotate180: return "Rotate180";
+      case vk::SurfaceTransformFlagBitsKHR::eRotate270: return "Rotate270";
+      case vk::SurfaceTransformFlagBitsKHR::eHorizontalMirror: return "HorizontalMirror";
+      case vk::SurfaceTransformFlagBitsKHR::eHorizontalMirrorRotate90: return "HorizontalMirrorRotate90";
+      case vk::SurfaceTransformFlagBitsKHR::eHorizontalMirrorRotate180: return "HorizontalMirrorRotate180";
+      case vk::SurfaceTransformFlagBitsKHR::eHorizontalMirrorRotate270: return "HorizontalMirrorRotate270";
+      case vk::SurfaceTransformFlagBitsKHR::eInherit: return "Inherit";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+
+  std::string to_string( vk::SurfaceTransformFlagsKHR value )
+  {
+    if ( !value )
+      return "{}";
+
+    std::string result;
+    if ( value & vk::SurfaceTransformFlagBitsKHR::eIdentity )
+      result += "Identity | ";
+    if ( value & vk::SurfaceTransformFlagBitsKHR::eRotate90 )
+      result += "Rotate90 | ";
+    if ( value & vk::SurfaceTransformFlagBitsKHR::eRotate180 )
+      result += "Rotate180 | ";
+    if ( value & vk::SurfaceTransformFlagBitsKHR::eRotate270 )
+      result += "Rotate270 | ";
+    if ( value & vk::SurfaceTransformFlagBitsKHR::eHorizontalMirror )
+      result += "HorizontalMirror | ";
+    if ( value & vk::SurfaceTransformFlagBitsKHR::eHorizontalMirrorRotate90 )
+      result += "HorizontalMirrorRotate90 | ";
+    if ( value & vk::SurfaceTransformFlagBitsKHR::eHorizontalMirrorRotate180 )
+      result += "HorizontalMirrorRotate180 | ";
+    if ( value & vk::SurfaceTransformFlagBitsKHR::eHorizontalMirrorRotate270 )
+      result += "HorizontalMirrorRotate270 | ";
+    if ( value & vk::SurfaceTransformFlagBitsKHR::eInherit )
+      result += "Inherit | ";
+
+    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
 void cout( vk::SurfaceCapabilitiesKHR const & surfaceCapabilities )
 {
-  std::cout << "\tCapabilities:\n";
-  std::cout << "\t\t"
-            << "currentExtent           = " << surfaceCapabilities.currentExtent.width << " x " << surfaceCapabilities.currentExtent.height << "\n";
-  std::cout << "\t\t"
-            << "currentTransform        = " << vk::to_string( surfaceCapabilities.currentTransform ) << "\n";
-  std::cout << "\t\t"
-            << "maxImageArrayLayers     = " << surfaceCapabilities.maxImageArrayLayers << "\n";
-  std::cout << "\t\t"
-            << "maxImageCount           = " << surfaceCapabilities.maxImageCount << "\n";
-  std::cout << "\t\t"
-            << "maxImageExtent          = " << surfaceCapabilities.maxImageExtent.width << " x " << surfaceCapabilities.maxImageExtent.height << "\n";
-  std::cout << "\t\t"
-            << "minImageCount           = " << surfaceCapabilities.minImageCount << "\n";
-  std::cout << "\t\t"
-            << "minImageExtent          = " << surfaceCapabilities.minImageExtent.width << " x " << surfaceCapabilities.minImageExtent.height << "\n";
-  std::cout << "\t\t"
-            << "supportedCompositeAlpha = " << vk::to_string( surfaceCapabilities.supportedCompositeAlpha ) << "\n";
-  std::cout << "\t\t"
-            << "supportedTransforms     = " << vk::to_string( surfaceCapabilities.supportedTransforms ) << "\n";
-  std::cout << "\t\t"
-            << "supportedUsageFlags     = " << vk::to_string( surfaceCapabilities.supportedUsageFlags ) << "\n";
+  std::cout << std::string( "\t" ) << "Capabilities:\n";
+  std::cout << std::string( "\t\t" ) << "currentExtent           = " << surfaceCapabilities.currentExtent.width << " x "
+            << surfaceCapabilities.currentExtent.height << "\n";
+  std::cout << std::string( "\t\t" ) << "currentTransform        = " << to_string( surfaceCapabilities.currentTransform ) << "\n";
+  std::cout << std::string( "\t\t" ) << "maxImageArrayLayers     = " << surfaceCapabilities.maxImageArrayLayers << "\n";
+  std::cout << std::string( "\t\t" ) << "maxImageCount           = " << surfaceCapabilities.maxImageCount << "\n";
+  std::cout << std::string( "\t\t" ) << "maxImageExtent          = " << surfaceCapabilities.maxImageExtent.width << " x "
+            << surfaceCapabilities.maxImageExtent.height << "\n";
+  std::cout << std::string( "\t\t" ) << "minImageCount           = " << surfaceCapabilities.minImageCount << "\n";
+  std::cout << std::string( "\t\t" ) << "minImageExtent          = " << surfaceCapabilities.minImageExtent.width << " x "
+            << surfaceCapabilities.minImageExtent.height << "\n";
+  std::cout << std::string( "\t\t" ) << "supportedCompositeAlpha = " << to_string( surfaceCapabilities.supportedCompositeAlpha ) << "\n";
+  std::cout << std::string( "\t\t" ) << "supportedTransforms     = " << to_string( surfaceCapabilities.supportedTransforms ) << "\n";
+  std::cout << std::string( "\t\t" ) << "supportedUsageFlags     = " << to_string( surfaceCapabilities.supportedUsageFlags ) << "\n";
   std::cout << "\n";
 }
 
@@ -110,18 +226,17 @@ int main( int /*argc*/, char ** /*argv*/ )
         {
           vk::DisplayNativeHdrSurfaceCapabilitiesAMD displayNativeHdrSurfaceCapabilities =
             surfaceCapabilities2.get<vk::DisplayNativeHdrSurfaceCapabilitiesAMD>();
-          std::cout << "\tDisplayNativeHdrSurfaceCapabilitiesAMD:\n";
-          std::cout << "\t\t"
-                    << "localDimmingSupport = " << !!displayNativeHdrSurfaceCapabilities.localDimmingSupport << "\n";
+          std::cout << std::string( "\t" ) << "DisplayNativeHdrSurfaceCapabilitiesAMD:\n";
+          std::cout << std::string( "\t\t" ) << "localDimmingSupport = " << !!displayNativeHdrSurfaceCapabilities.localDimmingSupport << "\n";
           std::cout << "\n";
         }
 
         if ( vk::su::contains( extensionProperties, "VK_KHR_shared_presentable_image" ) )
         {
           vk::SharedPresentSurfaceCapabilitiesKHR sharedPresentSurfaceCapabilities = surfaceCapabilities2.get<vk::SharedPresentSurfaceCapabilitiesKHR>();
-          std::cout << "\tSharedPresentSurfaceCapabilitiesKHR:\n";
-          std::cout << "\t\t"
-                    << "sharedPresentSupportedUsageFlags  = " << vk::to_string( sharedPresentSurfaceCapabilities.sharedPresentSupportedUsageFlags ) << "\n";
+          std::cout << std::string( "\t" ) << "SharedPresentSurfaceCapabilitiesKHR:\n";
+          std::cout << std::string( "\t\t" )
+                    << "sharedPresentSupportedUsageFlags  = " << to_string( sharedPresentSurfaceCapabilities.sharedPresentSupportedUsageFlags ) << "\n";
           std::cout << "\n";
         }
 
@@ -129,18 +244,17 @@ int main( int /*argc*/, char ** /*argv*/ )
         {
           vk::SurfaceCapabilitiesFullScreenExclusiveEXT surfaceCapabilitiesFullScreenExclusive =
             surfaceCapabilities2.get<vk::SurfaceCapabilitiesFullScreenExclusiveEXT>();
-          std::cout << "\tSurfaceCapabilitiesFullScreenExclusiveEXT:\n";
-          std::cout << "\t\t"
-                    << "fullScreenExclusiveSupported  = " << !!surfaceCapabilitiesFullScreenExclusive.fullScreenExclusiveSupported << "\n";
+          std::cout << std::string( "\t" ) << "SurfaceCapabilitiesFullScreenExclusiveEXT:\n";
+          std::cout << std::string( "\t\t" ) << "fullScreenExclusiveSupported  = " << !!surfaceCapabilitiesFullScreenExclusive.fullScreenExclusiveSupported
+                    << "\n";
           std::cout << "\n";
         }
 
         if ( vk::su::contains( extensionProperties, "VK_KHR_surface_protected_capabilities" ) )
         {
           vk::SurfaceProtectedCapabilitiesKHR surfaceProtectedCapabilities = surfaceCapabilities2.get<vk::SurfaceProtectedCapabilitiesKHR>();
-          std::cout << "\tSurfaceProtectedCapabilitiesKHR:\n";
-          std::cout << "\t\t"
-                    << "supportsProtected  = " << !!surfaceProtectedCapabilities.supportsProtected << "\n";
+          std::cout << std::string( "\t" ) << "SurfaceProtectedCapabilitiesKHR:\n";
+          std::cout << std::string( "\t\t" ) << "supportsProtected  = " << !!surfaceProtectedCapabilities.supportsProtected << "\n";
           std::cout << "\n";
         }
       }

--- a/samples/SurfaceFormats/SurfaceFormats.cpp
+++ b/samples/SurfaceFormats/SurfaceFormats.cpp
@@ -25,6 +25,293 @@
 static char const * AppName    = "SurfaceFormats";
 static char const * EngineName = "Vulkan.hpp";
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+namespace local
+{
+  std::string to_string( vk::ColorSpaceKHR value )
+  {
+    switch ( value )
+    {
+      case vk::ColorSpaceKHR::eSrgbNonlinear: return "SrgbNonlinear";
+      case vk::ColorSpaceKHR::eDisplayP3NonlinearEXT: return "DisplayP3NonlinearEXT";
+      case vk::ColorSpaceKHR::eExtendedSrgbLinearEXT: return "ExtendedSrgbLinearEXT";
+      case vk::ColorSpaceKHR::eDisplayP3LinearEXT: return "DisplayP3LinearEXT";
+      case vk::ColorSpaceKHR::eDciP3NonlinearEXT: return "DciP3NonlinearEXT";
+      case vk::ColorSpaceKHR::eBt709LinearEXT: return "Bt709LinearEXT";
+      case vk::ColorSpaceKHR::eBt709NonlinearEXT: return "Bt709NonlinearEXT";
+      case vk::ColorSpaceKHR::eBt2020LinearEXT: return "Bt2020LinearEXT";
+      case vk::ColorSpaceKHR::eHdr10St2084EXT: return "Hdr10St2084EXT";
+      case vk::ColorSpaceKHR::eDolbyvisionEXT: return "DolbyvisionEXT";
+      case vk::ColorSpaceKHR::eHdr10HlgEXT: return "Hdr10HlgEXT";
+      case vk::ColorSpaceKHR::eAdobergbLinearEXT: return "AdobergbLinearEXT";
+      case vk::ColorSpaceKHR::eAdobergbNonlinearEXT: return "AdobergbNonlinearEXT";
+      case vk::ColorSpaceKHR::ePassThroughEXT: return "PassThroughEXT";
+      case vk::ColorSpaceKHR::eExtendedSrgbNonlinearEXT: return "ExtendedSrgbNonlinearEXT";
+      case vk::ColorSpaceKHR::eDisplayNativeAMD: return "DisplayNativeAMD";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+
+  std::string to_string( vk::Format value )
+  {
+    switch ( value )
+    {
+      case vk::Format::eUndefined: return "Undefined";
+      case vk::Format::eR4G4UnormPack8: return "R4G4UnormPack8";
+      case vk::Format::eR4G4B4A4UnormPack16: return "R4G4B4A4UnormPack16";
+      case vk::Format::eB4G4R4A4UnormPack16: return "B4G4R4A4UnormPack16";
+      case vk::Format::eR5G6B5UnormPack16: return "R5G6B5UnormPack16";
+      case vk::Format::eB5G6R5UnormPack16: return "B5G6R5UnormPack16";
+      case vk::Format::eR5G5B5A1UnormPack16: return "R5G5B5A1UnormPack16";
+      case vk::Format::eB5G5R5A1UnormPack16: return "B5G5R5A1UnormPack16";
+      case vk::Format::eA1R5G5B5UnormPack16: return "A1R5G5B5UnormPack16";
+      case vk::Format::eR8Unorm: return "R8Unorm";
+      case vk::Format::eR8Snorm: return "R8Snorm";
+      case vk::Format::eR8Uscaled: return "R8Uscaled";
+      case vk::Format::eR8Sscaled: return "R8Sscaled";
+      case vk::Format::eR8Uint: return "R8Uint";
+      case vk::Format::eR8Sint: return "R8Sint";
+      case vk::Format::eR8Srgb: return "R8Srgb";
+      case vk::Format::eR8G8Unorm: return "R8G8Unorm";
+      case vk::Format::eR8G8Snorm: return "R8G8Snorm";
+      case vk::Format::eR8G8Uscaled: return "R8G8Uscaled";
+      case vk::Format::eR8G8Sscaled: return "R8G8Sscaled";
+      case vk::Format::eR8G8Uint: return "R8G8Uint";
+      case vk::Format::eR8G8Sint: return "R8G8Sint";
+      case vk::Format::eR8G8Srgb: return "R8G8Srgb";
+      case vk::Format::eR8G8B8Unorm: return "R8G8B8Unorm";
+      case vk::Format::eR8G8B8Snorm: return "R8G8B8Snorm";
+      case vk::Format::eR8G8B8Uscaled: return "R8G8B8Uscaled";
+      case vk::Format::eR8G8B8Sscaled: return "R8G8B8Sscaled";
+      case vk::Format::eR8G8B8Uint: return "R8G8B8Uint";
+      case vk::Format::eR8G8B8Sint: return "R8G8B8Sint";
+      case vk::Format::eR8G8B8Srgb: return "R8G8B8Srgb";
+      case vk::Format::eB8G8R8Unorm: return "B8G8R8Unorm";
+      case vk::Format::eB8G8R8Snorm: return "B8G8R8Snorm";
+      case vk::Format::eB8G8R8Uscaled: return "B8G8R8Uscaled";
+      case vk::Format::eB8G8R8Sscaled: return "B8G8R8Sscaled";
+      case vk::Format::eB8G8R8Uint: return "B8G8R8Uint";
+      case vk::Format::eB8G8R8Sint: return "B8G8R8Sint";
+      case vk::Format::eB8G8R8Srgb: return "B8G8R8Srgb";
+      case vk::Format::eR8G8B8A8Unorm: return "R8G8B8A8Unorm";
+      case vk::Format::eR8G8B8A8Snorm: return "R8G8B8A8Snorm";
+      case vk::Format::eR8G8B8A8Uscaled: return "R8G8B8A8Uscaled";
+      case vk::Format::eR8G8B8A8Sscaled: return "R8G8B8A8Sscaled";
+      case vk::Format::eR8G8B8A8Uint: return "R8G8B8A8Uint";
+      case vk::Format::eR8G8B8A8Sint: return "R8G8B8A8Sint";
+      case vk::Format::eR8G8B8A8Srgb: return "R8G8B8A8Srgb";
+      case vk::Format::eB8G8R8A8Unorm: return "B8G8R8A8Unorm";
+      case vk::Format::eB8G8R8A8Snorm: return "B8G8R8A8Snorm";
+      case vk::Format::eB8G8R8A8Uscaled: return "B8G8R8A8Uscaled";
+      case vk::Format::eB8G8R8A8Sscaled: return "B8G8R8A8Sscaled";
+      case vk::Format::eB8G8R8A8Uint: return "B8G8R8A8Uint";
+      case vk::Format::eB8G8R8A8Sint: return "B8G8R8A8Sint";
+      case vk::Format::eB8G8R8A8Srgb: return "B8G8R8A8Srgb";
+      case vk::Format::eA8B8G8R8UnormPack32: return "A8B8G8R8UnormPack32";
+      case vk::Format::eA8B8G8R8SnormPack32: return "A8B8G8R8SnormPack32";
+      case vk::Format::eA8B8G8R8UscaledPack32: return "A8B8G8R8UscaledPack32";
+      case vk::Format::eA8B8G8R8SscaledPack32: return "A8B8G8R8SscaledPack32";
+      case vk::Format::eA8B8G8R8UintPack32: return "A8B8G8R8UintPack32";
+      case vk::Format::eA8B8G8R8SintPack32: return "A8B8G8R8SintPack32";
+      case vk::Format::eA8B8G8R8SrgbPack32: return "A8B8G8R8SrgbPack32";
+      case vk::Format::eA2R10G10B10UnormPack32: return "A2R10G10B10UnormPack32";
+      case vk::Format::eA2R10G10B10SnormPack32: return "A2R10G10B10SnormPack32";
+      case vk::Format::eA2R10G10B10UscaledPack32: return "A2R10G10B10UscaledPack32";
+      case vk::Format::eA2R10G10B10SscaledPack32: return "A2R10G10B10SscaledPack32";
+      case vk::Format::eA2R10G10B10UintPack32: return "A2R10G10B10UintPack32";
+      case vk::Format::eA2R10G10B10SintPack32: return "A2R10G10B10SintPack32";
+      case vk::Format::eA2B10G10R10UnormPack32: return "A2B10G10R10UnormPack32";
+      case vk::Format::eA2B10G10R10SnormPack32: return "A2B10G10R10SnormPack32";
+      case vk::Format::eA2B10G10R10UscaledPack32: return "A2B10G10R10UscaledPack32";
+      case vk::Format::eA2B10G10R10SscaledPack32: return "A2B10G10R10SscaledPack32";
+      case vk::Format::eA2B10G10R10UintPack32: return "A2B10G10R10UintPack32";
+      case vk::Format::eA2B10G10R10SintPack32: return "A2B10G10R10SintPack32";
+      case vk::Format::eR16Unorm: return "R16Unorm";
+      case vk::Format::eR16Snorm: return "R16Snorm";
+      case vk::Format::eR16Uscaled: return "R16Uscaled";
+      case vk::Format::eR16Sscaled: return "R16Sscaled";
+      case vk::Format::eR16Uint: return "R16Uint";
+      case vk::Format::eR16Sint: return "R16Sint";
+      case vk::Format::eR16Sfloat: return "R16Sfloat";
+      case vk::Format::eR16G16Unorm: return "R16G16Unorm";
+      case vk::Format::eR16G16Snorm: return "R16G16Snorm";
+      case vk::Format::eR16G16Uscaled: return "R16G16Uscaled";
+      case vk::Format::eR16G16Sscaled: return "R16G16Sscaled";
+      case vk::Format::eR16G16Uint: return "R16G16Uint";
+      case vk::Format::eR16G16Sint: return "R16G16Sint";
+      case vk::Format::eR16G16Sfloat: return "R16G16Sfloat";
+      case vk::Format::eR16G16B16Unorm: return "R16G16B16Unorm";
+      case vk::Format::eR16G16B16Snorm: return "R16G16B16Snorm";
+      case vk::Format::eR16G16B16Uscaled: return "R16G16B16Uscaled";
+      case vk::Format::eR16G16B16Sscaled: return "R16G16B16Sscaled";
+      case vk::Format::eR16G16B16Uint: return "R16G16B16Uint";
+      case vk::Format::eR16G16B16Sint: return "R16G16B16Sint";
+      case vk::Format::eR16G16B16Sfloat: return "R16G16B16Sfloat";
+      case vk::Format::eR16G16B16A16Unorm: return "R16G16B16A16Unorm";
+      case vk::Format::eR16G16B16A16Snorm: return "R16G16B16A16Snorm";
+      case vk::Format::eR16G16B16A16Uscaled: return "R16G16B16A16Uscaled";
+      case vk::Format::eR16G16B16A16Sscaled: return "R16G16B16A16Sscaled";
+      case vk::Format::eR16G16B16A16Uint: return "R16G16B16A16Uint";
+      case vk::Format::eR16G16B16A16Sint: return "R16G16B16A16Sint";
+      case vk::Format::eR16G16B16A16Sfloat: return "R16G16B16A16Sfloat";
+      case vk::Format::eR32Uint: return "R32Uint";
+      case vk::Format::eR32Sint: return "R32Sint";
+      case vk::Format::eR32Sfloat: return "R32Sfloat";
+      case vk::Format::eR32G32Uint: return "R32G32Uint";
+      case vk::Format::eR32G32Sint: return "R32G32Sint";
+      case vk::Format::eR32G32Sfloat: return "R32G32Sfloat";
+      case vk::Format::eR32G32B32Uint: return "R32G32B32Uint";
+      case vk::Format::eR32G32B32Sint: return "R32G32B32Sint";
+      case vk::Format::eR32G32B32Sfloat: return "R32G32B32Sfloat";
+      case vk::Format::eR32G32B32A32Uint: return "R32G32B32A32Uint";
+      case vk::Format::eR32G32B32A32Sint: return "R32G32B32A32Sint";
+      case vk::Format::eR32G32B32A32Sfloat: return "R32G32B32A32Sfloat";
+      case vk::Format::eR64Uint: return "R64Uint";
+      case vk::Format::eR64Sint: return "R64Sint";
+      case vk::Format::eR64Sfloat: return "R64Sfloat";
+      case vk::Format::eR64G64Uint: return "R64G64Uint";
+      case vk::Format::eR64G64Sint: return "R64G64Sint";
+      case vk::Format::eR64G64Sfloat: return "R64G64Sfloat";
+      case vk::Format::eR64G64B64Uint: return "R64G64B64Uint";
+      case vk::Format::eR64G64B64Sint: return "R64G64B64Sint";
+      case vk::Format::eR64G64B64Sfloat: return "R64G64B64Sfloat";
+      case vk::Format::eR64G64B64A64Uint: return "R64G64B64A64Uint";
+      case vk::Format::eR64G64B64A64Sint: return "R64G64B64A64Sint";
+      case vk::Format::eR64G64B64A64Sfloat: return "R64G64B64A64Sfloat";
+      case vk::Format::eB10G11R11UfloatPack32: return "B10G11R11UfloatPack32";
+      case vk::Format::eE5B9G9R9UfloatPack32: return "E5B9G9R9UfloatPack32";
+      case vk::Format::eD16Unorm: return "D16Unorm";
+      case vk::Format::eX8D24UnormPack32: return "X8D24UnormPack32";
+      case vk::Format::eD32Sfloat: return "D32Sfloat";
+      case vk::Format::eS8Uint: return "S8Uint";
+      case vk::Format::eD16UnormS8Uint: return "D16UnormS8Uint";
+      case vk::Format::eD24UnormS8Uint: return "D24UnormS8Uint";
+      case vk::Format::eD32SfloatS8Uint: return "D32SfloatS8Uint";
+      case vk::Format::eBc1RgbUnormBlock: return "Bc1RgbUnormBlock";
+      case vk::Format::eBc1RgbSrgbBlock: return "Bc1RgbSrgbBlock";
+      case vk::Format::eBc1RgbaUnormBlock: return "Bc1RgbaUnormBlock";
+      case vk::Format::eBc1RgbaSrgbBlock: return "Bc1RgbaSrgbBlock";
+      case vk::Format::eBc2UnormBlock: return "Bc2UnormBlock";
+      case vk::Format::eBc2SrgbBlock: return "Bc2SrgbBlock";
+      case vk::Format::eBc3UnormBlock: return "Bc3UnormBlock";
+      case vk::Format::eBc3SrgbBlock: return "Bc3SrgbBlock";
+      case vk::Format::eBc4UnormBlock: return "Bc4UnormBlock";
+      case vk::Format::eBc4SnormBlock: return "Bc4SnormBlock";
+      case vk::Format::eBc5UnormBlock: return "Bc5UnormBlock";
+      case vk::Format::eBc5SnormBlock: return "Bc5SnormBlock";
+      case vk::Format::eBc6HUfloatBlock: return "Bc6HUfloatBlock";
+      case vk::Format::eBc6HSfloatBlock: return "Bc6HSfloatBlock";
+      case vk::Format::eBc7UnormBlock: return "Bc7UnormBlock";
+      case vk::Format::eBc7SrgbBlock: return "Bc7SrgbBlock";
+      case vk::Format::eEtc2R8G8B8UnormBlock: return "Etc2R8G8B8UnormBlock";
+      case vk::Format::eEtc2R8G8B8SrgbBlock: return "Etc2R8G8B8SrgbBlock";
+      case vk::Format::eEtc2R8G8B8A1UnormBlock: return "Etc2R8G8B8A1UnormBlock";
+      case vk::Format::eEtc2R8G8B8A1SrgbBlock: return "Etc2R8G8B8A1SrgbBlock";
+      case vk::Format::eEtc2R8G8B8A8UnormBlock: return "Etc2R8G8B8A8UnormBlock";
+      case vk::Format::eEtc2R8G8B8A8SrgbBlock: return "Etc2R8G8B8A8SrgbBlock";
+      case vk::Format::eEacR11UnormBlock: return "EacR11UnormBlock";
+      case vk::Format::eEacR11SnormBlock: return "EacR11SnormBlock";
+      case vk::Format::eEacR11G11UnormBlock: return "EacR11G11UnormBlock";
+      case vk::Format::eEacR11G11SnormBlock: return "EacR11G11SnormBlock";
+      case vk::Format::eAstc4x4UnormBlock: return "Astc4x4UnormBlock";
+      case vk::Format::eAstc4x4SrgbBlock: return "Astc4x4SrgbBlock";
+      case vk::Format::eAstc5x4UnormBlock: return "Astc5x4UnormBlock";
+      case vk::Format::eAstc5x4SrgbBlock: return "Astc5x4SrgbBlock";
+      case vk::Format::eAstc5x5UnormBlock: return "Astc5x5UnormBlock";
+      case vk::Format::eAstc5x5SrgbBlock: return "Astc5x5SrgbBlock";
+      case vk::Format::eAstc6x5UnormBlock: return "Astc6x5UnormBlock";
+      case vk::Format::eAstc6x5SrgbBlock: return "Astc6x5SrgbBlock";
+      case vk::Format::eAstc6x6UnormBlock: return "Astc6x6UnormBlock";
+      case vk::Format::eAstc6x6SrgbBlock: return "Astc6x6SrgbBlock";
+      case vk::Format::eAstc8x5UnormBlock: return "Astc8x5UnormBlock";
+      case vk::Format::eAstc8x5SrgbBlock: return "Astc8x5SrgbBlock";
+      case vk::Format::eAstc8x6UnormBlock: return "Astc8x6UnormBlock";
+      case vk::Format::eAstc8x6SrgbBlock: return "Astc8x6SrgbBlock";
+      case vk::Format::eAstc8x8UnormBlock: return "Astc8x8UnormBlock";
+      case vk::Format::eAstc8x8SrgbBlock: return "Astc8x8SrgbBlock";
+      case vk::Format::eAstc10x5UnormBlock: return "Astc10x5UnormBlock";
+      case vk::Format::eAstc10x5SrgbBlock: return "Astc10x5SrgbBlock";
+      case vk::Format::eAstc10x6UnormBlock: return "Astc10x6UnormBlock";
+      case vk::Format::eAstc10x6SrgbBlock: return "Astc10x6SrgbBlock";
+      case vk::Format::eAstc10x8UnormBlock: return "Astc10x8UnormBlock";
+      case vk::Format::eAstc10x8SrgbBlock: return "Astc10x8SrgbBlock";
+      case vk::Format::eAstc10x10UnormBlock: return "Astc10x10UnormBlock";
+      case vk::Format::eAstc10x10SrgbBlock: return "Astc10x10SrgbBlock";
+      case vk::Format::eAstc12x10UnormBlock: return "Astc12x10UnormBlock";
+      case vk::Format::eAstc12x10SrgbBlock: return "Astc12x10SrgbBlock";
+      case vk::Format::eAstc12x12UnormBlock: return "Astc12x12UnormBlock";
+      case vk::Format::eAstc12x12SrgbBlock: return "Astc12x12SrgbBlock";
+      case vk::Format::eG8B8G8R8422Unorm: return "G8B8G8R8422Unorm";
+      case vk::Format::eB8G8R8G8422Unorm: return "B8G8R8G8422Unorm";
+      case vk::Format::eG8B8R83Plane420Unorm: return "G8B8R83Plane420Unorm";
+      case vk::Format::eG8B8R82Plane420Unorm: return "G8B8R82Plane420Unorm";
+      case vk::Format::eG8B8R83Plane422Unorm: return "G8B8R83Plane422Unorm";
+      case vk::Format::eG8B8R82Plane422Unorm: return "G8B8R82Plane422Unorm";
+      case vk::Format::eG8B8R83Plane444Unorm: return "G8B8R83Plane444Unorm";
+      case vk::Format::eR10X6UnormPack16: return "R10X6UnormPack16";
+      case vk::Format::eR10X6G10X6Unorm2Pack16: return "R10X6G10X6Unorm2Pack16";
+      case vk::Format::eR10X6G10X6B10X6A10X6Unorm4Pack16: return "R10X6G10X6B10X6A10X6Unorm4Pack16";
+      case vk::Format::eG10X6B10X6G10X6R10X6422Unorm4Pack16: return "G10X6B10X6G10X6R10X6422Unorm4Pack16";
+      case vk::Format::eB10X6G10X6R10X6G10X6422Unorm4Pack16: return "B10X6G10X6R10X6G10X6422Unorm4Pack16";
+      case vk::Format::eG10X6B10X6R10X63Plane420Unorm3Pack16: return "G10X6B10X6R10X63Plane420Unorm3Pack16";
+      case vk::Format::eG10X6B10X6R10X62Plane420Unorm3Pack16: return "G10X6B10X6R10X62Plane420Unorm3Pack16";
+      case vk::Format::eG10X6B10X6R10X63Plane422Unorm3Pack16: return "G10X6B10X6R10X63Plane422Unorm3Pack16";
+      case vk::Format::eG10X6B10X6R10X62Plane422Unorm3Pack16: return "G10X6B10X6R10X62Plane422Unorm3Pack16";
+      case vk::Format::eG10X6B10X6R10X63Plane444Unorm3Pack16: return "G10X6B10X6R10X63Plane444Unorm3Pack16";
+      case vk::Format::eR12X4UnormPack16: return "R12X4UnormPack16";
+      case vk::Format::eR12X4G12X4Unorm2Pack16: return "R12X4G12X4Unorm2Pack16";
+      case vk::Format::eR12X4G12X4B12X4A12X4Unorm4Pack16: return "R12X4G12X4B12X4A12X4Unorm4Pack16";
+      case vk::Format::eG12X4B12X4G12X4R12X4422Unorm4Pack16: return "G12X4B12X4G12X4R12X4422Unorm4Pack16";
+      case vk::Format::eB12X4G12X4R12X4G12X4422Unorm4Pack16: return "B12X4G12X4R12X4G12X4422Unorm4Pack16";
+      case vk::Format::eG12X4B12X4R12X43Plane420Unorm3Pack16: return "G12X4B12X4R12X43Plane420Unorm3Pack16";
+      case vk::Format::eG12X4B12X4R12X42Plane420Unorm3Pack16: return "G12X4B12X4R12X42Plane420Unorm3Pack16";
+      case vk::Format::eG12X4B12X4R12X43Plane422Unorm3Pack16: return "G12X4B12X4R12X43Plane422Unorm3Pack16";
+      case vk::Format::eG12X4B12X4R12X42Plane422Unorm3Pack16: return "G12X4B12X4R12X42Plane422Unorm3Pack16";
+      case vk::Format::eG12X4B12X4R12X43Plane444Unorm3Pack16: return "G12X4B12X4R12X43Plane444Unorm3Pack16";
+      case vk::Format::eG16B16G16R16422Unorm: return "G16B16G16R16422Unorm";
+      case vk::Format::eB16G16R16G16422Unorm: return "B16G16R16G16422Unorm";
+      case vk::Format::eG16B16R163Plane420Unorm: return "G16B16R163Plane420Unorm";
+      case vk::Format::eG16B16R162Plane420Unorm: return "G16B16R162Plane420Unorm";
+      case vk::Format::eG16B16R163Plane422Unorm: return "G16B16R163Plane422Unorm";
+      case vk::Format::eG16B16R162Plane422Unorm: return "G16B16R162Plane422Unorm";
+      case vk::Format::eG16B16R163Plane444Unorm: return "G16B16R163Plane444Unorm";
+      case vk::Format::eG8B8R82Plane444Unorm: return "G8B8R82Plane444Unorm";
+      case vk::Format::eG10X6B10X6R10X62Plane444Unorm3Pack16: return "G10X6B10X6R10X62Plane444Unorm3Pack16";
+      case vk::Format::eG12X4B12X4R12X42Plane444Unorm3Pack16: return "G12X4B12X4R12X42Plane444Unorm3Pack16";
+      case vk::Format::eG16B16R162Plane444Unorm: return "G16B16R162Plane444Unorm";
+      case vk::Format::eA4R4G4B4UnormPack16: return "A4R4G4B4UnormPack16";
+      case vk::Format::eA4B4G4R4UnormPack16: return "A4B4G4R4UnormPack16";
+      case vk::Format::eAstc4x4SfloatBlock: return "Astc4x4SfloatBlock";
+      case vk::Format::eAstc5x4SfloatBlock: return "Astc5x4SfloatBlock";
+      case vk::Format::eAstc5x5SfloatBlock: return "Astc5x5SfloatBlock";
+      case vk::Format::eAstc6x5SfloatBlock: return "Astc6x5SfloatBlock";
+      case vk::Format::eAstc6x6SfloatBlock: return "Astc6x6SfloatBlock";
+      case vk::Format::eAstc8x5SfloatBlock: return "Astc8x5SfloatBlock";
+      case vk::Format::eAstc8x6SfloatBlock: return "Astc8x6SfloatBlock";
+      case vk::Format::eAstc8x8SfloatBlock: return "Astc8x8SfloatBlock";
+      case vk::Format::eAstc10x5SfloatBlock: return "Astc10x5SfloatBlock";
+      case vk::Format::eAstc10x6SfloatBlock: return "Astc10x6SfloatBlock";
+      case vk::Format::eAstc10x8SfloatBlock: return "Astc10x8SfloatBlock";
+      case vk::Format::eAstc10x10SfloatBlock: return "Astc10x10SfloatBlock";
+      case vk::Format::eAstc12x10SfloatBlock: return "Astc12x10SfloatBlock";
+      case vk::Format::eAstc12x12SfloatBlock: return "Astc12x12SfloatBlock";
+      case vk::Format::ePvrtc12BppUnormBlockIMG: return "Pvrtc12BppUnormBlockIMG";
+      case vk::Format::ePvrtc14BppUnormBlockIMG: return "Pvrtc14BppUnormBlockIMG";
+      case vk::Format::ePvrtc22BppUnormBlockIMG: return "Pvrtc22BppUnormBlockIMG";
+      case vk::Format::ePvrtc24BppUnormBlockIMG: return "Pvrtc24BppUnormBlockIMG";
+      case vk::Format::ePvrtc12BppSrgbBlockIMG: return "Pvrtc12BppSrgbBlockIMG";
+      case vk::Format::ePvrtc14BppSrgbBlockIMG: return "Pvrtc14BppSrgbBlockIMG";
+      case vk::Format::ePvrtc22BppSrgbBlockIMG: return "Pvrtc22BppSrgbBlockIMG";
+      case vk::Format::ePvrtc24BppSrgbBlockIMG: return "Pvrtc24BppSrgbBlockIMG";
+      default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+    }
+  }
+}  // namespace local
+using local::to_string;
+#else
+using vk::to_string;
+#endif
+
 int main( int /*argc*/, char ** /*argv*/ )
 {
   try
@@ -48,11 +335,9 @@ int main( int /*argc*/, char ** /*argv*/ )
       std::vector<vk::SurfaceFormatKHR> surfaceFormats = physicalDevices[i].getSurfaceFormatsKHR( surfaceData.surface );
       for ( size_t j = 0; j < surfaceFormats.size(); j++ )
       {
-        std::cout << "\tFormat " << j << "\n";
-        std::cout << "\t\t"
-                  << "colorSpace  = " << vk::to_string( surfaceFormats[j].colorSpace ) << "\n";
-        std::cout << "\t\t"
-                  << "format      = " << vk::to_string( surfaceFormats[j].format ) << "\n";
+        std::cout << std::string( "\t" ) << "Format " << j << "\n";
+        std::cout << std::string( "\t\t" ) << "colorSpace  = " << to_string( surfaceFormats[j].colorSpace ) << "\n";
+        std::cout << std::string( "\t\t" ) << "format      = " << to_string( surfaceFormats[j].format ) << "\n";
         std::cout << "\n";
       }
     }

--- a/samples/utils/utils.cpp
+++ b/samples/utils/utils.cpp
@@ -361,6 +361,97 @@ namespace vk
       return device.createRenderPass( vk::RenderPassCreateInfo( vk::RenderPassCreateFlags(), attachmentDescriptions, subpassDescription ) );
     }
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+    namespace local
+    {
+      std::string to_string( vk::DebugUtilsMessageSeverityFlagBitsEXT value )
+      {
+        switch ( value )
+        {
+          case vk::DebugUtilsMessageSeverityFlagBitsEXT::eVerbose: return "Verbose";
+          case vk::DebugUtilsMessageSeverityFlagBitsEXT::eInfo: return "Info";
+          case vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning: return "Warning";
+          case vk::DebugUtilsMessageSeverityFlagBitsEXT::eError: return "Error";
+          default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+        }
+      }
+
+      std::string to_string( vk::DebugUtilsMessageTypeFlagsEXT value )
+      {
+        if ( !value )
+          return "{}";
+
+        std::string result;
+        if ( value & vk::DebugUtilsMessageTypeFlagBitsEXT::eGeneral )
+          result += "General | ";
+        if ( value & vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation )
+          result += "Validation | ";
+        if ( value & vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance )
+          result += "Performance | ";
+
+        return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+      }
+
+      std::string to_string( vk::ObjectType value )
+      {
+        switch ( value )
+        {
+          case vk::ObjectType::eUnknown: return "Unknown";
+          case vk::ObjectType::eInstance: return "Instance";
+          case vk::ObjectType::ePhysicalDevice: return "PhysicalDevice";
+          case vk::ObjectType::eDevice: return "Device";
+          case vk::ObjectType::eQueue: return "Queue";
+          case vk::ObjectType::eSemaphore: return "Semaphore";
+          case vk::ObjectType::eCommandBuffer: return "CommandBuffer";
+          case vk::ObjectType::eFence: return "Fence";
+          case vk::ObjectType::eDeviceMemory: return "DeviceMemory";
+          case vk::ObjectType::eBuffer: return "Buffer";
+          case vk::ObjectType::eImage: return "Image";
+          case vk::ObjectType::eEvent: return "Event";
+          case vk::ObjectType::eQueryPool: return "QueryPool";
+          case vk::ObjectType::eBufferView: return "BufferView";
+          case vk::ObjectType::eImageView: return "ImageView";
+          case vk::ObjectType::eShaderModule: return "ShaderModule";
+          case vk::ObjectType::ePipelineCache: return "PipelineCache";
+          case vk::ObjectType::ePipelineLayout: return "PipelineLayout";
+          case vk::ObjectType::eRenderPass: return "RenderPass";
+          case vk::ObjectType::ePipeline: return "Pipeline";
+          case vk::ObjectType::eDescriptorSetLayout: return "DescriptorSetLayout";
+          case vk::ObjectType::eSampler: return "Sampler";
+          case vk::ObjectType::eDescriptorPool: return "DescriptorPool";
+          case vk::ObjectType::eDescriptorSet: return "DescriptorSet";
+          case vk::ObjectType::eFramebuffer: return "Framebuffer";
+          case vk::ObjectType::eCommandPool: return "CommandPool";
+          case vk::ObjectType::eSamplerYcbcrConversion: return "SamplerYcbcrConversion";
+          case vk::ObjectType::eDescriptorUpdateTemplate: return "DescriptorUpdateTemplate";
+          case vk::ObjectType::ePrivateDataSlot: return "PrivateDataSlot";
+          case vk::ObjectType::eSurfaceKHR: return "SurfaceKHR";
+          case vk::ObjectType::eSwapchainKHR: return "SwapchainKHR";
+          case vk::ObjectType::eDisplayKHR: return "DisplayKHR";
+          case vk::ObjectType::eDisplayModeKHR: return "DisplayModeKHR";
+          case vk::ObjectType::eDebugReportCallbackEXT: return "DebugReportCallbackEXT";
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
+          case vk::ObjectType::eVideoSessionKHR: return "VideoSessionKHR";
+          case vk::ObjectType::eVideoSessionParametersKHR: return "VideoSessionParametersKHR";
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
+          case vk::ObjectType::eCuModuleNVX: return "CuModuleNVX";
+          case vk::ObjectType::eCuFunctionNVX: return "CuFunctionNVX";
+          case vk::ObjectType::eDebugUtilsMessengerEXT: return "DebugUtilsMessengerEXT";
+          case vk::ObjectType::eAccelerationStructureKHR: return "AccelerationStructureKHR";
+          case vk::ObjectType::eValidationCacheEXT: return "ValidationCacheEXT";
+          case vk::ObjectType::eAccelerationStructureNV: return "AccelerationStructureNV";
+          case vk::ObjectType::ePerformanceConfigurationINTEL: return "PerformanceConfigurationINTEL";
+          case vk::ObjectType::eDeferredOperationKHR: return "DeferredOperationKHR";
+          case vk::ObjectType::eIndirectCommandsLayoutNV: return "IndirectCommandsLayoutNV";
+#  if defined( VK_USE_PLATFORM_FUCHSIA )
+          case vk::ObjectType::eBufferCollectionFUCHSIA: return "BufferCollectionFUCHSIA";
+#  endif /*VK_USE_PLATFORM_FUCHSIA*/
+          default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
+        }
+      }
+    }  // namespace local
+#endif
+
     VKAPI_ATTR VkBool32 VKAPI_CALL debugUtilsMessengerCallback( VkDebugUtilsMessageSeverityFlagBitsEXT       messageSeverity,
                                                                 VkDebugUtilsMessageTypeFlagsEXT              messageTypes,
                                                                 VkDebugUtilsMessengerCallbackDataEXT const * pCallbackData,
@@ -379,50 +470,49 @@ namespace vk
       }
 #endif
 
+#if defined( VULKAN_HPP_NO_TO_STRING )
+      std::cerr << local::to_string( static_cast<vk::DebugUtilsMessageSeverityFlagBitsEXT>( messageSeverity ) ) << ": "
+                << local::to_string( static_cast<vk::DebugUtilsMessageTypeFlagsEXT>( messageTypes ) ) << ":\n";
+#else
       std::cerr << vk::to_string( static_cast<vk::DebugUtilsMessageSeverityFlagBitsEXT>( messageSeverity ) ) << ": "
                 << vk::to_string( static_cast<vk::DebugUtilsMessageTypeFlagsEXT>( messageTypes ) ) << ":\n";
-      std::cerr << "\t"
-                << "messageIDName   = <" << pCallbackData->pMessageIdName << ">\n";
-      std::cerr << "\t"
-                << "messageIdNumber = " << pCallbackData->messageIdNumber << "\n";
-      std::cerr << "\t"
-                << "message         = <" << pCallbackData->pMessage << ">\n";
+#endif
+      std::cerr << std::string( "\t" ) << "messageIDName   = <" << pCallbackData->pMessageIdName << ">\n";
+      std::cerr << std::string( "\t" ) << "messageIdNumber = " << pCallbackData->messageIdNumber << "\n";
+      std::cerr << std::string( "\t" ) << "message         = <" << pCallbackData->pMessage << ">\n";
       if ( 0 < pCallbackData->queueLabelCount )
       {
-        std::cerr << "\t"
-                  << "Queue Labels:\n";
+        std::cerr << std::string( "\t" ) << "Queue Labels:\n";
         for ( uint32_t i = 0; i < pCallbackData->queueLabelCount; i++ )
         {
-          std::cerr << "\t\t"
-                    << "labelName = <" << pCallbackData->pQueueLabels[i].pLabelName << ">\n";
+          std::cerr << std::string( "\t\t" ) << "labelName = <" << pCallbackData->pQueueLabels[i].pLabelName << ">\n";
         }
       }
       if ( 0 < pCallbackData->cmdBufLabelCount )
       {
-        std::cerr << "\t"
-                  << "CommandBuffer Labels:\n";
+        std::cerr << std::string( "\t" ) << "CommandBuffer Labels:\n";
         for ( uint32_t i = 0; i < pCallbackData->cmdBufLabelCount; i++ )
         {
-          std::cerr << "\t\t"
-                    << "labelName = <" << pCallbackData->pCmdBufLabels[i].pLabelName << ">\n";
+          std::cerr << std::string( "\t\t" ) << "labelName = <" << pCallbackData->pCmdBufLabels[i].pLabelName << ">\n";
         }
       }
       if ( 0 < pCallbackData->objectCount )
       {
-        std::cerr << "\t"
-                  << "Objects:\n";
+        std::cerr << std::string( "\t" ) << "Objects:\n";
         for ( uint32_t i = 0; i < pCallbackData->objectCount; i++ )
         {
-          std::cerr << "\t\t"
-                    << "Object " << i << "\n";
-          std::cerr << "\t\t\t"
-                    << "objectType   = " << vk::to_string( static_cast<vk::ObjectType>( pCallbackData->pObjects[i].objectType ) ) << "\n";
-          std::cerr << "\t\t\t"
-                    << "objectHandle = " << pCallbackData->pObjects[i].objectHandle << "\n";
+          std::cerr << std::string( "\t\t" ) << "Object " << i << "\n";
+#if defined( VULKAN_HPP_NO_TO_STRING )
+          std::cerr << std::string( "\t\t\t" ) << "objectType  = " << local::to_string( static_cast<vk::ObjectType>( pCallbackData->pObjects[i].objectType ) )
+                    << "\n";
+#else
+          std::cerr << std::string( "\t\t\t" ) << "objectType   = " << vk::to_string( static_cast<vk::ObjectType>( pCallbackData->pObjects[i].objectType ) )
+                    << "\n";
+#endif
+          std::cerr << std::string( "\t\t\t" ) << "objectHandle = " << pCallbackData->pObjects[i].objectHandle << "\n";
           if ( pCallbackData->pObjects[i].pObjectName )
           {
-            std::cerr << "\t\t\t"
-                      << "objectName   = <" << pCallbackData->pObjects[i].pObjectName << ">\n";
+            std::cerr << std::string( "\t\t\t" ) << "objectName   = <" << pCallbackData->pObjects[i].pObjectName << ">\n";
           }
         }
       }

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -5624,7 +5624,11 @@ namespace VULKAN_HPP_NAMESPACE
     }
     virtual std::string message( int ev ) const override
     {
-      return to_string( static_cast<Result>( ev ) );
+#  if defined( VULKAN_HPP_NO_TO_STRING )
+      return std::to_string( ev );
+#  else
+      return VULKAN_HPP_NAMESPACE::to_string( static_cast<VULKAN_HPP_NAMESPACE::Result>( ev ) );
+#  endif
     }
   };
 

--- a/vulkan/vulkan_enums.hpp
+++ b/vulkan/vulkan_enums.hpp
@@ -95,6 +95,7 @@ namespace VULKAN_HPP_NAMESPACE
     ePipelineCompileRequiredEXT          = VK_PIPELINE_COMPILE_REQUIRED_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( Result value )
   {
     switch ( value )
@@ -130,19 +131,19 @@ namespace VULKAN_HPP_NAMESPACE
       case Result::eErrorIncompatibleDisplayKHR: return "ErrorIncompatibleDisplayKHR";
       case Result::eErrorValidationFailedEXT: return "ErrorValidationFailedEXT";
       case Result::eErrorInvalidShaderNV: return "ErrorInvalidShaderNV";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case Result::eErrorImageUsageNotSupportedKHR: return "ErrorImageUsageNotSupportedKHR";
       case Result::eErrorVideoPictureLayoutNotSupportedKHR: return "ErrorVideoPictureLayoutNotSupportedKHR";
       case Result::eErrorVideoProfileOperationNotSupportedKHR: return "ErrorVideoProfileOperationNotSupportedKHR";
       case Result::eErrorVideoProfileFormatNotSupportedKHR: return "ErrorVideoProfileFormatNotSupportedKHR";
       case Result::eErrorVideoProfileCodecNotSupportedKHR: return "ErrorVideoProfileCodecNotSupportedKHR";
       case Result::eErrorVideoStdVersionNotSupportedKHR: return "ErrorVideoStdVersionNotSupportedKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       case Result::eErrorInvalidDrmFormatModifierPlaneLayoutEXT: return "ErrorInvalidDrmFormatModifierPlaneLayoutEXT";
       case Result::eErrorNotPermittedKHR: return "ErrorNotPermittedKHR";
-#if defined( VK_USE_PLATFORM_WIN32_KHR )
+#  if defined( VK_USE_PLATFORM_WIN32_KHR )
       case Result::eErrorFullScreenExclusiveModeLostEXT: return "ErrorFullScreenExclusiveModeLostEXT";
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+#  endif /*VK_USE_PLATFORM_WIN32_KHR*/
       case Result::eThreadIdleKHR: return "ThreadIdleKHR";
       case Result::eThreadDoneKHR: return "ThreadDoneKHR";
       case Result::eOperationDeferredKHR: return "OperationDeferredKHR";
@@ -151,6 +152,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class StructureType
   {
@@ -1057,6 +1059,7 @@ namespace VULKAN_HPP_NAMESPACE
     eWriteDescriptorSetInlineUniformBlockEXT                   = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( StructureType value )
   {
     switch ( value )
@@ -1288,27 +1291,27 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::eDisplayModeCreateInfoKHR: return "DisplayModeCreateInfoKHR";
       case StructureType::eDisplaySurfaceCreateInfoKHR: return "DisplaySurfaceCreateInfoKHR";
       case StructureType::eDisplayPresentInfoKHR: return "DisplayPresentInfoKHR";
-#if defined( VK_USE_PLATFORM_XLIB_KHR )
+#  if defined( VK_USE_PLATFORM_XLIB_KHR )
       case StructureType::eXlibSurfaceCreateInfoKHR: return "XlibSurfaceCreateInfoKHR";
-#endif /*VK_USE_PLATFORM_XLIB_KHR*/
-#if defined( VK_USE_PLATFORM_XCB_KHR )
+#  endif /*VK_USE_PLATFORM_XLIB_KHR*/
+#  if defined( VK_USE_PLATFORM_XCB_KHR )
       case StructureType::eXcbSurfaceCreateInfoKHR: return "XcbSurfaceCreateInfoKHR";
-#endif /*VK_USE_PLATFORM_XCB_KHR*/
-#if defined( VK_USE_PLATFORM_WAYLAND_KHR )
+#  endif /*VK_USE_PLATFORM_XCB_KHR*/
+#  if defined( VK_USE_PLATFORM_WAYLAND_KHR )
       case StructureType::eWaylandSurfaceCreateInfoKHR: return "WaylandSurfaceCreateInfoKHR";
-#endif /*VK_USE_PLATFORM_WAYLAND_KHR*/
-#if defined( VK_USE_PLATFORM_ANDROID_KHR )
+#  endif /*VK_USE_PLATFORM_WAYLAND_KHR*/
+#  if defined( VK_USE_PLATFORM_ANDROID_KHR )
       case StructureType::eAndroidSurfaceCreateInfoKHR: return "AndroidSurfaceCreateInfoKHR";
-#endif /*VK_USE_PLATFORM_ANDROID_KHR*/
-#if defined( VK_USE_PLATFORM_WIN32_KHR )
+#  endif /*VK_USE_PLATFORM_ANDROID_KHR*/
+#  if defined( VK_USE_PLATFORM_WIN32_KHR )
       case StructureType::eWin32SurfaceCreateInfoKHR: return "Win32SurfaceCreateInfoKHR";
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+#  endif /*VK_USE_PLATFORM_WIN32_KHR*/
       case StructureType::eDebugReportCallbackCreateInfoEXT: return "DebugReportCallbackCreateInfoEXT";
       case StructureType::ePipelineRasterizationStateRasterizationOrderAMD: return "PipelineRasterizationStateRasterizationOrderAMD";
       case StructureType::eDebugMarkerObjectNameInfoEXT: return "DebugMarkerObjectNameInfoEXT";
       case StructureType::eDebugMarkerObjectTagInfoEXT: return "DebugMarkerObjectTagInfoEXT";
       case StructureType::eDebugMarkerMarkerInfoEXT: return "DebugMarkerMarkerInfoEXT";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case StructureType::eVideoProfileKHR: return "VideoProfileKHR";
       case StructureType::eVideoCapabilitiesKHR: return "VideoCapabilitiesKHR";
       case StructureType::eVideoPictureResourceKHR: return "VideoPictureResourceKHR";
@@ -1328,7 +1331,7 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::eQueueFamilyQueryResultStatusProperties2KHR: return "QueueFamilyQueryResultStatusProperties2KHR";
       case StructureType::eVideoDecodeInfoKHR: return "VideoDecodeInfoKHR";
       case StructureType::eVideoDecodeCapabilitiesKHR: return "VideoDecodeCapabilitiesKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       case StructureType::eDedicatedAllocationImageCreateInfoNV: return "DedicatedAllocationImageCreateInfoNV";
       case StructureType::eDedicatedAllocationBufferCreateInfoNV: return "DedicatedAllocationBufferCreateInfoNV";
       case StructureType::eDedicatedAllocationMemoryAllocateInfoNV: return "DedicatedAllocationMemoryAllocateInfoNV";
@@ -1340,7 +1343,7 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::eCuLaunchInfoNVX: return "CuLaunchInfoNVX";
       case StructureType::eImageViewHandleInfoNVX: return "ImageViewHandleInfoNVX";
       case StructureType::eImageViewAddressPropertiesNVX: return "ImageViewAddressPropertiesNVX";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case StructureType::eVideoEncodeH264CapabilitiesEXT: return "VideoEncodeH264CapabilitiesEXT";
       case StructureType::eVideoEncodeH264SessionParametersCreateInfoEXT: return "VideoEncodeH264SessionParametersCreateInfoEXT";
       case StructureType::eVideoEncodeH264SessionParametersAddInfoEXT: return "VideoEncodeH264SessionParametersAddInfoEXT";
@@ -1370,48 +1373,48 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::eVideoDecodeH264SessionParametersCreateInfoEXT: return "VideoDecodeH264SessionParametersCreateInfoEXT";
       case StructureType::eVideoDecodeH264SessionParametersAddInfoEXT: return "VideoDecodeH264SessionParametersAddInfoEXT";
       case StructureType::eVideoDecodeH264DpbSlotInfoEXT: return "VideoDecodeH264DpbSlotInfoEXT";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       case StructureType::eTextureLodGatherFormatPropertiesAMD: return "TextureLodGatherFormatPropertiesAMD";
       case StructureType::eRenderingFragmentShadingRateAttachmentInfoKHR: return "RenderingFragmentShadingRateAttachmentInfoKHR";
       case StructureType::eRenderingFragmentDensityMapAttachmentInfoEXT: return "RenderingFragmentDensityMapAttachmentInfoEXT";
       case StructureType::eAttachmentSampleCountInfoAMD: return "AttachmentSampleCountInfoAMD";
       case StructureType::eMultiviewPerViewAttributesInfoNVX: return "MultiviewPerViewAttributesInfoNVX";
-#if defined( VK_USE_PLATFORM_GGP )
+#  if defined( VK_USE_PLATFORM_GGP )
       case StructureType::eStreamDescriptorSurfaceCreateInfoGGP: return "StreamDescriptorSurfaceCreateInfoGGP";
-#endif /*VK_USE_PLATFORM_GGP*/
+#  endif /*VK_USE_PLATFORM_GGP*/
       case StructureType::ePhysicalDeviceCornerSampledImageFeaturesNV: return "PhysicalDeviceCornerSampledImageFeaturesNV";
       case StructureType::eExternalMemoryImageCreateInfoNV: return "ExternalMemoryImageCreateInfoNV";
       case StructureType::eExportMemoryAllocateInfoNV: return "ExportMemoryAllocateInfoNV";
-#if defined( VK_USE_PLATFORM_WIN32_KHR )
+#  if defined( VK_USE_PLATFORM_WIN32_KHR )
       case StructureType::eImportMemoryWin32HandleInfoNV: return "ImportMemoryWin32HandleInfoNV";
       case StructureType::eExportMemoryWin32HandleInfoNV: return "ExportMemoryWin32HandleInfoNV";
       case StructureType::eWin32KeyedMutexAcquireReleaseInfoNV: return "Win32KeyedMutexAcquireReleaseInfoNV";
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+#  endif /*VK_USE_PLATFORM_WIN32_KHR*/
       case StructureType::eValidationFlagsEXT: return "ValidationFlagsEXT";
-#if defined( VK_USE_PLATFORM_VI_NN )
+#  if defined( VK_USE_PLATFORM_VI_NN )
       case StructureType::eViSurfaceCreateInfoNN: return "ViSurfaceCreateInfoNN";
-#endif /*VK_USE_PLATFORM_VI_NN*/
+#  endif /*VK_USE_PLATFORM_VI_NN*/
       case StructureType::eImageViewAstcDecodeModeEXT: return "ImageViewAstcDecodeModeEXT";
       case StructureType::ePhysicalDeviceAstcDecodeFeaturesEXT: return "PhysicalDeviceAstcDecodeFeaturesEXT";
       case StructureType::ePipelineRobustnessCreateInfoEXT: return "PipelineRobustnessCreateInfoEXT";
       case StructureType::ePhysicalDevicePipelineRobustnessFeaturesEXT: return "PhysicalDevicePipelineRobustnessFeaturesEXT";
       case StructureType::ePhysicalDevicePipelineRobustnessPropertiesEXT: return "PhysicalDevicePipelineRobustnessPropertiesEXT";
-#if defined( VK_USE_PLATFORM_WIN32_KHR )
+#  if defined( VK_USE_PLATFORM_WIN32_KHR )
       case StructureType::eImportMemoryWin32HandleInfoKHR: return "ImportMemoryWin32HandleInfoKHR";
       case StructureType::eExportMemoryWin32HandleInfoKHR: return "ExportMemoryWin32HandleInfoKHR";
       case StructureType::eMemoryWin32HandlePropertiesKHR: return "MemoryWin32HandlePropertiesKHR";
       case StructureType::eMemoryGetWin32HandleInfoKHR: return "MemoryGetWin32HandleInfoKHR";
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+#  endif /*VK_USE_PLATFORM_WIN32_KHR*/
       case StructureType::eImportMemoryFdInfoKHR: return "ImportMemoryFdInfoKHR";
       case StructureType::eMemoryFdPropertiesKHR: return "MemoryFdPropertiesKHR";
       case StructureType::eMemoryGetFdInfoKHR: return "MemoryGetFdInfoKHR";
-#if defined( VK_USE_PLATFORM_WIN32_KHR )
+#  if defined( VK_USE_PLATFORM_WIN32_KHR )
       case StructureType::eWin32KeyedMutexAcquireReleaseInfoKHR: return "Win32KeyedMutexAcquireReleaseInfoKHR";
       case StructureType::eImportSemaphoreWin32HandleInfoKHR: return "ImportSemaphoreWin32HandleInfoKHR";
       case StructureType::eExportSemaphoreWin32HandleInfoKHR: return "ExportSemaphoreWin32HandleInfoKHR";
       case StructureType::eD3D12FenceSubmitInfoKHR: return "D3D12FenceSubmitInfoKHR";
       case StructureType::eSemaphoreGetWin32HandleInfoKHR: return "SemaphoreGetWin32HandleInfoKHR";
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+#  endif /*VK_USE_PLATFORM_WIN32_KHR*/
       case StructureType::eImportSemaphoreFdInfoKHR: return "ImportSemaphoreFdInfoKHR";
       case StructureType::eSemaphoreGetFdInfoKHR: return "SemaphoreGetFdInfoKHR";
       case StructureType::ePhysicalDevicePushDescriptorPropertiesKHR: return "PhysicalDevicePushDescriptorPropertiesKHR";
@@ -1436,11 +1439,11 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::ePipelineRasterizationDepthClipStateCreateInfoEXT: return "PipelineRasterizationDepthClipStateCreateInfoEXT";
       case StructureType::eHdrMetadataEXT: return "HdrMetadataEXT";
       case StructureType::eSharedPresentSurfaceCapabilitiesKHR: return "SharedPresentSurfaceCapabilitiesKHR";
-#if defined( VK_USE_PLATFORM_WIN32_KHR )
+#  if defined( VK_USE_PLATFORM_WIN32_KHR )
       case StructureType::eImportFenceWin32HandleInfoKHR: return "ImportFenceWin32HandleInfoKHR";
       case StructureType::eExportFenceWin32HandleInfoKHR: return "ExportFenceWin32HandleInfoKHR";
       case StructureType::eFenceGetWin32HandleInfoKHR: return "FenceGetWin32HandleInfoKHR";
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+#  endif /*VK_USE_PLATFORM_WIN32_KHR*/
       case StructureType::eImportFenceFdInfoKHR: return "ImportFenceFdInfoKHR";
       case StructureType::eFenceGetFdInfoKHR: return "FenceGetFdInfoKHR";
       case StructureType::ePhysicalDevicePerformanceQueryFeaturesKHR: return "PhysicalDevicePerformanceQueryFeaturesKHR";
@@ -1458,18 +1461,18 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::eDisplayModeProperties2KHR: return "DisplayModeProperties2KHR";
       case StructureType::eDisplayPlaneInfo2KHR: return "DisplayPlaneInfo2KHR";
       case StructureType::eDisplayPlaneCapabilities2KHR: return "DisplayPlaneCapabilities2KHR";
-#if defined( VK_USE_PLATFORM_IOS_MVK )
+#  if defined( VK_USE_PLATFORM_IOS_MVK )
       case StructureType::eIosSurfaceCreateInfoMVK: return "IosSurfaceCreateInfoMVK";
-#endif /*VK_USE_PLATFORM_IOS_MVK*/
-#if defined( VK_USE_PLATFORM_MACOS_MVK )
+#  endif /*VK_USE_PLATFORM_IOS_MVK*/
+#  if defined( VK_USE_PLATFORM_MACOS_MVK )
       case StructureType::eMacosSurfaceCreateInfoMVK: return "MacosSurfaceCreateInfoMVK";
-#endif /*VK_USE_PLATFORM_MACOS_MVK*/
+#  endif /*VK_USE_PLATFORM_MACOS_MVK*/
       case StructureType::eDebugUtilsObjectNameInfoEXT: return "DebugUtilsObjectNameInfoEXT";
       case StructureType::eDebugUtilsObjectTagInfoEXT: return "DebugUtilsObjectTagInfoEXT";
       case StructureType::eDebugUtilsLabelEXT: return "DebugUtilsLabelEXT";
       case StructureType::eDebugUtilsMessengerCallbackDataEXT: return "DebugUtilsMessengerCallbackDataEXT";
       case StructureType::eDebugUtilsMessengerCreateInfoEXT: return "DebugUtilsMessengerCreateInfoEXT";
-#if defined( VK_USE_PLATFORM_ANDROID_KHR )
+#  if defined( VK_USE_PLATFORM_ANDROID_KHR )
       case StructureType::eAndroidHardwareBufferUsageANDROID: return "AndroidHardwareBufferUsageANDROID";
       case StructureType::eAndroidHardwareBufferPropertiesANDROID: return "AndroidHardwareBufferPropertiesANDROID";
       case StructureType::eAndroidHardwareBufferFormatPropertiesANDROID: return "AndroidHardwareBufferFormatPropertiesANDROID";
@@ -1477,7 +1480,7 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::eMemoryGetAndroidHardwareBufferInfoANDROID: return "MemoryGetAndroidHardwareBufferInfoANDROID";
       case StructureType::eExternalFormatANDROID: return "ExternalFormatANDROID";
       case StructureType::eAndroidHardwareBufferFormatProperties2ANDROID: return "AndroidHardwareBufferFormatProperties2ANDROID";
-#endif /*VK_USE_PLATFORM_ANDROID_KHR*/
+#  endif /*VK_USE_PLATFORM_ANDROID_KHR*/
       case StructureType::eSampleLocationsInfoEXT: return "SampleLocationsInfoEXT";
       case StructureType::eRenderPassSampleLocationsBeginInfoEXT: return "RenderPassSampleLocationsBeginInfoEXT";
       case StructureType::ePipelineSampleLocationsStateCreateInfoEXT: return "PipelineSampleLocationsStateCreateInfoEXT";
@@ -1519,10 +1522,10 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::eDrmFormatModifierPropertiesList2EXT: return "DrmFormatModifierPropertiesList2EXT";
       case StructureType::eValidationCacheCreateInfoEXT: return "ValidationCacheCreateInfoEXT";
       case StructureType::eShaderModuleValidationCacheCreateInfoEXT: return "ShaderModuleValidationCacheCreateInfoEXT";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case StructureType::ePhysicalDevicePortabilitySubsetFeaturesKHR: return "PhysicalDevicePortabilitySubsetFeaturesKHR";
       case StructureType::ePhysicalDevicePortabilitySubsetPropertiesKHR: return "PhysicalDevicePortabilitySubsetPropertiesKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       case StructureType::ePipelineViewportShadingRateImageStateCreateInfoNV: return "PipelineViewportShadingRateImageStateCreateInfoNV";
       case StructureType::ePhysicalDeviceShadingRateImageFeaturesNV: return "PhysicalDeviceShadingRateImageFeaturesNV";
       case StructureType::ePhysicalDeviceShadingRateImagePropertiesNV: return "PhysicalDeviceShadingRateImagePropertiesNV";
@@ -1549,14 +1552,14 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::ePipelineCompilerControlCreateInfoAMD: return "PipelineCompilerControlCreateInfoAMD";
       case StructureType::eCalibratedTimestampInfoEXT: return "CalibratedTimestampInfoEXT";
       case StructureType::ePhysicalDeviceShaderCorePropertiesAMD: return "PhysicalDeviceShaderCorePropertiesAMD";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case StructureType::eVideoDecodeH265CapabilitiesEXT: return "VideoDecodeH265CapabilitiesEXT";
       case StructureType::eVideoDecodeH265SessionParametersCreateInfoEXT: return "VideoDecodeH265SessionParametersCreateInfoEXT";
       case StructureType::eVideoDecodeH265SessionParametersAddInfoEXT: return "VideoDecodeH265SessionParametersAddInfoEXT";
       case StructureType::eVideoDecodeH265ProfileEXT: return "VideoDecodeH265ProfileEXT";
       case StructureType::eVideoDecodeH265PictureInfoEXT: return "VideoDecodeH265PictureInfoEXT";
       case StructureType::eVideoDecodeH265DpbSlotInfoEXT: return "VideoDecodeH265DpbSlotInfoEXT";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       case StructureType::eDeviceQueueGlobalPriorityCreateInfoKHR: return "DeviceQueueGlobalPriorityCreateInfoKHR";
       case StructureType::ePhysicalDeviceGlobalPriorityQueryFeaturesKHR: return "PhysicalDeviceGlobalPriorityQueryFeaturesKHR";
       case StructureType::eQueueFamilyGlobalPriorityPropertiesKHR: return "QueueFamilyGlobalPriorityPropertiesKHR";
@@ -1564,9 +1567,9 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::ePhysicalDeviceVertexAttributeDivisorPropertiesEXT: return "PhysicalDeviceVertexAttributeDivisorPropertiesEXT";
       case StructureType::ePipelineVertexInputDivisorStateCreateInfoEXT: return "PipelineVertexInputDivisorStateCreateInfoEXT";
       case StructureType::ePhysicalDeviceVertexAttributeDivisorFeaturesEXT: return "PhysicalDeviceVertexAttributeDivisorFeaturesEXT";
-#if defined( VK_USE_PLATFORM_GGP )
+#  if defined( VK_USE_PLATFORM_GGP )
       case StructureType::ePresentFrameTokenGGP: return "PresentFrameTokenGGP";
-#endif /*VK_USE_PLATFORM_GGP*/
+#  endif /*VK_USE_PLATFORM_GGP*/
       case StructureType::ePhysicalDeviceComputeShaderDerivativesFeaturesNV: return "PhysicalDeviceComputeShaderDerivativesFeaturesNV";
       case StructureType::ePhysicalDeviceMeshShaderFeaturesNV: return "PhysicalDeviceMeshShaderFeaturesNV";
       case StructureType::ePhysicalDeviceMeshShaderPropertiesNV: return "PhysicalDeviceMeshShaderPropertiesNV";
@@ -1585,12 +1588,12 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::ePhysicalDevicePciBusInfoPropertiesEXT: return "PhysicalDevicePciBusInfoPropertiesEXT";
       case StructureType::eDisplayNativeHdrSurfaceCapabilitiesAMD: return "DisplayNativeHdrSurfaceCapabilitiesAMD";
       case StructureType::eSwapchainDisplayNativeHdrCreateInfoAMD: return "SwapchainDisplayNativeHdrCreateInfoAMD";
-#if defined( VK_USE_PLATFORM_FUCHSIA )
+#  if defined( VK_USE_PLATFORM_FUCHSIA )
       case StructureType::eImagepipeSurfaceCreateInfoFUCHSIA: return "ImagepipeSurfaceCreateInfoFUCHSIA";
-#endif /*VK_USE_PLATFORM_FUCHSIA*/
-#if defined( VK_USE_PLATFORM_METAL_EXT )
+#  endif /*VK_USE_PLATFORM_FUCHSIA*/
+#  if defined( VK_USE_PLATFORM_METAL_EXT )
       case StructureType::eMetalSurfaceCreateInfoEXT: return "MetalSurfaceCreateInfoEXT";
-#endif /*VK_USE_PLATFORM_METAL_EXT*/
+#  endif /*VK_USE_PLATFORM_METAL_EXT*/
       case StructureType::ePhysicalDeviceFragmentDensityMapFeaturesEXT: return "PhysicalDeviceFragmentDensityMapFeaturesEXT";
       case StructureType::ePhysicalDeviceFragmentDensityMapPropertiesEXT: return "PhysicalDeviceFragmentDensityMapPropertiesEXT";
       case StructureType::eRenderPassFragmentDensityMapCreateInfoEXT: return "RenderPassFragmentDensityMapCreateInfoEXT";
@@ -1622,11 +1625,11 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::ePhysicalDeviceProvokingVertexFeaturesEXT: return "PhysicalDeviceProvokingVertexFeaturesEXT";
       case StructureType::ePipelineRasterizationProvokingVertexStateCreateInfoEXT: return "PipelineRasterizationProvokingVertexStateCreateInfoEXT";
       case StructureType::ePhysicalDeviceProvokingVertexPropertiesEXT: return "PhysicalDeviceProvokingVertexPropertiesEXT";
-#if defined( VK_USE_PLATFORM_WIN32_KHR )
+#  if defined( VK_USE_PLATFORM_WIN32_KHR )
       case StructureType::eSurfaceFullScreenExclusiveInfoEXT: return "SurfaceFullScreenExclusiveInfoEXT";
       case StructureType::eSurfaceCapabilitiesFullScreenExclusiveEXT: return "SurfaceCapabilitiesFullScreenExclusiveEXT";
       case StructureType::eSurfaceFullScreenExclusiveWin32InfoEXT: return "SurfaceFullScreenExclusiveWin32InfoEXT";
-#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+#  endif /*VK_USE_PLATFORM_WIN32_KHR*/
       case StructureType::eHeadlessSurfaceCreateInfoEXT: return "HeadlessSurfaceCreateInfoEXT";
       case StructureType::ePhysicalDeviceLineRasterizationFeaturesEXT: return "PhysicalDeviceLineRasterizationFeaturesEXT";
       case StructureType::ePipelineRasterizationLineStateCreateInfoEXT: return "PipelineRasterizationLineStateCreateInfoEXT";
@@ -1665,15 +1668,15 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::ePipelineLibraryCreateInfoKHR: return "PipelineLibraryCreateInfoKHR";
       case StructureType::ePresentIdKHR: return "PresentIdKHR";
       case StructureType::ePhysicalDevicePresentIdFeaturesKHR: return "PhysicalDevicePresentIdFeaturesKHR";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case StructureType::eVideoEncodeInfoKHR: return "VideoEncodeInfoKHR";
       case StructureType::eVideoEncodeRateControlInfoKHR: return "VideoEncodeRateControlInfoKHR";
       case StructureType::eVideoEncodeRateControlLayerInfoKHR: return "VideoEncodeRateControlLayerInfoKHR";
       case StructureType::eVideoEncodeCapabilitiesKHR: return "VideoEncodeCapabilitiesKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       case StructureType::ePhysicalDeviceDiagnosticsConfigFeaturesNV: return "PhysicalDeviceDiagnosticsConfigFeaturesNV";
       case StructureType::eDeviceDiagnosticsConfigCreateInfoNV: return "DeviceDiagnosticsConfigCreateInfoNV";
-#if defined( VK_USE_PLATFORM_METAL_EXT )
+#  if defined( VK_USE_PLATFORM_METAL_EXT )
       case StructureType::eExportMetalObjectCreateInfoEXT: return "ExportMetalObjectCreateInfoEXT";
       case StructureType::eExportMetalObjectsInfoEXT: return "ExportMetalObjectsInfoEXT";
       case StructureType::eExportMetalDeviceInfoEXT: return "ExportMetalDeviceInfoEXT";
@@ -1686,7 +1689,7 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::eImportMetalIoSurfaceInfoEXT: return "ImportMetalIoSurfaceInfoEXT";
       case StructureType::eExportMetalSharedEventInfoEXT: return "ExportMetalSharedEventInfoEXT";
       case StructureType::eImportMetalSharedEventInfoEXT: return "ImportMetalSharedEventInfoEXT";
-#endif /*VK_USE_PLATFORM_METAL_EXT*/
+#  endif /*VK_USE_PLATFORM_METAL_EXT*/
       case StructureType::eQueueFamilyCheckpointProperties2NV: return "QueueFamilyCheckpointProperties2NV";
       case StructureType::eCheckpointData2NV: return "CheckpointData2NV";
       case StructureType::ePhysicalDeviceGraphicsPipelineLibraryFeaturesEXT: return "PhysicalDeviceGraphicsPipelineLibraryFeaturesEXT";
@@ -1715,9 +1718,9 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::ePhysicalDevice4444FormatsFeaturesEXT: return "PhysicalDevice4444FormatsFeaturesEXT";
       case StructureType::ePhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM: return "PhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM";
       case StructureType::ePhysicalDeviceRgba10X6FormatsFeaturesEXT: return "PhysicalDeviceRgba10X6FormatsFeaturesEXT";
-#if defined( VK_USE_PLATFORM_DIRECTFB_EXT )
+#  if defined( VK_USE_PLATFORM_DIRECTFB_EXT )
       case StructureType::eDirectfbSurfaceCreateInfoEXT: return "DirectfbSurfaceCreateInfoEXT";
-#endif /*VK_USE_PLATFORM_DIRECTFB_EXT*/
+#  endif /*VK_USE_PLATFORM_DIRECTFB_EXT*/
       case StructureType::ePhysicalDeviceMutableDescriptorTypeFeaturesVALVE: return "PhysicalDeviceMutableDescriptorTypeFeaturesVALVE";
       case StructureType::eMutableDescriptorTypeCreateInfoVALVE: return "MutableDescriptorTypeCreateInfoVALVE";
       case StructureType::ePhysicalDeviceVertexInputDynamicStateFeaturesEXT: return "PhysicalDeviceVertexInputDynamicStateFeaturesEXT";
@@ -1727,7 +1730,7 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::ePhysicalDeviceDepthClipControlFeaturesEXT: return "PhysicalDeviceDepthClipControlFeaturesEXT";
       case StructureType::ePipelineViewportDepthClipControlCreateInfoEXT: return "PipelineViewportDepthClipControlCreateInfoEXT";
       case StructureType::ePhysicalDevicePrimitiveTopologyListRestartFeaturesEXT: return "PhysicalDevicePrimitiveTopologyListRestartFeaturesEXT";
-#if defined( VK_USE_PLATFORM_FUCHSIA )
+#  if defined( VK_USE_PLATFORM_FUCHSIA )
       case StructureType::eImportMemoryZirconHandleInfoFUCHSIA: return "ImportMemoryZirconHandleInfoFUCHSIA";
       case StructureType::eMemoryZirconHandlePropertiesFUCHSIA: return "MemoryZirconHandlePropertiesFUCHSIA";
       case StructureType::eMemoryGetZirconHandleInfoFUCHSIA: return "MemoryGetZirconHandleInfoFUCHSIA";
@@ -1743,7 +1746,7 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::eImageFormatConstraintsInfoFUCHSIA: return "ImageFormatConstraintsInfoFUCHSIA";
       case StructureType::eSysmemColorSpaceFUCHSIA: return "SysmemColorSpaceFUCHSIA";
       case StructureType::eBufferCollectionConstraintsInfoFUCHSIA: return "BufferCollectionConstraintsInfoFUCHSIA";
-#endif /*VK_USE_PLATFORM_FUCHSIA*/
+#  endif /*VK_USE_PLATFORM_FUCHSIA*/
       case StructureType::eSubpassShadingPipelineCreateInfoHUAWEI: return "SubpassShadingPipelineCreateInfoHUAWEI";
       case StructureType::ePhysicalDeviceSubpassShadingFeaturesHUAWEI: return "PhysicalDeviceSubpassShadingFeaturesHUAWEI";
       case StructureType::ePhysicalDeviceSubpassShadingPropertiesHUAWEI: return "PhysicalDeviceSubpassShadingPropertiesHUAWEI";
@@ -1756,9 +1759,9 @@ namespace VULKAN_HPP_NAMESPACE
       case StructureType::eSubpassResolvePerformanceQueryEXT: return "SubpassResolvePerformanceQueryEXT";
       case StructureType::eMultisampledRenderToSingleSampledInfoEXT: return "MultisampledRenderToSingleSampledInfoEXT";
       case StructureType::ePhysicalDeviceExtendedDynamicState2FeaturesEXT: return "PhysicalDeviceExtendedDynamicState2FeaturesEXT";
-#if defined( VK_USE_PLATFORM_SCREEN_QNX )
+#  if defined( VK_USE_PLATFORM_SCREEN_QNX )
       case StructureType::eScreenSurfaceCreateInfoQNX: return "ScreenSurfaceCreateInfoQNX";
-#endif /*VK_USE_PLATFORM_SCREEN_QNX*/
+#  endif /*VK_USE_PLATFORM_SCREEN_QNX*/
       case StructureType::ePhysicalDeviceColorWriteEnableFeaturesEXT: return "PhysicalDeviceColorWriteEnableFeaturesEXT";
       case StructureType::ePipelineColorWriteCreateInfoEXT: return "PipelineColorWriteCreateInfoEXT";
       case StructureType::ePhysicalDevicePrimitivesGeneratedQueryFeaturesEXT: return "PhysicalDevicePrimitivesGeneratedQueryFeaturesEXT";
@@ -1796,12 +1799,14 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PipelineCacheHeaderVersion
   {
     eOne = VK_PIPELINE_CACHE_HEADER_VERSION_ONE
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineCacheHeaderVersion value )
   {
     switch ( value )
@@ -1810,6 +1815,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ObjectType
   {
@@ -1868,6 +1874,7 @@ namespace VULKAN_HPP_NAMESPACE
     eSamplerYcbcrConversionKHR   = VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ObjectType value )
   {
     switch ( value )
@@ -1906,10 +1913,10 @@ namespace VULKAN_HPP_NAMESPACE
       case ObjectType::eDisplayKHR: return "DisplayKHR";
       case ObjectType::eDisplayModeKHR: return "DisplayModeKHR";
       case ObjectType::eDebugReportCallbackEXT: return "DebugReportCallbackEXT";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case ObjectType::eVideoSessionKHR: return "VideoSessionKHR";
       case ObjectType::eVideoSessionParametersKHR: return "VideoSessionParametersKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       case ObjectType::eCuModuleNVX: return "CuModuleNVX";
       case ObjectType::eCuFunctionNVX: return "CuFunctionNVX";
       case ObjectType::eDebugUtilsMessengerEXT: return "DebugUtilsMessengerEXT";
@@ -1919,12 +1926,13 @@ namespace VULKAN_HPP_NAMESPACE
       case ObjectType::ePerformanceConfigurationINTEL: return "PerformanceConfigurationINTEL";
       case ObjectType::eDeferredOperationKHR: return "DeferredOperationKHR";
       case ObjectType::eIndirectCommandsLayoutNV: return "IndirectCommandsLayoutNV";
-#if defined( VK_USE_PLATFORM_FUCHSIA )
+#  if defined( VK_USE_PLATFORM_FUCHSIA )
       case ObjectType::eBufferCollectionFUCHSIA: return "BufferCollectionFUCHSIA";
-#endif /*VK_USE_PLATFORM_FUCHSIA*/
+#  endif /*VK_USE_PLATFORM_FUCHSIA*/
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class VendorId
   {
@@ -1936,6 +1944,7 @@ namespace VULKAN_HPP_NAMESPACE
     ePocl     = VK_VENDOR_ID_POCL
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VendorId value )
   {
     switch ( value )
@@ -1949,6 +1958,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class Format
   {
@@ -2255,6 +2265,7 @@ namespace VULKAN_HPP_NAMESPACE
     eR12X4UnormPack16KHR                     = VK_FORMAT_R12X4_UNORM_PACK16_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( Format value )
   {
     switch ( value )
@@ -2509,6 +2520,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class FormatFeatureFlagBits : VkFormatFeatureFlags
   {
@@ -2562,6 +2574,7 @@ namespace VULKAN_HPP_NAMESPACE
     eTransferSrcKHR                                             = VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( FormatFeatureFlagBits value )
   {
     switch ( value )
@@ -2590,21 +2603,22 @@ namespace VULKAN_HPP_NAMESPACE
       case FormatFeatureFlagBits::eDisjoint: return "Disjoint";
       case FormatFeatureFlagBits::eCositedChromaSamples: return "CositedChromaSamples";
       case FormatFeatureFlagBits::eSampledImageFilterMinmax: return "SampledImageFilterMinmax";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case FormatFeatureFlagBits::eVideoDecodeOutputKHR: return "VideoDecodeOutputKHR";
       case FormatFeatureFlagBits::eVideoDecodeDpbKHR: return "VideoDecodeDpbKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       case FormatFeatureFlagBits::eAccelerationStructureVertexBufferKHR: return "AccelerationStructureVertexBufferKHR";
       case FormatFeatureFlagBits::eSampledImageFilterCubicEXT: return "SampledImageFilterCubicEXT";
       case FormatFeatureFlagBits::eFragmentDensityMapEXT: return "FragmentDensityMapEXT";
       case FormatFeatureFlagBits::eFragmentShadingRateAttachmentKHR: return "FragmentShadingRateAttachmentKHR";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case FormatFeatureFlagBits::eVideoEncodeInputKHR: return "VideoEncodeInputKHR";
       case FormatFeatureFlagBits::eVideoEncodeDpbKHR: return "VideoEncodeDpbKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ImageCreateFlagBits : VkImageCreateFlags
   {
@@ -2634,6 +2648,7 @@ namespace VULKAN_HPP_NAMESPACE
     eSplitInstanceBindRegionsKHR          = VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageCreateFlagBits value )
   {
     switch ( value )
@@ -2659,6 +2674,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ImageTiling
   {
@@ -2667,6 +2683,7 @@ namespace VULKAN_HPP_NAMESPACE
     eDrmFormatModifierEXT = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageTiling value )
   {
     switch ( value )
@@ -2677,6 +2694,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ImageType
   {
@@ -2685,6 +2703,7 @@ namespace VULKAN_HPP_NAMESPACE
     e3D = VK_IMAGE_TYPE_3D
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageType value )
   {
     switch ( value )
@@ -2695,6 +2714,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ImageUsageFlagBits : VkImageUsageFlags
   {
@@ -2724,6 +2744,7 @@ namespace VULKAN_HPP_NAMESPACE
     eShadingRateImageNV   = VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageUsageFlagBits value )
   {
     switch ( value )
@@ -2736,30 +2757,32 @@ namespace VULKAN_HPP_NAMESPACE
       case ImageUsageFlagBits::eDepthStencilAttachment: return "DepthStencilAttachment";
       case ImageUsageFlagBits::eTransientAttachment: return "TransientAttachment";
       case ImageUsageFlagBits::eInputAttachment: return "InputAttachment";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case ImageUsageFlagBits::eVideoDecodeDstKHR: return "VideoDecodeDstKHR";
       case ImageUsageFlagBits::eVideoDecodeSrcKHR: return "VideoDecodeSrcKHR";
       case ImageUsageFlagBits::eVideoDecodeDpbKHR: return "VideoDecodeDpbKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       case ImageUsageFlagBits::eFragmentDensityMapEXT: return "FragmentDensityMapEXT";
       case ImageUsageFlagBits::eFragmentShadingRateAttachmentKHR: return "FragmentShadingRateAttachmentKHR";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case ImageUsageFlagBits::eVideoEncodeDstKHR: return "VideoEncodeDstKHR";
       case ImageUsageFlagBits::eVideoEncodeSrcKHR: return "VideoEncodeSrcKHR";
       case ImageUsageFlagBits::eVideoEncodeDpbKHR: return "VideoEncodeDpbKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       case ImageUsageFlagBits::eInvocationMaskHUAWEI: return "InvocationMaskHUAWEI";
       case ImageUsageFlagBits::eSampleWeightQCOM: return "SampleWeightQCOM";
       case ImageUsageFlagBits::eSampleBlockMatchQCOM: return "SampleBlockMatchQCOM";
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class InstanceCreateFlagBits : VkInstanceCreateFlags
   {
     eEnumeratePortabilityKHR = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( InstanceCreateFlagBits value )
   {
     switch ( value )
@@ -2768,12 +2791,14 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class InternalAllocationType
   {
     eExecutable = VK_INTERNAL_ALLOCATION_TYPE_EXECUTABLE
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( InternalAllocationType value )
   {
     switch ( value )
@@ -2782,6 +2807,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class MemoryHeapFlagBits : VkMemoryHeapFlags
   {
@@ -2790,6 +2816,7 @@ namespace VULKAN_HPP_NAMESPACE
     eMultiInstanceKHR = VK_MEMORY_HEAP_MULTI_INSTANCE_BIT_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( MemoryHeapFlagBits value )
   {
     switch ( value )
@@ -2799,6 +2826,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class MemoryPropertyFlagBits : VkMemoryPropertyFlags
   {
@@ -2813,6 +2841,7 @@ namespace VULKAN_HPP_NAMESPACE
     eRdmaCapableNV     = VK_MEMORY_PROPERTY_RDMA_CAPABLE_BIT_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( MemoryPropertyFlagBits value )
   {
     switch ( value )
@@ -2829,6 +2858,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PhysicalDeviceType
   {
@@ -2839,6 +2869,7 @@ namespace VULKAN_HPP_NAMESPACE
     eCpu           = VK_PHYSICAL_DEVICE_TYPE_CPU
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PhysicalDeviceType value )
   {
     switch ( value )
@@ -2851,6 +2882,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class QueueFlagBits : VkQueueFlags
   {
@@ -2865,6 +2897,7 @@ namespace VULKAN_HPP_NAMESPACE
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( QueueFlagBits value )
   {
     switch ( value )
@@ -2874,13 +2907,14 @@ namespace VULKAN_HPP_NAMESPACE
       case QueueFlagBits::eTransfer: return "Transfer";
       case QueueFlagBits::eSparseBinding: return "SparseBinding";
       case QueueFlagBits::eProtected: return "Protected";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case QueueFlagBits::eVideoDecodeKHR: return "VideoDecodeKHR";
       case QueueFlagBits::eVideoEncodeKHR: return "VideoEncodeKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class SampleCountFlagBits : VkSampleCountFlags
   {
@@ -2893,6 +2927,7 @@ namespace VULKAN_HPP_NAMESPACE
     e64 = VK_SAMPLE_COUNT_64_BIT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SampleCountFlagBits value )
   {
     switch ( value )
@@ -2907,6 +2942,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class SystemAllocationScope
   {
@@ -2917,6 +2953,7 @@ namespace VULKAN_HPP_NAMESPACE
     eInstance = VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SystemAllocationScope value )
   {
     switch ( value )
@@ -2929,15 +2966,18 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DeviceCreateFlagBits
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DeviceCreateFlagBits )
   {
     return "(void)";
   }
+#endif
 
   enum class PipelineStageFlagBits : VkPipelineStageFlags
   {
@@ -2974,6 +3014,7 @@ namespace VULKAN_HPP_NAMESPACE
     eShadingRateImageNV               = VK_PIPELINE_STAGE_SHADING_RATE_IMAGE_BIT_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineStageFlagBits value )
   {
     switch ( value )
@@ -3008,15 +3049,18 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class MemoryMapFlagBits : VkMemoryMapFlags
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( MemoryMapFlagBits )
   {
     return "(void)";
   }
+#endif
 
   enum class ImageAspectFlagBits : VkImageAspectFlags
   {
@@ -3038,6 +3082,7 @@ namespace VULKAN_HPP_NAMESPACE
     ePlane2KHR       = VK_IMAGE_ASPECT_PLANE_2_BIT_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageAspectFlagBits value )
   {
     switch ( value )
@@ -3057,6 +3102,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class SparseImageFormatFlagBits : VkSparseImageFormatFlags
   {
@@ -3065,6 +3111,7 @@ namespace VULKAN_HPP_NAMESPACE
     eNonstandardBlockSize = VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SparseImageFormatFlagBits value )
   {
     switch ( value )
@@ -3075,12 +3122,14 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class SparseMemoryBindFlagBits : VkSparseMemoryBindFlags
   {
     eMetadata = VK_SPARSE_MEMORY_BIND_METADATA_BIT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SparseMemoryBindFlagBits value )
   {
     switch ( value )
@@ -3089,12 +3138,14 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class FenceCreateFlagBits : VkFenceCreateFlags
   {
     eSignaled = VK_FENCE_CREATE_SIGNALED_BIT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( FenceCreateFlagBits value )
   {
     switch ( value )
@@ -3103,15 +3154,18 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class SemaphoreCreateFlagBits : VkSemaphoreCreateFlags
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SemaphoreCreateFlagBits )
   {
     return "(void)";
   }
+#endif
 
   enum class EventCreateFlagBits : VkEventCreateFlags
   {
@@ -3119,6 +3173,7 @@ namespace VULKAN_HPP_NAMESPACE
     eDeviceOnlyKHR = VK_EVENT_CREATE_DEVICE_ONLY_BIT_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( EventCreateFlagBits value )
   {
     switch ( value )
@@ -3127,6 +3182,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class QueryPipelineStatisticFlagBits : VkQueryPipelineStatisticFlags
   {
@@ -3143,6 +3199,7 @@ namespace VULKAN_HPP_NAMESPACE
     eComputeShaderInvocations                = VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( QueryPipelineStatisticFlagBits value )
   {
     switch ( value )
@@ -3161,6 +3218,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class QueryResultFlagBits : VkQueryResultFlags
   {
@@ -3173,6 +3231,7 @@ namespace VULKAN_HPP_NAMESPACE
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( QueryResultFlagBits value )
   {
     switch ( value )
@@ -3181,12 +3240,13 @@ namespace VULKAN_HPP_NAMESPACE
       case QueryResultFlagBits::eWait: return "Wait";
       case QueryResultFlagBits::eWithAvailability: return "WithAvailability";
       case QueryResultFlagBits::ePartial: return "Partial";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case QueryResultFlagBits::eWithStatusKHR: return "WithStatusKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class QueryType
   {
@@ -3210,6 +3270,7 @@ namespace VULKAN_HPP_NAMESPACE
     eAccelerationStructureSizeKHR                             = VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SIZE_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( QueryType value )
   {
     switch ( value )
@@ -3217,33 +3278,36 @@ namespace VULKAN_HPP_NAMESPACE
       case QueryType::eOcclusion: return "Occlusion";
       case QueryType::ePipelineStatistics: return "PipelineStatistics";
       case QueryType::eTimestamp: return "Timestamp";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case QueryType::eResultStatusOnlyKHR: return "ResultStatusOnlyKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       case QueryType::eTransformFeedbackStreamEXT: return "TransformFeedbackStreamEXT";
       case QueryType::ePerformanceQueryKHR: return "PerformanceQueryKHR";
       case QueryType::eAccelerationStructureCompactedSizeKHR: return "AccelerationStructureCompactedSizeKHR";
       case QueryType::eAccelerationStructureSerializationSizeKHR: return "AccelerationStructureSerializationSizeKHR";
       case QueryType::eAccelerationStructureCompactedSizeNV: return "AccelerationStructureCompactedSizeNV";
       case QueryType::ePerformanceQueryINTEL: return "PerformanceQueryINTEL";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case QueryType::eVideoEncodeBitstreamBufferRangeKHR: return "VideoEncodeBitstreamBufferRangeKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       case QueryType::ePrimitivesGeneratedEXT: return "PrimitivesGeneratedEXT";
       case QueryType::eAccelerationStructureSerializationBottomLevelPointersKHR: return "AccelerationStructureSerializationBottomLevelPointersKHR";
       case QueryType::eAccelerationStructureSizeKHR: return "AccelerationStructureSizeKHR";
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class QueryPoolCreateFlagBits
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( QueryPoolCreateFlagBits )
   {
     return "(void)";
   }
+#endif
 
   enum class BufferCreateFlagBits : VkBufferCreateFlags
   {
@@ -3256,6 +3320,7 @@ namespace VULKAN_HPP_NAMESPACE
     eDeviceAddressCaptureReplayKHR = VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( BufferCreateFlagBits value )
   {
     switch ( value )
@@ -3268,6 +3333,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class BufferUsageFlagBits : VkBufferUsageFlags
   {
@@ -3300,6 +3366,7 @@ namespace VULKAN_HPP_NAMESPACE
     eShaderDeviceAddressKHR = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( BufferUsageFlagBits value )
   {
     switch ( value )
@@ -3314,23 +3381,24 @@ namespace VULKAN_HPP_NAMESPACE
       case BufferUsageFlagBits::eVertexBuffer: return "VertexBuffer";
       case BufferUsageFlagBits::eIndirectBuffer: return "IndirectBuffer";
       case BufferUsageFlagBits::eShaderDeviceAddress: return "ShaderDeviceAddress";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case BufferUsageFlagBits::eVideoDecodeSrcKHR: return "VideoDecodeSrcKHR";
       case BufferUsageFlagBits::eVideoDecodeDstKHR: return "VideoDecodeDstKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       case BufferUsageFlagBits::eTransformFeedbackBufferEXT: return "TransformFeedbackBufferEXT";
       case BufferUsageFlagBits::eTransformFeedbackCounterBufferEXT: return "TransformFeedbackCounterBufferEXT";
       case BufferUsageFlagBits::eConditionalRenderingEXT: return "ConditionalRenderingEXT";
       case BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR: return "AccelerationStructureBuildInputReadOnlyKHR";
       case BufferUsageFlagBits::eAccelerationStructureStorageKHR: return "AccelerationStructureStorageKHR";
       case BufferUsageFlagBits::eShaderBindingTableKHR: return "ShaderBindingTableKHR";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case BufferUsageFlagBits::eVideoEncodeDstKHR: return "VideoEncodeDstKHR";
       case BufferUsageFlagBits::eVideoEncodeSrcKHR: return "VideoEncodeSrcKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class SharingMode
   {
@@ -3338,6 +3406,7 @@ namespace VULKAN_HPP_NAMESPACE
     eConcurrent = VK_SHARING_MODE_CONCURRENT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SharingMode value )
   {
     switch ( value )
@@ -3347,15 +3416,18 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class BufferViewCreateFlagBits : VkBufferViewCreateFlags
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( BufferViewCreateFlagBits )
   {
     return "(void)";
   }
+#endif
 
   enum class ImageLayout
   {
@@ -3401,6 +3473,7 @@ namespace VULKAN_HPP_NAMESPACE
     eStencilReadOnlyOptimalKHR                = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageLayout value )
   {
     switch ( value )
@@ -3423,22 +3496,23 @@ namespace VULKAN_HPP_NAMESPACE
       case ImageLayout::eReadOnlyOptimal: return "ReadOnlyOptimal";
       case ImageLayout::eAttachmentOptimal: return "AttachmentOptimal";
       case ImageLayout::ePresentSrcKHR: return "PresentSrcKHR";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case ImageLayout::eVideoDecodeDstKHR: return "VideoDecodeDstKHR";
       case ImageLayout::eVideoDecodeSrcKHR: return "VideoDecodeSrcKHR";
       case ImageLayout::eVideoDecodeDpbKHR: return "VideoDecodeDpbKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       case ImageLayout::eSharedPresentKHR: return "SharedPresentKHR";
       case ImageLayout::eFragmentDensityMapOptimalEXT: return "FragmentDensityMapOptimalEXT";
       case ImageLayout::eFragmentShadingRateAttachmentOptimalKHR: return "FragmentShadingRateAttachmentOptimalKHR";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case ImageLayout::eVideoEncodeDstKHR: return "VideoEncodeDstKHR";
       case ImageLayout::eVideoEncodeSrcKHR: return "VideoEncodeSrcKHR";
       case ImageLayout::eVideoEncodeDpbKHR: return "VideoEncodeDpbKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ComponentSwizzle
   {
@@ -3451,6 +3525,7 @@ namespace VULKAN_HPP_NAMESPACE
     eA        = VK_COMPONENT_SWIZZLE_A
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ComponentSwizzle value )
   {
     switch ( value )
@@ -3465,6 +3540,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ImageViewCreateFlagBits : VkImageViewCreateFlags
   {
@@ -3472,6 +3548,7 @@ namespace VULKAN_HPP_NAMESPACE
     eFragmentDensityMapDeferredEXT = VK_IMAGE_VIEW_CREATE_FRAGMENT_DENSITY_MAP_DEFERRED_BIT_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageViewCreateFlagBits value )
   {
     switch ( value )
@@ -3481,6 +3558,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ImageViewType
   {
@@ -3493,6 +3571,7 @@ namespace VULKAN_HPP_NAMESPACE
     eCubeArray = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageViewType value )
   {
     switch ( value )
@@ -3507,15 +3586,18 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ShaderModuleCreateFlagBits : VkShaderModuleCreateFlags
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ShaderModuleCreateFlagBits )
   {
     return "(void)";
   }
+#endif
 
   enum class BlendFactor
   {
@@ -3540,6 +3622,7 @@ namespace VULKAN_HPP_NAMESPACE
     eOneMinusSrc1Alpha     = VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( BlendFactor value )
   {
     switch ( value )
@@ -3566,6 +3649,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class BlendOp
   {
@@ -3622,6 +3706,7 @@ namespace VULKAN_HPP_NAMESPACE
     eBlueEXT             = VK_BLEND_OP_BLUE_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( BlendOp value )
   {
     switch ( value )
@@ -3680,6 +3765,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ColorComponentFlagBits : VkColorComponentFlags
   {
@@ -3689,6 +3775,7 @@ namespace VULKAN_HPP_NAMESPACE
     eA = VK_COLOR_COMPONENT_A_BIT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ColorComponentFlagBits value )
   {
     switch ( value )
@@ -3700,6 +3787,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class CompareOp
   {
@@ -3713,6 +3801,7 @@ namespace VULKAN_HPP_NAMESPACE
     eAlways         = VK_COMPARE_OP_ALWAYS
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CompareOp value )
   {
     switch ( value )
@@ -3728,6 +3817,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class CullModeFlagBits : VkCullModeFlags
   {
@@ -3737,6 +3827,7 @@ namespace VULKAN_HPP_NAMESPACE
     eFrontAndBack = VK_CULL_MODE_FRONT_AND_BACK
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CullModeFlagBits value )
   {
     switch ( value )
@@ -3748,6 +3839,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DynamicState
   {
@@ -3805,6 +3897,7 @@ namespace VULKAN_HPP_NAMESPACE
     eViewportWithCountEXT           = VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DynamicState value )
   {
     switch ( value )
@@ -3849,6 +3942,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class FrontFace
   {
@@ -3856,6 +3950,7 @@ namespace VULKAN_HPP_NAMESPACE
     eClockwise        = VK_FRONT_FACE_CLOCKWISE
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( FrontFace value )
   {
     switch ( value )
@@ -3865,6 +3960,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class LogicOp
   {
@@ -3886,6 +3982,7 @@ namespace VULKAN_HPP_NAMESPACE
     eSet          = VK_LOGIC_OP_SET
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( LogicOp value )
   {
     switch ( value )
@@ -3909,6 +4006,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PipelineCreateFlagBits : VkPipelineCreateFlags
   {
@@ -3944,6 +4042,7 @@ namespace VULKAN_HPP_NAMESPACE
     eVkPipelineRasterizationStateCreateFragmentShadingRateAttachmentKHR = VK_PIPELINE_RASTERIZATION_STATE_CREATE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineCreateFlagBits value )
   {
     switch ( value )
@@ -3975,6 +4074,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PipelineShaderStageCreateFlagBits : VkPipelineShaderStageCreateFlags
   {
@@ -3984,6 +4084,7 @@ namespace VULKAN_HPP_NAMESPACE
     eRequireFullSubgroupsEXT     = VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineShaderStageCreateFlagBits value )
   {
     switch ( value )
@@ -3993,6 +4094,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PolygonMode
   {
@@ -4002,6 +4104,7 @@ namespace VULKAN_HPP_NAMESPACE
     eFillRectangleNV = VK_POLYGON_MODE_FILL_RECTANGLE_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PolygonMode value )
   {
     switch ( value )
@@ -4013,6 +4116,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PrimitiveTopology
   {
@@ -4029,6 +4133,7 @@ namespace VULKAN_HPP_NAMESPACE
     ePatchList                  = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PrimitiveTopology value )
   {
     switch ( value )
@@ -4047,6 +4152,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ShaderStageFlagBits : VkShaderStageFlags
   {
@@ -4075,6 +4181,7 @@ namespace VULKAN_HPP_NAMESPACE
     eRaygenNV               = VK_SHADER_STAGE_RAYGEN_BIT_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ShaderStageFlagBits value )
   {
     switch ( value )
@@ -4099,6 +4206,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class StencilOp
   {
@@ -4112,6 +4220,7 @@ namespace VULKAN_HPP_NAMESPACE
     eDecrementAndWrap  = VK_STENCIL_OP_DECREMENT_AND_WRAP
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( StencilOp value )
   {
     switch ( value )
@@ -4127,6 +4236,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class VertexInputRate
   {
@@ -4134,6 +4244,7 @@ namespace VULKAN_HPP_NAMESPACE
     eInstance = VK_VERTEX_INPUT_RATE_INSTANCE
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VertexInputRate value )
   {
     switch ( value )
@@ -4143,69 +4254,84 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PipelineDynamicStateCreateFlagBits : VkPipelineDynamicStateCreateFlags
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineDynamicStateCreateFlagBits )
   {
     return "(void)";
   }
+#endif
 
   enum class PipelineInputAssemblyStateCreateFlagBits : VkPipelineInputAssemblyStateCreateFlags
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineInputAssemblyStateCreateFlagBits )
   {
     return "(void)";
   }
+#endif
 
   enum class PipelineMultisampleStateCreateFlagBits : VkPipelineMultisampleStateCreateFlags
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineMultisampleStateCreateFlagBits )
   {
     return "(void)";
   }
+#endif
 
   enum class PipelineRasterizationStateCreateFlagBits : VkPipelineRasterizationStateCreateFlags
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineRasterizationStateCreateFlagBits )
   {
     return "(void)";
   }
+#endif
 
   enum class PipelineTessellationStateCreateFlagBits : VkPipelineTessellationStateCreateFlags
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineTessellationStateCreateFlagBits )
   {
     return "(void)";
   }
+#endif
 
   enum class PipelineVertexInputStateCreateFlagBits : VkPipelineVertexInputStateCreateFlags
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineVertexInputStateCreateFlagBits )
   {
     return "(void)";
   }
+#endif
 
   enum class PipelineViewportStateCreateFlagBits : VkPipelineViewportStateCreateFlags
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineViewportStateCreateFlagBits )
   {
     return "(void)";
   }
+#endif
 
   enum class BorderColor
   {
@@ -4219,6 +4345,7 @@ namespace VULKAN_HPP_NAMESPACE
     eIntCustomEXT          = VK_BORDER_COLOR_INT_CUSTOM_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( BorderColor value )
   {
     switch ( value )
@@ -4234,6 +4361,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class Filter
   {
@@ -4243,6 +4371,7 @@ namespace VULKAN_HPP_NAMESPACE
     eCubicIMG = VK_FILTER_CUBIC_IMG
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( Filter value )
   {
     switch ( value )
@@ -4253,6 +4382,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class SamplerAddressMode
   {
@@ -4264,6 +4394,7 @@ namespace VULKAN_HPP_NAMESPACE
     eMirrorClampToEdgeKHR = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SamplerAddressMode value )
   {
     switch ( value )
@@ -4276,6 +4407,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class SamplerCreateFlagBits : VkSamplerCreateFlags
   {
@@ -4285,6 +4417,7 @@ namespace VULKAN_HPP_NAMESPACE
     eImageProcessingQCOM               = VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SamplerCreateFlagBits value )
   {
     switch ( value )
@@ -4296,6 +4429,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class SamplerMipmapMode
   {
@@ -4303,6 +4437,7 @@ namespace VULKAN_HPP_NAMESPACE
     eLinear  = VK_SAMPLER_MIPMAP_MODE_LINEAR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SamplerMipmapMode value )
   {
     switch ( value )
@@ -4312,6 +4447,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DescriptorPoolCreateFlagBits : VkDescriptorPoolCreateFlags
   {
@@ -4321,6 +4457,7 @@ namespace VULKAN_HPP_NAMESPACE
     eUpdateAfterBindEXT = VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DescriptorPoolCreateFlagBits value )
   {
     switch ( value )
@@ -4331,6 +4468,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DescriptorSetLayoutCreateFlagBits : VkDescriptorSetLayoutCreateFlags
   {
@@ -4340,6 +4478,7 @@ namespace VULKAN_HPP_NAMESPACE
     eUpdateAfterBindPoolEXT = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DescriptorSetLayoutCreateFlagBits value )
   {
     switch ( value )
@@ -4350,6 +4489,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DescriptorType
   {
@@ -4373,6 +4513,7 @@ namespace VULKAN_HPP_NAMESPACE
     eInlineUniformBlockEXT    = VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DescriptorType value )
   {
     switch ( value )
@@ -4397,15 +4538,18 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DescriptorPoolResetFlagBits : VkDescriptorPoolResetFlags
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DescriptorPoolResetFlagBits )
   {
     return "(void)";
   }
+#endif
 
   enum class AccessFlagBits : VkAccessFlags
   {
@@ -4444,6 +4588,7 @@ namespace VULKAN_HPP_NAMESPACE
     eShadingRateImageReadNV               = VK_ACCESS_SHADING_RATE_IMAGE_READ_BIT_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AccessFlagBits value )
   {
     switch ( value )
@@ -4480,12 +4625,14 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class AttachmentDescriptionFlagBits : VkAttachmentDescriptionFlags
   {
     eMayAlias = VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AttachmentDescriptionFlagBits value )
   {
     switch ( value )
@@ -4494,6 +4641,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class AttachmentLoadOp
   {
@@ -4503,6 +4651,7 @@ namespace VULKAN_HPP_NAMESPACE
     eNoneEXT  = VK_ATTACHMENT_LOAD_OP_NONE_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AttachmentLoadOp value )
   {
     switch ( value )
@@ -4514,6 +4663,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class AttachmentStoreOp
   {
@@ -4525,6 +4675,7 @@ namespace VULKAN_HPP_NAMESPACE
     eNoneQCOM = VK_ATTACHMENT_STORE_OP_NONE_QCOM
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AttachmentStoreOp value )
   {
     switch ( value )
@@ -4535,6 +4686,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DependencyFlagBits : VkDependencyFlags
   {
@@ -4545,6 +4697,7 @@ namespace VULKAN_HPP_NAMESPACE
     eViewLocalKHR   = VK_DEPENDENCY_VIEW_LOCAL_BIT_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DependencyFlagBits value )
   {
     switch ( value )
@@ -4555,6 +4708,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class FramebufferCreateFlagBits : VkFramebufferCreateFlags
   {
@@ -4562,6 +4716,7 @@ namespace VULKAN_HPP_NAMESPACE
     eImagelessKHR = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( FramebufferCreateFlagBits value )
   {
     switch ( value )
@@ -4570,6 +4725,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PipelineBindPoint
   {
@@ -4580,6 +4736,7 @@ namespace VULKAN_HPP_NAMESPACE
     eRayTracingNV         = VK_PIPELINE_BIND_POINT_RAY_TRACING_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineBindPoint value )
   {
     switch ( value )
@@ -4591,12 +4748,14 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class RenderPassCreateFlagBits : VkRenderPassCreateFlags
   {
     eTransformQCOM = VK_RENDER_PASS_CREATE_TRANSFORM_BIT_QCOM
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( RenderPassCreateFlagBits value )
   {
     switch ( value )
@@ -4605,6 +4764,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class SubpassDescriptionFlagBits : VkSubpassDescriptionFlags
   {
@@ -4617,6 +4777,7 @@ namespace VULKAN_HPP_NAMESPACE
     eRasterizationOrderAttachmentStencilAccessARM = VK_SUBPASS_DESCRIPTION_RASTERIZATION_ORDER_ATTACHMENT_STENCIL_ACCESS_BIT_ARM
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SubpassDescriptionFlagBits value )
   {
     switch ( value )
@@ -4631,6 +4792,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class CommandPoolCreateFlagBits : VkCommandPoolCreateFlags
   {
@@ -4639,6 +4801,7 @@ namespace VULKAN_HPP_NAMESPACE
     eProtected          = VK_COMMAND_POOL_CREATE_PROTECTED_BIT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CommandPoolCreateFlagBits value )
   {
     switch ( value )
@@ -4649,12 +4812,14 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class CommandPoolResetFlagBits : VkCommandPoolResetFlags
   {
     eReleaseResources = VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CommandPoolResetFlagBits value )
   {
     switch ( value )
@@ -4663,6 +4828,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class CommandBufferLevel
   {
@@ -4670,6 +4836,7 @@ namespace VULKAN_HPP_NAMESPACE
     eSecondary = VK_COMMAND_BUFFER_LEVEL_SECONDARY
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CommandBufferLevel value )
   {
     switch ( value )
@@ -4679,12 +4846,14 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class CommandBufferResetFlagBits : VkCommandBufferResetFlags
   {
     eReleaseResources = VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CommandBufferResetFlagBits value )
   {
     switch ( value )
@@ -4693,6 +4862,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class CommandBufferUsageFlagBits : VkCommandBufferUsageFlags
   {
@@ -4701,6 +4871,7 @@ namespace VULKAN_HPP_NAMESPACE
     eSimultaneousUse    = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CommandBufferUsageFlagBits value )
   {
     switch ( value )
@@ -4711,12 +4882,14 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class QueryControlFlagBits : VkQueryControlFlags
   {
     ePrecise = VK_QUERY_CONTROL_PRECISE_BIT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( QueryControlFlagBits value )
   {
     switch ( value )
@@ -4725,6 +4898,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class IndexType
   {
@@ -4735,6 +4909,7 @@ namespace VULKAN_HPP_NAMESPACE
     eNoneNV   = VK_INDEX_TYPE_NONE_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( IndexType value )
   {
     switch ( value )
@@ -4746,6 +4921,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class StencilFaceFlagBits : VkStencilFaceFlags
   {
@@ -4755,6 +4931,7 @@ namespace VULKAN_HPP_NAMESPACE
     eVkStencilFrontAndBack = VK_STENCIL_FRONT_AND_BACK
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( StencilFaceFlagBits value )
   {
     switch ( value )
@@ -4765,6 +4942,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class SubpassContents
   {
@@ -4772,6 +4950,7 @@ namespace VULKAN_HPP_NAMESPACE
     eSecondaryCommandBuffers = VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SubpassContents value )
   {
     switch ( value )
@@ -4781,6 +4960,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_VERSION_1_1 ===
 
@@ -4797,6 +4977,7 @@ namespace VULKAN_HPP_NAMESPACE
     ePartitionedNV   = VK_SUBGROUP_FEATURE_PARTITIONED_BIT_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SubgroupFeatureFlagBits value )
   {
     switch ( value )
@@ -4813,6 +4994,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PeerMemoryFeatureFlagBits : VkPeerMemoryFeatureFlags
   {
@@ -4823,6 +5005,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using PeerMemoryFeatureFlagBitsKHR = PeerMemoryFeatureFlagBits;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PeerMemoryFeatureFlagBits value )
   {
     switch ( value )
@@ -4834,6 +5017,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class MemoryAllocateFlagBits : VkMemoryAllocateFlags
   {
@@ -4843,6 +5027,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using MemoryAllocateFlagBitsKHR = MemoryAllocateFlagBits;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( MemoryAllocateFlagBits value )
   {
     switch ( value )
@@ -4853,15 +5038,18 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class CommandPoolTrimFlagBits : VkCommandPoolTrimFlags
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CommandPoolTrimFlagBits )
   {
     return "(void)";
   }
+#endif
 
   enum class PointClippingBehavior
   {
@@ -4870,6 +5058,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using PointClippingBehaviorKHR = PointClippingBehavior;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PointClippingBehavior value )
   {
     switch ( value )
@@ -4879,6 +5068,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class TessellationDomainOrigin
   {
@@ -4887,6 +5077,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using TessellationDomainOriginKHR = TessellationDomainOrigin;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( TessellationDomainOrigin value )
   {
     switch ( value )
@@ -4896,12 +5087,14 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DeviceQueueCreateFlagBits : VkDeviceQueueCreateFlags
   {
     eProtected = VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DeviceQueueCreateFlagBits value )
   {
     switch ( value )
@@ -4910,6 +5103,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class SamplerYcbcrModelConversion
   {
@@ -4921,6 +5115,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using SamplerYcbcrModelConversionKHR = SamplerYcbcrModelConversion;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SamplerYcbcrModelConversion value )
   {
     switch ( value )
@@ -4933,6 +5128,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class SamplerYcbcrRange
   {
@@ -4941,6 +5137,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using SamplerYcbcrRangeKHR = SamplerYcbcrRange;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SamplerYcbcrRange value )
   {
     switch ( value )
@@ -4950,6 +5147,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ChromaLocation
   {
@@ -4958,6 +5156,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using ChromaLocationKHR = ChromaLocation;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ChromaLocation value )
   {
     switch ( value )
@@ -4967,6 +5166,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DescriptorUpdateTemplateType
   {
@@ -4975,6 +5175,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using DescriptorUpdateTemplateTypeKHR = DescriptorUpdateTemplateType;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DescriptorUpdateTemplateType value )
   {
     switch ( value )
@@ -4984,15 +5185,18 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DescriptorUpdateTemplateCreateFlagBits : VkDescriptorUpdateTemplateCreateFlags
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DescriptorUpdateTemplateCreateFlagBits )
   {
     return "(void)";
   }
+#endif
 
   enum class ExternalMemoryHandleTypeFlagBits : VkExternalMemoryHandleTypeFlags
   {
@@ -5016,6 +5220,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using ExternalMemoryHandleTypeFlagBitsKHR = ExternalMemoryHandleTypeFlagBits;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ExternalMemoryHandleTypeFlagBits value )
   {
     switch ( value )
@@ -5028,18 +5233,19 @@ namespace VULKAN_HPP_NAMESPACE
       case ExternalMemoryHandleTypeFlagBits::eD3D12Heap: return "D3D12Heap";
       case ExternalMemoryHandleTypeFlagBits::eD3D12Resource: return "D3D12Resource";
       case ExternalMemoryHandleTypeFlagBits::eDmaBufEXT: return "DmaBufEXT";
-#if defined( VK_USE_PLATFORM_ANDROID_KHR )
+#  if defined( VK_USE_PLATFORM_ANDROID_KHR )
       case ExternalMemoryHandleTypeFlagBits::eAndroidHardwareBufferANDROID: return "AndroidHardwareBufferANDROID";
-#endif /*VK_USE_PLATFORM_ANDROID_KHR*/
+#  endif /*VK_USE_PLATFORM_ANDROID_KHR*/
       case ExternalMemoryHandleTypeFlagBits::eHostAllocationEXT: return "HostAllocationEXT";
       case ExternalMemoryHandleTypeFlagBits::eHostMappedForeignMemoryEXT: return "HostMappedForeignMemoryEXT";
-#if defined( VK_USE_PLATFORM_FUCHSIA )
+#  if defined( VK_USE_PLATFORM_FUCHSIA )
       case ExternalMemoryHandleTypeFlagBits::eZirconVmoFUCHSIA: return "ZirconVmoFUCHSIA";
-#endif /*VK_USE_PLATFORM_FUCHSIA*/
+#  endif /*VK_USE_PLATFORM_FUCHSIA*/
       case ExternalMemoryHandleTypeFlagBits::eRdmaAddressNV: return "RdmaAddressNV";
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ExternalMemoryFeatureFlagBits : VkExternalMemoryFeatureFlags
   {
@@ -5049,6 +5255,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using ExternalMemoryFeatureFlagBitsKHR = ExternalMemoryFeatureFlagBits;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ExternalMemoryFeatureFlagBits value )
   {
     switch ( value )
@@ -5059,6 +5266,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ExternalFenceHandleTypeFlagBits : VkExternalFenceHandleTypeFlags
   {
@@ -5069,6 +5277,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using ExternalFenceHandleTypeFlagBitsKHR = ExternalFenceHandleTypeFlagBits;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ExternalFenceHandleTypeFlagBits value )
   {
     switch ( value )
@@ -5080,6 +5289,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ExternalFenceFeatureFlagBits : VkExternalFenceFeatureFlags
   {
@@ -5088,6 +5298,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using ExternalFenceFeatureFlagBitsKHR = ExternalFenceFeatureFlagBits;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ExternalFenceFeatureFlagBits value )
   {
     switch ( value )
@@ -5097,6 +5308,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class FenceImportFlagBits : VkFenceImportFlags
   {
@@ -5104,6 +5316,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using FenceImportFlagBitsKHR = FenceImportFlagBits;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( FenceImportFlagBits value )
   {
     switch ( value )
@@ -5112,6 +5325,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class SemaphoreImportFlagBits : VkSemaphoreImportFlags
   {
@@ -5119,6 +5333,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using SemaphoreImportFlagBitsKHR = SemaphoreImportFlagBits;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SemaphoreImportFlagBits value )
   {
     switch ( value )
@@ -5127,6 +5342,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ExternalSemaphoreHandleTypeFlagBits : VkExternalSemaphoreHandleTypeFlags
   {
@@ -5142,6 +5358,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using ExternalSemaphoreHandleTypeFlagBitsKHR = ExternalSemaphoreHandleTypeFlagBits;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ExternalSemaphoreHandleTypeFlagBits value )
   {
     switch ( value )
@@ -5151,12 +5368,13 @@ namespace VULKAN_HPP_NAMESPACE
       case ExternalSemaphoreHandleTypeFlagBits::eOpaqueWin32Kmt: return "OpaqueWin32Kmt";
       case ExternalSemaphoreHandleTypeFlagBits::eD3D12Fence: return "D3D12Fence";
       case ExternalSemaphoreHandleTypeFlagBits::eSyncFd: return "SyncFd";
-#if defined( VK_USE_PLATFORM_FUCHSIA )
+#  if defined( VK_USE_PLATFORM_FUCHSIA )
       case ExternalSemaphoreHandleTypeFlagBits::eZirconEventFUCHSIA: return "ZirconEventFUCHSIA";
-#endif /*VK_USE_PLATFORM_FUCHSIA*/
+#  endif /*VK_USE_PLATFORM_FUCHSIA*/
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ExternalSemaphoreFeatureFlagBits : VkExternalSemaphoreFeatureFlags
   {
@@ -5165,6 +5383,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using ExternalSemaphoreFeatureFlagBitsKHR = ExternalSemaphoreFeatureFlagBits;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ExternalSemaphoreFeatureFlagBits value )
   {
     switch ( value )
@@ -5174,6 +5393,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_VERSION_1_2 ===
 
@@ -5205,6 +5425,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using DriverIdKHR = DriverId;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DriverId value )
   {
     switch ( value )
@@ -5235,6 +5456,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ShaderFloatControlsIndependence
   {
@@ -5244,6 +5466,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using ShaderFloatControlsIndependenceKHR = ShaderFloatControlsIndependence;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ShaderFloatControlsIndependence value )
   {
     switch ( value )
@@ -5254,6 +5477,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DescriptorBindingFlagBits : VkDescriptorBindingFlags
   {
@@ -5264,6 +5488,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using DescriptorBindingFlagBitsEXT = DescriptorBindingFlagBits;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DescriptorBindingFlagBits value )
   {
     switch ( value )
@@ -5275,6 +5500,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ResolveModeFlagBits : VkResolveModeFlags
   {
@@ -5286,6 +5512,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using ResolveModeFlagBitsKHR = ResolveModeFlagBits;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ResolveModeFlagBits value )
   {
     switch ( value )
@@ -5298,6 +5525,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class SamplerReductionMode
   {
@@ -5307,6 +5535,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using SamplerReductionModeEXT = SamplerReductionMode;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SamplerReductionMode value )
   {
     switch ( value )
@@ -5317,6 +5546,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class SemaphoreType
   {
@@ -5325,6 +5555,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using SemaphoreTypeKHR = SemaphoreType;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SemaphoreType value )
   {
     switch ( value )
@@ -5334,6 +5565,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class SemaphoreWaitFlagBits : VkSemaphoreWaitFlags
   {
@@ -5341,6 +5573,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using SemaphoreWaitFlagBitsKHR = SemaphoreWaitFlagBits;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SemaphoreWaitFlagBits value )
   {
     switch ( value )
@@ -5349,6 +5582,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_VERSION_1_3 ===
 
@@ -5360,6 +5594,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using PipelineCreationFeedbackFlagBitsEXT = PipelineCreationFeedbackFlagBits;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineCreationFeedbackFlagBits value )
   {
     switch ( value )
@@ -5370,6 +5605,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ToolPurposeFlagBits : VkToolPurposeFlags
   {
@@ -5383,6 +5619,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using ToolPurposeFlagBitsEXT = ToolPurposeFlagBits;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ToolPurposeFlagBits value )
   {
     switch ( value )
@@ -5397,16 +5634,19 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PrivateDataSlotCreateFlagBits : VkPrivateDataSlotCreateFlags
   {
   };
   using PrivateDataSlotCreateFlagBitsEXT = PrivateDataSlotCreateFlagBits;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PrivateDataSlotCreateFlagBits )
   {
     return "(void)";
   }
+#endif
 
   enum class PipelineStageFlagBits2 : VkPipelineStageFlags2
   {
@@ -5458,6 +5698,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using PipelineStageFlagBits2KHR = PipelineStageFlagBits2;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineStageFlagBits2 value )
   {
     switch ( value )
@@ -5487,10 +5728,10 @@ namespace VULKAN_HPP_NAMESPACE
       case PipelineStageFlagBits2::eIndexInput: return "IndexInput";
       case PipelineStageFlagBits2::eVertexAttributeInput: return "VertexAttributeInput";
       case PipelineStageFlagBits2::ePreRasterizationShaders: return "PreRasterizationShaders";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case PipelineStageFlagBits2::eVideoDecodeKHR: return "VideoDecodeKHR";
       case PipelineStageFlagBits2::eVideoEncodeKHR: return "VideoEncodeKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       case PipelineStageFlagBits2::eTransformFeedbackEXT: return "TransformFeedbackEXT";
       case PipelineStageFlagBits2::eConditionalRenderingEXT: return "ConditionalRenderingEXT";
       case PipelineStageFlagBits2::eCommandPreprocessNV: return "CommandPreprocessNV";
@@ -5506,6 +5747,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class AccessFlagBits2 : VkAccessFlags2
   {
@@ -5555,6 +5797,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using AccessFlagBits2KHR = AccessFlagBits2;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AccessFlagBits2 value )
   {
     switch ( value )
@@ -5580,12 +5823,12 @@ namespace VULKAN_HPP_NAMESPACE
       case AccessFlagBits2::eShaderSampledRead: return "ShaderSampledRead";
       case AccessFlagBits2::eShaderStorageRead: return "ShaderStorageRead";
       case AccessFlagBits2::eShaderStorageWrite: return "ShaderStorageWrite";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case AccessFlagBits2::eVideoDecodeReadKHR: return "VideoDecodeReadKHR";
       case AccessFlagBits2::eVideoDecodeWriteKHR: return "VideoDecodeWriteKHR";
       case AccessFlagBits2::eVideoEncodeReadKHR: return "VideoEncodeReadKHR";
       case AccessFlagBits2::eVideoEncodeWriteKHR: return "VideoEncodeWriteKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       case AccessFlagBits2::eTransformFeedbackWriteEXT: return "TransformFeedbackWriteEXT";
       case AccessFlagBits2::eTransformFeedbackCounterReadEXT: return "TransformFeedbackCounterReadEXT";
       case AccessFlagBits2::eTransformFeedbackCounterWriteEXT: return "TransformFeedbackCounterWriteEXT";
@@ -5602,6 +5845,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class SubmitFlagBits : VkSubmitFlags
   {
@@ -5609,6 +5853,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using SubmitFlagBitsKHR = SubmitFlagBits;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SubmitFlagBits value )
   {
     switch ( value )
@@ -5617,6 +5862,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class RenderingFlagBits : VkRenderingFlags
   {
@@ -5626,6 +5872,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using RenderingFlagBitsKHR = RenderingFlagBits;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( RenderingFlagBits value )
   {
     switch ( value )
@@ -5636,6 +5883,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class FormatFeatureFlagBits2 : VkFormatFeatureFlags2
   {
@@ -5687,6 +5935,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using FormatFeatureFlagBits2KHR = FormatFeatureFlagBits2;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( FormatFeatureFlagBits2 value )
   {
     switch ( value )
@@ -5719,17 +5968,17 @@ namespace VULKAN_HPP_NAMESPACE
       case FormatFeatureFlagBits2::eStorageReadWithoutFormat: return "StorageReadWithoutFormat";
       case FormatFeatureFlagBits2::eStorageWriteWithoutFormat: return "StorageWriteWithoutFormat";
       case FormatFeatureFlagBits2::eSampledImageDepthComparison: return "SampledImageDepthComparison";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case FormatFeatureFlagBits2::eVideoDecodeOutputKHR: return "VideoDecodeOutputKHR";
       case FormatFeatureFlagBits2::eVideoDecodeDpbKHR: return "VideoDecodeDpbKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       case FormatFeatureFlagBits2::eAccelerationStructureVertexBufferKHR: return "AccelerationStructureVertexBufferKHR";
       case FormatFeatureFlagBits2::eFragmentDensityMapEXT: return "FragmentDensityMapEXT";
       case FormatFeatureFlagBits2::eFragmentShadingRateAttachmentKHR: return "FragmentShadingRateAttachmentKHR";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
       case FormatFeatureFlagBits2::eVideoEncodeInputKHR: return "VideoEncodeInputKHR";
       case FormatFeatureFlagBits2::eVideoEncodeDpbKHR: return "VideoEncodeDpbKHR";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
       case FormatFeatureFlagBits2::eLinearColorAttachmentNV: return "LinearColorAttachmentNV";
       case FormatFeatureFlagBits2::eWeightImageQCOM: return "WeightImageQCOM";
       case FormatFeatureFlagBits2::eWeightSampledImageQCOM: return "WeightSampledImageQCOM";
@@ -5738,6 +5987,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_KHR_surface ===
 
@@ -5754,6 +6004,7 @@ namespace VULKAN_HPP_NAMESPACE
     eInherit                   = VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SurfaceTransformFlagBitsKHR value )
   {
     switch ( value )
@@ -5770,6 +6021,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PresentModeKHR
   {
@@ -5781,6 +6033,7 @@ namespace VULKAN_HPP_NAMESPACE
     eSharedContinuousRefresh = VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PresentModeKHR value )
   {
     switch ( value )
@@ -5794,6 +6047,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ColorSpaceKHR
   {
@@ -5817,6 +6071,7 @@ namespace VULKAN_HPP_NAMESPACE
     eDciP3LinearEXT            = VK_COLOR_SPACE_DCI_P3_LINEAR_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ColorSpaceKHR value )
   {
     switch ( value )
@@ -5840,6 +6095,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class CompositeAlphaFlagBitsKHR : VkCompositeAlphaFlagsKHR
   {
@@ -5849,6 +6105,7 @@ namespace VULKAN_HPP_NAMESPACE
     eInherit        = VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CompositeAlphaFlagBitsKHR value )
   {
     switch ( value )
@@ -5860,6 +6117,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_KHR_swapchain ===
 
@@ -5870,6 +6128,7 @@ namespace VULKAN_HPP_NAMESPACE
     eMutableFormat            = VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SwapchainCreateFlagBitsKHR value )
   {
     switch ( value )
@@ -5880,6 +6139,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DeviceGroupPresentModeFlagBitsKHR : VkDeviceGroupPresentModeFlagsKHR
   {
@@ -5889,6 +6149,7 @@ namespace VULKAN_HPP_NAMESPACE
     eLocalMultiDevice = VK_DEVICE_GROUP_PRESENT_MODE_LOCAL_MULTI_DEVICE_BIT_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DeviceGroupPresentModeFlagBitsKHR value )
   {
     switch ( value )
@@ -5900,6 +6161,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_KHR_display ===
 
@@ -5911,6 +6173,7 @@ namespace VULKAN_HPP_NAMESPACE
     ePerPixelPremultiplied = VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DisplayPlaneAlphaFlagBitsKHR value )
   {
     switch ( value )
@@ -5922,24 +6185,29 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DisplayModeCreateFlagBitsKHR : VkDisplayModeCreateFlagsKHR
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DisplayModeCreateFlagBitsKHR )
   {
     return "(void)";
   }
+#endif
 
   enum class DisplaySurfaceCreateFlagBitsKHR : VkDisplaySurfaceCreateFlagsKHR
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DisplaySurfaceCreateFlagBitsKHR )
   {
     return "(void)";
   }
+#endif
 
 #if defined( VK_USE_PLATFORM_XLIB_KHR )
   //=== VK_KHR_xlib_surface ===
@@ -5948,10 +6216,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( XlibSurfaceCreateFlagBitsKHR )
   {
     return "(void)";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_XLIB_KHR*/
 
 #if defined( VK_USE_PLATFORM_XCB_KHR )
@@ -5961,10 +6231,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( XcbSurfaceCreateFlagBitsKHR )
   {
     return "(void)";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_XCB_KHR*/
 
 #if defined( VK_USE_PLATFORM_WAYLAND_KHR )
@@ -5974,10 +6246,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( WaylandSurfaceCreateFlagBitsKHR )
   {
     return "(void)";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_WAYLAND_KHR*/
 
 #if defined( VK_USE_PLATFORM_ANDROID_KHR )
@@ -5987,10 +6261,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AndroidSurfaceCreateFlagBitsKHR )
   {
     return "(void)";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_ANDROID_KHR*/
 
 #if defined( VK_USE_PLATFORM_WIN32_KHR )
@@ -6000,10 +6276,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( Win32SurfaceCreateFlagBitsKHR )
   {
     return "(void)";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_WIN32_KHR*/
 
   //=== VK_EXT_debug_report ===
@@ -6017,6 +6295,7 @@ namespace VULKAN_HPP_NAMESPACE
     eDebug              = VK_DEBUG_REPORT_DEBUG_BIT_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DebugReportFlagBitsEXT value )
   {
     switch ( value )
@@ -6029,6 +6308,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DebugReportObjectTypeEXT
   {
@@ -6079,6 +6359,7 @@ namespace VULKAN_HPP_NAMESPACE
     eValidationCache             = VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DebugReportObjectTypeEXT value )
   {
     switch ( value )
@@ -6121,12 +6402,13 @@ namespace VULKAN_HPP_NAMESPACE
       case DebugReportObjectTypeEXT::eCuFunctionNVX: return "CuFunctionNVX";
       case DebugReportObjectTypeEXT::eAccelerationStructureKHR: return "AccelerationStructureKHR";
       case DebugReportObjectTypeEXT::eAccelerationStructureNV: return "AccelerationStructureNV";
-#if defined( VK_USE_PLATFORM_FUCHSIA )
+#  if defined( VK_USE_PLATFORM_FUCHSIA )
       case DebugReportObjectTypeEXT::eBufferCollectionFUCHSIA: return "BufferCollectionFUCHSIA";
-#endif /*VK_USE_PLATFORM_FUCHSIA*/
+#  endif /*VK_USE_PLATFORM_FUCHSIA*/
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_AMD_rasterization_order ===
 
@@ -6136,6 +6418,7 @@ namespace VULKAN_HPP_NAMESPACE
     eRelaxed = VK_RASTERIZATION_ORDER_RELAXED_AMD
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( RasterizationOrderAMD value )
   {
     switch ( value )
@@ -6145,6 +6428,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
   //=== VK_KHR_video_queue ===
@@ -6160,20 +6444,22 @@ namespace VULKAN_HPP_NAMESPACE
 #  endif /*VK_ENABLE_BETA_EXTENSIONS*/
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoCodecOperationFlagBitsKHR value )
   {
     switch ( value )
     {
       case VideoCodecOperationFlagBitsKHR::eInvalid: return "Invalid";
-#  if defined( VK_ENABLE_BETA_EXTENSIONS )
+#    if defined( VK_ENABLE_BETA_EXTENSIONS )
       case VideoCodecOperationFlagBitsKHR::eEncodeH264EXT: return "EncodeH264EXT";
       case VideoCodecOperationFlagBitsKHR::eEncodeH265EXT: return "EncodeH265EXT";
       case VideoCodecOperationFlagBitsKHR::eDecodeH264EXT: return "DecodeH264EXT";
       case VideoCodecOperationFlagBitsKHR::eDecodeH265EXT: return "DecodeH265EXT";
-#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#    endif /*VK_ENABLE_BETA_EXTENSIONS*/
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoChromaSubsamplingFlagBitsKHR : VkVideoChromaSubsamplingFlagsKHR
   {
@@ -6184,6 +6470,7 @@ namespace VULKAN_HPP_NAMESPACE
     e444        = VK_VIDEO_CHROMA_SUBSAMPLING_444_BIT_KHR
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoChromaSubsamplingFlagBitsKHR value )
   {
     switch ( value )
@@ -6196,6 +6483,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoComponentBitDepthFlagBitsKHR : VkVideoComponentBitDepthFlagsKHR
   {
@@ -6205,6 +6493,7 @@ namespace VULKAN_HPP_NAMESPACE
     e12      = VK_VIDEO_COMPONENT_BIT_DEPTH_12_BIT_KHR
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoComponentBitDepthFlagBitsKHR value )
   {
     switch ( value )
@@ -6216,6 +6505,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoCapabilityFlagBitsKHR : VkVideoCapabilityFlagsKHR
   {
@@ -6223,6 +6513,7 @@ namespace VULKAN_HPP_NAMESPACE
     eSeparateReferenceImages = VK_VIDEO_CAPABILITY_SEPARATE_REFERENCE_IMAGES_BIT_KHR
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoCapabilityFlagBitsKHR value )
   {
     switch ( value )
@@ -6232,6 +6523,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoSessionCreateFlagBitsKHR : VkVideoSessionCreateFlagsKHR
   {
@@ -6239,6 +6531,7 @@ namespace VULKAN_HPP_NAMESPACE
     eProtectedContent = VK_VIDEO_SESSION_CREATE_PROTECTED_CONTENT_BIT_KHR
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoSessionCreateFlagBitsKHR value )
   {
     switch ( value )
@@ -6248,6 +6541,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoCodingControlFlagBitsKHR : VkVideoCodingControlFlagsKHR
   {
@@ -6255,6 +6549,7 @@ namespace VULKAN_HPP_NAMESPACE
     eReset   = VK_VIDEO_CODING_CONTROL_RESET_BIT_KHR
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoCodingControlFlagBitsKHR value )
   {
     switch ( value )
@@ -6264,6 +6559,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoCodingQualityPresetFlagBitsKHR : VkVideoCodingQualityPresetFlagsKHR
   {
@@ -6272,6 +6568,7 @@ namespace VULKAN_HPP_NAMESPACE
     eQuality = VK_VIDEO_CODING_QUALITY_PRESET_QUALITY_BIT_KHR
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoCodingQualityPresetFlagBitsKHR value )
   {
     switch ( value )
@@ -6282,6 +6579,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class QueryResultStatusKHR
   {
@@ -6290,6 +6588,7 @@ namespace VULKAN_HPP_NAMESPACE
     eComplete = VK_QUERY_RESULT_STATUS_COMPLETE_KHR
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( QueryResultStatusKHR value )
   {
     switch ( value )
@@ -6300,24 +6599,29 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoBeginCodingFlagBitsKHR : VkVideoBeginCodingFlagsKHR
   {
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoBeginCodingFlagBitsKHR )
   {
     return "(void)";
   }
+#  endif
 
   enum class VideoEndCodingFlagBitsKHR : VkVideoEndCodingFlagsKHR
   {
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEndCodingFlagBitsKHR )
   {
     return "(void)";
   }
+#  endif
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
@@ -6330,6 +6634,7 @@ namespace VULKAN_HPP_NAMESPACE
     eDpbAndOutputDistinct = VK_VIDEO_DECODE_CAPABILITY_DPB_AND_OUTPUT_DISTINCT_BIT_KHR
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoDecodeCapabilityFlagBitsKHR value )
   {
     switch ( value )
@@ -6340,6 +6645,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoDecodeFlagBitsKHR : VkVideoDecodeFlagsKHR
   {
@@ -6347,6 +6653,7 @@ namespace VULKAN_HPP_NAMESPACE
     eReserved0 = VK_VIDEO_DECODE_RESERVED_0_BIT_KHR
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoDecodeFlagBitsKHR value )
   {
     switch ( value )
@@ -6356,6 +6663,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
   //=== VK_EXT_transform_feedback ===
@@ -6364,10 +6672,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineRasterizationStateStreamCreateFlagBitsEXT )
   {
     return "(void)";
   }
+#endif
 
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
   //=== VK_EXT_video_encode_h264 ===
@@ -6401,6 +6711,7 @@ namespace VULKAN_HPP_NAMESPACE
     eBFrameInL1List              = VK_VIDEO_ENCODE_H264_CAPABILITY_B_FRAME_IN_L1_LIST_BIT_EXT
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH264CapabilityFlagBitsEXT value )
   {
     switch ( value )
@@ -6433,6 +6744,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoEncodeH264InputModeFlagBitsEXT : VkVideoEncodeH264InputModeFlagsEXT
   {
@@ -6441,6 +6753,7 @@ namespace VULKAN_HPP_NAMESPACE
     eNonVcl = VK_VIDEO_ENCODE_H264_INPUT_MODE_NON_VCL_BIT_EXT
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH264InputModeFlagBitsEXT value )
   {
     switch ( value )
@@ -6451,6 +6764,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoEncodeH264OutputModeFlagBitsEXT : VkVideoEncodeH264OutputModeFlagsEXT
   {
@@ -6459,6 +6773,7 @@ namespace VULKAN_HPP_NAMESPACE
     eNonVcl = VK_VIDEO_ENCODE_H264_OUTPUT_MODE_NON_VCL_BIT_EXT
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH264OutputModeFlagBitsEXT value )
   {
     switch ( value )
@@ -6469,6 +6784,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoEncodeH264RateControlStructureFlagBitsEXT : VkVideoEncodeH264RateControlStructureFlagsEXT
   {
@@ -6477,6 +6793,7 @@ namespace VULKAN_HPP_NAMESPACE
     eDyadic  = VK_VIDEO_ENCODE_H264_RATE_CONTROL_STRUCTURE_DYADIC_BIT_EXT
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH264RateControlStructureFlagBitsEXT value )
   {
     switch ( value )
@@ -6487,6 +6804,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
@@ -6522,6 +6840,7 @@ namespace VULKAN_HPP_NAMESPACE
     eBFrameInL1List                  = VK_VIDEO_ENCODE_H265_CAPABILITY_B_FRAME_IN_L1_LIST_BIT_EXT
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH265CapabilityFlagBitsEXT value )
   {
     switch ( value )
@@ -6555,6 +6874,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoEncodeH265InputModeFlagBitsEXT : VkVideoEncodeH265InputModeFlagsEXT
   {
@@ -6563,6 +6883,7 @@ namespace VULKAN_HPP_NAMESPACE
     eNonVcl       = VK_VIDEO_ENCODE_H265_INPUT_MODE_NON_VCL_BIT_EXT
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH265InputModeFlagBitsEXT value )
   {
     switch ( value )
@@ -6573,6 +6894,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoEncodeH265OutputModeFlagBitsEXT : VkVideoEncodeH265OutputModeFlagsEXT
   {
@@ -6581,6 +6903,7 @@ namespace VULKAN_HPP_NAMESPACE
     eNonVcl       = VK_VIDEO_ENCODE_H265_OUTPUT_MODE_NON_VCL_BIT_EXT
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH265OutputModeFlagBitsEXT value )
   {
     switch ( value )
@@ -6591,6 +6914,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoEncodeH265CtbSizeFlagBitsEXT : VkVideoEncodeH265CtbSizeFlagsEXT
   {
@@ -6599,6 +6923,7 @@ namespace VULKAN_HPP_NAMESPACE
     e64 = VK_VIDEO_ENCODE_H265_CTB_SIZE_64_BIT_EXT
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH265CtbSizeFlagBitsEXT value )
   {
     switch ( value )
@@ -6609,6 +6934,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoEncodeH265TransformBlockSizeFlagBitsEXT : VkVideoEncodeH265TransformBlockSizeFlagsEXT
   {
@@ -6618,6 +6944,7 @@ namespace VULKAN_HPP_NAMESPACE
     e32 = VK_VIDEO_ENCODE_H265_TRANSFORM_BLOCK_SIZE_32_BIT_EXT
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH265TransformBlockSizeFlagBitsEXT value )
   {
     switch ( value )
@@ -6629,6 +6956,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoEncodeH265RateControlStructureFlagBitsEXT : VkVideoEncodeH265RateControlStructureFlagsEXT
   {
@@ -6637,6 +6965,7 @@ namespace VULKAN_HPP_NAMESPACE
     eDyadic  = VK_VIDEO_ENCODE_H265_RATE_CONTROL_STRUCTURE_DYADIC_BIT_EXT
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH265RateControlStructureFlagBitsEXT value )
   {
     switch ( value )
@@ -6647,6 +6976,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
@@ -6659,6 +6989,7 @@ namespace VULKAN_HPP_NAMESPACE
     eInterlacedSeparatePlanes   = VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_INTERLACED_SEPARATE_PLANES_BIT_EXT
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoDecodeH264PictureLayoutFlagBitsEXT value )
   {
     switch ( value )
@@ -6669,6 +7000,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
   //=== VK_AMD_shader_info ===
@@ -6680,6 +7012,7 @@ namespace VULKAN_HPP_NAMESPACE
     eDisassembly = VK_SHADER_INFO_TYPE_DISASSEMBLY_AMD
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ShaderInfoTypeAMD value )
   {
     switch ( value )
@@ -6690,6 +7023,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
 #if defined( VK_USE_PLATFORM_GGP )
   //=== VK_GGP_stream_descriptor_surface ===
@@ -6698,10 +7032,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( StreamDescriptorSurfaceCreateFlagBitsGGP )
   {
     return "(void)";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_GGP*/
 
   //=== VK_NV_external_memory_capabilities ===
@@ -6714,6 +7050,7 @@ namespace VULKAN_HPP_NAMESPACE
     eD3D11ImageKmt  = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_IMAGE_KMT_BIT_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ExternalMemoryHandleTypeFlagBitsNV value )
   {
     switch ( value )
@@ -6725,6 +7062,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ExternalMemoryFeatureFlagBitsNV : VkExternalMemoryFeatureFlagsNV
   {
@@ -6733,6 +7071,7 @@ namespace VULKAN_HPP_NAMESPACE
     eImportable    = VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ExternalMemoryFeatureFlagBitsNV value )
   {
     switch ( value )
@@ -6743,6 +7082,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_EXT_validation_flags ===
 
@@ -6752,6 +7092,7 @@ namespace VULKAN_HPP_NAMESPACE
     eShaders = VK_VALIDATION_CHECK_SHADERS_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ValidationCheckEXT value )
   {
     switch ( value )
@@ -6761,6 +7102,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
 #if defined( VK_USE_PLATFORM_VI_NN )
   //=== VK_NN_vi_surface ===
@@ -6769,10 +7111,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ViSurfaceCreateFlagBitsNN )
   {
     return "(void)";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_VI_NN*/
 
   //=== VK_EXT_pipeline_robustness ===
@@ -6785,6 +7129,7 @@ namespace VULKAN_HPP_NAMESPACE
     eRobustBufferAccess2 = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineRobustnessBufferBehaviorEXT value )
   {
     switch ( value )
@@ -6796,6 +7141,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PipelineRobustnessImageBehaviorEXT
   {
@@ -6805,6 +7151,7 @@ namespace VULKAN_HPP_NAMESPACE
     eRobustImageAccess2 = VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineRobustnessImageBehaviorEXT value )
   {
     switch ( value )
@@ -6816,6 +7163,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_EXT_conditional_rendering ===
 
@@ -6824,6 +7172,7 @@ namespace VULKAN_HPP_NAMESPACE
     eInverted = VK_CONDITIONAL_RENDERING_INVERTED_BIT_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ConditionalRenderingFlagBitsEXT value )
   {
     switch ( value )
@@ -6832,6 +7181,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_EXT_display_surface_counter ===
 
@@ -6840,6 +7190,7 @@ namespace VULKAN_HPP_NAMESPACE
     eVblank = VK_SURFACE_COUNTER_VBLANK_BIT_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SurfaceCounterFlagBitsEXT value )
   {
     switch ( value )
@@ -6848,6 +7199,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_EXT_display_control ===
 
@@ -6858,6 +7210,7 @@ namespace VULKAN_HPP_NAMESPACE
     eOn      = VK_DISPLAY_POWER_STATE_ON_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DisplayPowerStateEXT value )
   {
     switch ( value )
@@ -6868,12 +7221,14 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DeviceEventTypeEXT
   {
     eDisplayHotplug = VK_DEVICE_EVENT_TYPE_DISPLAY_HOTPLUG_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DeviceEventTypeEXT value )
   {
     switch ( value )
@@ -6882,12 +7237,14 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DisplayEventTypeEXT
   {
     eFirstPixelOut = VK_DISPLAY_EVENT_TYPE_FIRST_PIXEL_OUT_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DisplayEventTypeEXT value )
   {
     switch ( value )
@@ -6896,6 +7253,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_NV_viewport_swizzle ===
 
@@ -6911,6 +7269,7 @@ namespace VULKAN_HPP_NAMESPACE
     eNegativeW = VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_W_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ViewportCoordinateSwizzleNV value )
   {
     switch ( value )
@@ -6926,15 +7285,18 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PipelineViewportSwizzleStateCreateFlagBitsNV : VkPipelineViewportSwizzleStateCreateFlagsNV
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineViewportSwizzleStateCreateFlagBitsNV )
   {
     return "(void)";
   }
+#endif
 
   //=== VK_EXT_discard_rectangles ===
 
@@ -6944,6 +7306,7 @@ namespace VULKAN_HPP_NAMESPACE
     eExclusive = VK_DISCARD_RECTANGLE_MODE_EXCLUSIVE_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DiscardRectangleModeEXT value )
   {
     switch ( value )
@@ -6953,15 +7316,18 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PipelineDiscardRectangleStateCreateFlagBitsEXT : VkPipelineDiscardRectangleStateCreateFlagsEXT
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineDiscardRectangleStateCreateFlagBitsEXT )
   {
     return "(void)";
   }
+#endif
 
   //=== VK_EXT_conservative_rasterization ===
 
@@ -6972,6 +7338,7 @@ namespace VULKAN_HPP_NAMESPACE
     eUnderestimate = VK_CONSERVATIVE_RASTERIZATION_MODE_UNDERESTIMATE_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ConservativeRasterizationModeEXT value )
   {
     switch ( value )
@@ -6982,15 +7349,18 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PipelineRasterizationConservativeStateCreateFlagBitsEXT : VkPipelineRasterizationConservativeStateCreateFlagsEXT
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineRasterizationConservativeStateCreateFlagBitsEXT )
   {
     return "(void)";
   }
+#endif
 
   //=== VK_EXT_depth_clip_enable ===
 
@@ -6998,10 +7368,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineRasterizationDepthClipStateCreateFlagBitsEXT )
   {
     return "(void)";
   }
+#endif
 
   //=== VK_KHR_performance_query ===
 
@@ -7011,6 +7383,7 @@ namespace VULKAN_HPP_NAMESPACE
     eConcurrentlyImpacted = VK_PERFORMANCE_COUNTER_DESCRIPTION_CONCURRENTLY_IMPACTED_BIT_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PerformanceCounterDescriptionFlagBitsKHR value )
   {
     switch ( value )
@@ -7020,6 +7393,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PerformanceCounterScopeKHR
   {
@@ -7031,6 +7405,7 @@ namespace VULKAN_HPP_NAMESPACE
     eVkQueryScopeRenderPass    = VK_QUERY_SCOPE_RENDER_PASS_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PerformanceCounterScopeKHR value )
   {
     switch ( value )
@@ -7041,6 +7416,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PerformanceCounterStorageKHR
   {
@@ -7052,6 +7428,7 @@ namespace VULKAN_HPP_NAMESPACE
     eFloat64 = VK_PERFORMANCE_COUNTER_STORAGE_FLOAT64_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PerformanceCounterStorageKHR value )
   {
     switch ( value )
@@ -7065,6 +7442,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PerformanceCounterUnitKHR
   {
@@ -7081,6 +7459,7 @@ namespace VULKAN_HPP_NAMESPACE
     eCycles         = VK_PERFORMANCE_COUNTER_UNIT_CYCLES_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PerformanceCounterUnitKHR value )
   {
     switch ( value )
@@ -7099,15 +7478,18 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class AcquireProfilingLockFlagBitsKHR : VkAcquireProfilingLockFlagsKHR
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AcquireProfilingLockFlagBitsKHR )
   {
     return "(void)";
   }
+#endif
 
 #if defined( VK_USE_PLATFORM_IOS_MVK )
   //=== VK_MVK_ios_surface ===
@@ -7116,10 +7498,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( IOSSurfaceCreateFlagBitsMVK )
   {
     return "(void)";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_IOS_MVK*/
 
 #if defined( VK_USE_PLATFORM_MACOS_MVK )
@@ -7129,10 +7513,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( MacOSSurfaceCreateFlagBitsMVK )
   {
     return "(void)";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_MACOS_MVK*/
 
   //=== VK_EXT_debug_utils ===
@@ -7145,6 +7531,7 @@ namespace VULKAN_HPP_NAMESPACE
     eError   = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DebugUtilsMessageSeverityFlagBitsEXT value )
   {
     switch ( value )
@@ -7156,6 +7543,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DebugUtilsMessageTypeFlagBitsEXT : VkDebugUtilsMessageTypeFlagsEXT
   {
@@ -7164,6 +7552,7 @@ namespace VULKAN_HPP_NAMESPACE
     ePerformance = VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DebugUtilsMessageTypeFlagBitsEXT value )
   {
     switch ( value )
@@ -7174,24 +7563,29 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DebugUtilsMessengerCallbackDataFlagBitsEXT : VkDebugUtilsMessengerCallbackDataFlagsEXT
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DebugUtilsMessengerCallbackDataFlagBitsEXT )
   {
     return "(void)";
   }
+#endif
 
   enum class DebugUtilsMessengerCreateFlagBitsEXT : VkDebugUtilsMessengerCreateFlagsEXT
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DebugUtilsMessengerCreateFlagBitsEXT )
   {
     return "(void)";
   }
+#endif
 
   //=== VK_EXT_blend_operation_advanced ===
 
@@ -7202,6 +7596,7 @@ namespace VULKAN_HPP_NAMESPACE
     eConjoint     = VK_BLEND_OVERLAP_CONJOINT_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( BlendOverlapEXT value )
   {
     switch ( value )
@@ -7212,6 +7607,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_NV_fragment_coverage_to_color ===
 
@@ -7219,10 +7615,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineCoverageToColorStateCreateFlagBitsNV )
   {
     return "(void)";
   }
+#endif
 
   //=== VK_KHR_acceleration_structure ===
 
@@ -7234,6 +7632,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using AccelerationStructureTypeNV = AccelerationStructureTypeKHR;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AccelerationStructureTypeKHR value )
   {
     switch ( value )
@@ -7244,6 +7643,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class AccelerationStructureBuildTypeKHR
   {
@@ -7252,6 +7652,7 @@ namespace VULKAN_HPP_NAMESPACE
     eHostOrDevice = VK_ACCELERATION_STRUCTURE_BUILD_TYPE_HOST_OR_DEVICE_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AccelerationStructureBuildTypeKHR value )
   {
     switch ( value )
@@ -7262,6 +7663,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class GeometryFlagBitsKHR : VkGeometryFlagsKHR
   {
@@ -7270,6 +7672,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using GeometryFlagBitsNV = GeometryFlagBitsKHR;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( GeometryFlagBitsKHR value )
   {
     switch ( value )
@@ -7279,6 +7682,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class GeometryInstanceFlagBitsKHR : VkGeometryInstanceFlagsKHR
   {
@@ -7292,6 +7696,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using GeometryInstanceFlagBitsNV = GeometryInstanceFlagBitsKHR;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( GeometryInstanceFlagBitsKHR value )
   {
     switch ( value )
@@ -7303,6 +7708,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class BuildAccelerationStructureFlagBitsKHR : VkBuildAccelerationStructureFlagsKHR
   {
@@ -7315,6 +7721,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using BuildAccelerationStructureFlagBitsNV = BuildAccelerationStructureFlagBitsKHR;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( BuildAccelerationStructureFlagBitsKHR value )
   {
     switch ( value )
@@ -7328,6 +7735,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class CopyAccelerationStructureModeKHR
   {
@@ -7338,6 +7746,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using CopyAccelerationStructureModeNV = CopyAccelerationStructureModeKHR;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CopyAccelerationStructureModeKHR value )
   {
     switch ( value )
@@ -7349,6 +7758,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class GeometryTypeKHR
   {
@@ -7358,6 +7768,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using GeometryTypeNV = GeometryTypeKHR;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( GeometryTypeKHR value )
   {
     switch ( value )
@@ -7368,6 +7779,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class AccelerationStructureCompatibilityKHR
   {
@@ -7375,6 +7787,7 @@ namespace VULKAN_HPP_NAMESPACE
     eIncompatible = VK_ACCELERATION_STRUCTURE_COMPATIBILITY_INCOMPATIBLE_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AccelerationStructureCompatibilityKHR value )
   {
     switch ( value )
@@ -7384,6 +7797,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class AccelerationStructureCreateFlagBitsKHR : VkAccelerationStructureCreateFlagsKHR
   {
@@ -7391,6 +7805,7 @@ namespace VULKAN_HPP_NAMESPACE
     eMotionNV                   = VK_ACCELERATION_STRUCTURE_CREATE_MOTION_BIT_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AccelerationStructureCreateFlagBitsKHR value )
   {
     switch ( value )
@@ -7400,6 +7815,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class BuildAccelerationStructureModeKHR
   {
@@ -7407,6 +7823,7 @@ namespace VULKAN_HPP_NAMESPACE
     eUpdate = VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( BuildAccelerationStructureModeKHR value )
   {
     switch ( value )
@@ -7416,6 +7833,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_NV_framebuffer_mixed_samples ===
 
@@ -7427,6 +7845,7 @@ namespace VULKAN_HPP_NAMESPACE
     eRgba  = VK_COVERAGE_MODULATION_MODE_RGBA_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CoverageModulationModeNV value )
   {
     switch ( value )
@@ -7438,15 +7857,18 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PipelineCoverageModulationStateCreateFlagBitsNV : VkPipelineCoverageModulationStateCreateFlagsNV
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineCoverageModulationStateCreateFlagBitsNV )
   {
     return "(void)";
   }
+#endif
 
   //=== VK_EXT_validation_cache ===
 
@@ -7455,6 +7877,7 @@ namespace VULKAN_HPP_NAMESPACE
     eOne = VK_VALIDATION_CACHE_HEADER_VERSION_ONE_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ValidationCacheHeaderVersionEXT value )
   {
     switch ( value )
@@ -7463,15 +7886,18 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ValidationCacheCreateFlagBitsEXT : VkValidationCacheCreateFlagsEXT
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ValidationCacheCreateFlagBitsEXT )
   {
     return "(void)";
   }
+#endif
 
   //=== VK_NV_shading_rate_image ===
 
@@ -7491,6 +7917,7 @@ namespace VULKAN_HPP_NAMESPACE
     e1InvocationPer4X4Pixels = VK_SHADING_RATE_PALETTE_ENTRY_1_INVOCATION_PER_4X4_PIXELS_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ShadingRatePaletteEntryNV value )
   {
     switch ( value )
@@ -7510,6 +7937,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class CoarseSampleOrderTypeNV
   {
@@ -7519,6 +7947,7 @@ namespace VULKAN_HPP_NAMESPACE
     eSampleMajor = VK_COARSE_SAMPLE_ORDER_TYPE_SAMPLE_MAJOR_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CoarseSampleOrderTypeNV value )
   {
     switch ( value )
@@ -7530,6 +7959,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_NV_ray_tracing ===
 
@@ -7540,6 +7970,7 @@ namespace VULKAN_HPP_NAMESPACE
     eUpdateScratch = VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_UPDATE_SCRATCH_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AccelerationStructureMemoryRequirementsTypeNV value )
   {
     switch ( value )
@@ -7550,6 +7981,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_AMD_pipeline_compiler_control ===
 
@@ -7557,10 +7989,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineCompilerControlFlagBitsAMD )
   {
     return "(void)";
   }
+#endif
 
   //=== VK_EXT_calibrated_timestamps ===
 
@@ -7572,6 +8006,7 @@ namespace VULKAN_HPP_NAMESPACE
     eQueryPerformanceCounter = VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( TimeDomainEXT value )
   {
     switch ( value )
@@ -7583,6 +8018,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_KHR_global_priority ===
 
@@ -7595,6 +8031,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using QueueGlobalPriorityEXT = QueueGlobalPriorityKHR;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( QueueGlobalPriorityKHR value )
   {
     switch ( value )
@@ -7606,6 +8043,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_AMD_memory_overallocation_behavior ===
 
@@ -7616,6 +8054,7 @@ namespace VULKAN_HPP_NAMESPACE
     eDisallowed = VK_MEMORY_OVERALLOCATION_BEHAVIOR_DISALLOWED_AMD
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( MemoryOverallocationBehaviorAMD value )
   {
     switch ( value )
@@ -7626,6 +8065,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_INTEL_performance_query ===
 
@@ -7634,6 +8074,7 @@ namespace VULKAN_HPP_NAMESPACE
     eCommandQueueMetricsDiscoveryActivated = VK_PERFORMANCE_CONFIGURATION_TYPE_COMMAND_QUEUE_METRICS_DISCOVERY_ACTIVATED_INTEL
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PerformanceConfigurationTypeINTEL value )
   {
     switch ( value )
@@ -7642,12 +8083,14 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class QueryPoolSamplingModeINTEL
   {
     eManual = VK_QUERY_POOL_SAMPLING_MODE_MANUAL_INTEL
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( QueryPoolSamplingModeINTEL value )
   {
     switch ( value )
@@ -7656,6 +8099,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PerformanceOverrideTypeINTEL
   {
@@ -7663,6 +8107,7 @@ namespace VULKAN_HPP_NAMESPACE
     eFlushGpuCaches = VK_PERFORMANCE_OVERRIDE_TYPE_FLUSH_GPU_CACHES_INTEL
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PerformanceOverrideTypeINTEL value )
   {
     switch ( value )
@@ -7672,6 +8117,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PerformanceParameterTypeINTEL
   {
@@ -7679,6 +8125,7 @@ namespace VULKAN_HPP_NAMESPACE
     eStreamMarkerValidBits = VK_PERFORMANCE_PARAMETER_TYPE_STREAM_MARKER_VALID_BITS_INTEL
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PerformanceParameterTypeINTEL value )
   {
     switch ( value )
@@ -7688,6 +8135,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PerformanceValueTypeINTEL
   {
@@ -7698,6 +8146,7 @@ namespace VULKAN_HPP_NAMESPACE
     eString = VK_PERFORMANCE_VALUE_TYPE_STRING_INTEL
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PerformanceValueTypeINTEL value )
   {
     switch ( value )
@@ -7710,6 +8159,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
 #if defined( VK_USE_PLATFORM_FUCHSIA )
   //=== VK_FUCHSIA_imagepipe_surface ===
@@ -7718,10 +8168,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImagePipeSurfaceCreateFlagBitsFUCHSIA )
   {
     return "(void)";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_FUCHSIA*/
 
 #if defined( VK_USE_PLATFORM_METAL_EXT )
@@ -7731,10 +8183,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( MetalSurfaceCreateFlagBitsEXT )
   {
     return "(void)";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_METAL_EXT*/
 
   //=== VK_KHR_fragment_shading_rate ===
@@ -7748,6 +8202,7 @@ namespace VULKAN_HPP_NAMESPACE
     eMul     = VK_FRAGMENT_SHADING_RATE_COMBINER_OP_MUL_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( FragmentShadingRateCombinerOpKHR value )
   {
     switch ( value )
@@ -7760,6 +8215,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_AMD_shader_core_properties2 ===
 
@@ -7767,10 +8223,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ShaderCorePropertiesFlagBitsAMD )
   {
     return "(void)";
   }
+#endif
 
   //=== VK_EXT_validation_features ===
 
@@ -7783,6 +8241,7 @@ namespace VULKAN_HPP_NAMESPACE
     eSynchronizationValidation     = VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ValidationFeatureEnableEXT value )
   {
     switch ( value )
@@ -7795,6 +8254,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ValidationFeatureDisableEXT
   {
@@ -7808,6 +8268,7 @@ namespace VULKAN_HPP_NAMESPACE
     eShaderValidationCache = VK_VALIDATION_FEATURE_DISABLE_SHADER_VALIDATION_CACHE_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ValidationFeatureDisableEXT value )
   {
     switch ( value )
@@ -7823,6 +8284,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_NV_cooperative_matrix ===
 
@@ -7834,6 +8296,7 @@ namespace VULKAN_HPP_NAMESPACE
     eQueueFamily = VK_SCOPE_QUEUE_FAMILY_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ScopeNV value )
   {
     switch ( value )
@@ -7845,6 +8308,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ComponentTypeNV
   {
@@ -7861,6 +8325,7 @@ namespace VULKAN_HPP_NAMESPACE
     eUint64  = VK_COMPONENT_TYPE_UINT64_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ComponentTypeNV value )
   {
     switch ( value )
@@ -7879,6 +8344,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_NV_coverage_reduction_mode ===
 
@@ -7888,6 +8354,7 @@ namespace VULKAN_HPP_NAMESPACE
     eTruncate = VK_COVERAGE_REDUCTION_MODE_TRUNCATE_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CoverageReductionModeNV value )
   {
     switch ( value )
@@ -7897,15 +8364,18 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PipelineCoverageReductionStateCreateFlagBitsNV : VkPipelineCoverageReductionStateCreateFlagsNV
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineCoverageReductionStateCreateFlagBitsNV )
   {
     return "(void)";
   }
+#endif
 
   //=== VK_EXT_provoking_vertex ===
 
@@ -7915,6 +8385,7 @@ namespace VULKAN_HPP_NAMESPACE
     eLastVertex  = VK_PROVOKING_VERTEX_MODE_LAST_VERTEX_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ProvokingVertexModeEXT value )
   {
     switch ( value )
@@ -7924,6 +8395,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
 #if defined( VK_USE_PLATFORM_WIN32_KHR )
   //=== VK_EXT_full_screen_exclusive ===
@@ -7936,6 +8408,7 @@ namespace VULKAN_HPP_NAMESPACE
     eApplicationControlled = VK_FULL_SCREEN_EXCLUSIVE_APPLICATION_CONTROLLED_EXT
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( FullScreenExclusiveEXT value )
   {
     switch ( value )
@@ -7947,6 +8420,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 #endif /*VK_USE_PLATFORM_WIN32_KHR*/
 
   //=== VK_EXT_headless_surface ===
@@ -7955,10 +8429,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( HeadlessSurfaceCreateFlagBitsEXT )
   {
     return "(void)";
   }
+#endif
 
   //=== VK_EXT_line_rasterization ===
 
@@ -7970,6 +8446,7 @@ namespace VULKAN_HPP_NAMESPACE
     eRectangularSmooth = VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( LineRasterizationModeEXT value )
   {
     switch ( value )
@@ -7981,6 +8458,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_KHR_pipeline_executable_properties ===
 
@@ -7992,6 +8470,7 @@ namespace VULKAN_HPP_NAMESPACE
     eFloat64 = VK_PIPELINE_EXECUTABLE_STATISTIC_FORMAT_FLOAT64_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineExecutableStatisticFormatKHR value )
   {
     switch ( value )
@@ -8003,6 +8482,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_NV_device_generated_commands ===
 
@@ -8011,6 +8491,7 @@ namespace VULKAN_HPP_NAMESPACE
     eFlagFrontface = VK_INDIRECT_STATE_FLAG_FRONTFACE_BIT_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( IndirectStateFlagBitsNV value )
   {
     switch ( value )
@@ -8019,6 +8500,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class IndirectCommandsTokenTypeNV
   {
@@ -8032,6 +8514,7 @@ namespace VULKAN_HPP_NAMESPACE
     eDrawTasks    = VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_TASKS_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( IndirectCommandsTokenTypeNV value )
   {
     switch ( value )
@@ -8047,6 +8530,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class IndirectCommandsLayoutUsageFlagBitsNV : VkIndirectCommandsLayoutUsageFlagsNV
   {
@@ -8055,6 +8539,7 @@ namespace VULKAN_HPP_NAMESPACE
     eUnorderedSequences = VK_INDIRECT_COMMANDS_LAYOUT_USAGE_UNORDERED_SEQUENCES_BIT_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( IndirectCommandsLayoutUsageFlagBitsNV value )
   {
     switch ( value )
@@ -8065,6 +8550,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_EXT_device_memory_report ===
 
@@ -8077,6 +8563,7 @@ namespace VULKAN_HPP_NAMESPACE
     eAllocationFailed = VK_DEVICE_MEMORY_REPORT_EVENT_TYPE_ALLOCATION_FAILED_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DeviceMemoryReportEventTypeEXT value )
   {
     switch ( value )
@@ -8089,15 +8576,18 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class DeviceMemoryReportFlagBitsEXT : VkDeviceMemoryReportFlagsEXT
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DeviceMemoryReportFlagBitsEXT )
   {
     return "(void)";
   }
+#endif
 
   //=== VK_EXT_pipeline_creation_cache_control ===
 
@@ -8107,6 +8597,7 @@ namespace VULKAN_HPP_NAMESPACE
     eExternallySynchronizedEXT = VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineCacheCreateFlagBits value )
   {
     switch ( value )
@@ -8115,6 +8606,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
   //=== VK_KHR_video_encode_queue ===
@@ -8125,6 +8617,7 @@ namespace VULKAN_HPP_NAMESPACE
     eReserved0 = VK_VIDEO_ENCODE_RESERVED_0_BIT_KHR
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeFlagBitsKHR value )
   {
     switch ( value )
@@ -8134,6 +8627,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoEncodeCapabilityFlagBitsKHR : VkVideoEncodeCapabilityFlagsKHR
   {
@@ -8141,6 +8635,7 @@ namespace VULKAN_HPP_NAMESPACE
     ePrecedingExternallyEncodedBytes = VK_VIDEO_ENCODE_CAPABILITY_PRECEDING_EXTERNALLY_ENCODED_BYTES_BIT_KHR
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeCapabilityFlagBitsKHR value )
   {
     switch ( value )
@@ -8150,6 +8645,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoEncodeRateControlFlagBitsKHR : VkVideoEncodeRateControlFlagsKHR
   {
@@ -8157,6 +8653,7 @@ namespace VULKAN_HPP_NAMESPACE
     eReserved0 = VK_VIDEO_ENCODE_RATE_CONTROL_RESERVED_0_BIT_KHR
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeRateControlFlagBitsKHR value )
   {
     switch ( value )
@@ -8166,6 +8663,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class VideoEncodeRateControlModeFlagBitsKHR : VkVideoEncodeRateControlModeFlagsKHR
   {
@@ -8174,6 +8672,7 @@ namespace VULKAN_HPP_NAMESPACE
     eVbr  = VK_VIDEO_ENCODE_RATE_CONTROL_MODE_VBR_BIT_KHR
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeRateControlModeFlagBitsKHR value )
   {
     switch ( value )
@@ -8184,6 +8683,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
   //=== VK_NV_device_diagnostics_config ===
@@ -8196,6 +8696,7 @@ namespace VULKAN_HPP_NAMESPACE
     eEnableShaderErrorReporting = VK_DEVICE_DIAGNOSTICS_CONFIG_ENABLE_SHADER_ERROR_REPORTING_BIT_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DeviceDiagnosticsConfigFlagBitsNV value )
   {
     switch ( value )
@@ -8207,6 +8708,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
 #if defined( VK_USE_PLATFORM_METAL_EXT )
   //=== VK_EXT_metal_objects ===
@@ -8221,6 +8723,7 @@ namespace VULKAN_HPP_NAMESPACE
     eMetalSharedEvent  = VK_EXPORT_METAL_OBJECT_TYPE_METAL_SHARED_EVENT_BIT_EXT
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ExportMetalObjectTypeFlagBitsEXT value )
   {
     switch ( value )
@@ -8234,6 +8737,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 #endif /*VK_USE_PLATFORM_METAL_EXT*/
 
   //=== VK_EXT_graphics_pipeline_library ===
@@ -8246,6 +8750,7 @@ namespace VULKAN_HPP_NAMESPACE
     eFragmentOutputInterface = VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_OUTPUT_INTERFACE_BIT_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( GraphicsPipelineLibraryFlagBitsEXT value )
   {
     switch ( value )
@@ -8257,12 +8762,14 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PipelineLayoutCreateFlagBits : VkPipelineLayoutCreateFlags
   {
     eIndependentSetsEXT = VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineLayoutCreateFlagBits value )
   {
     switch ( value )
@@ -8271,6 +8778,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_NV_fragment_shading_rate_enums ===
 
@@ -8290,6 +8798,7 @@ namespace VULKAN_HPP_NAMESPACE
     eNoInvocations           = VK_FRAGMENT_SHADING_RATE_NO_INVOCATIONS_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( FragmentShadingRateNV value )
   {
     switch ( value )
@@ -8309,6 +8818,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class FragmentShadingRateTypeNV
   {
@@ -8316,6 +8826,7 @@ namespace VULKAN_HPP_NAMESPACE
     eEnums        = VK_FRAGMENT_SHADING_RATE_TYPE_ENUMS_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( FragmentShadingRateTypeNV value )
   {
     switch ( value )
@@ -8325,6 +8836,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_NV_ray_tracing_motion_blur ===
 
@@ -8335,6 +8847,7 @@ namespace VULKAN_HPP_NAMESPACE
     eSrtMotion    = VK_ACCELERATION_STRUCTURE_MOTION_INSTANCE_TYPE_SRT_MOTION_NV
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AccelerationStructureMotionInstanceTypeNV value )
   {
     switch ( value )
@@ -8345,24 +8858,29 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class AccelerationStructureMotionInfoFlagBitsNV : VkAccelerationStructureMotionInfoFlagsNV
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AccelerationStructureMotionInfoFlagBitsNV )
   {
     return "(void)";
   }
+#endif
 
   enum class AccelerationStructureMotionInstanceFlagBitsNV : VkAccelerationStructureMotionInstanceFlagsNV
   {
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AccelerationStructureMotionInstanceFlagBitsNV )
   {
     return "(void)";
   }
+#endif
 
   //=== VK_EXT_image_compression_control ===
 
@@ -8374,6 +8892,7 @@ namespace VULKAN_HPP_NAMESPACE
     eDisabled          = VK_IMAGE_COMPRESSION_DISABLED_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageCompressionFlagBitsEXT value )
   {
     switch ( value )
@@ -8385,6 +8904,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ImageCompressionFixedRateFlagBitsEXT : VkImageCompressionFixedRateFlagsEXT
   {
@@ -8415,6 +8935,7 @@ namespace VULKAN_HPP_NAMESPACE
     e24Bpc = VK_IMAGE_COMPRESSION_FIXED_RATE_24BPC_BIT_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageCompressionFixedRateFlagBitsEXT value )
   {
     switch ( value )
@@ -8447,6 +8968,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   //=== VK_ARM_rasterization_order_attachment_access ===
 
@@ -8455,6 +8977,7 @@ namespace VULKAN_HPP_NAMESPACE
     eRasterizationOrderAttachmentAccessARM = VK_PIPELINE_COLOR_BLEND_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_BIT_ARM
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineColorBlendStateCreateFlagBits value )
   {
     switch ( value )
@@ -8463,6 +8986,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class PipelineDepthStencilStateCreateFlagBits : VkPipelineDepthStencilStateCreateFlags
   {
@@ -8470,6 +8994,7 @@ namespace VULKAN_HPP_NAMESPACE
     eRasterizationOrderAttachmentStencilAccessARM = VK_PIPELINE_DEPTH_STENCIL_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_STENCIL_ACCESS_BIT_ARM
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineDepthStencilStateCreateFlagBits value )
   {
     switch ( value )
@@ -8479,6 +9004,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
 #if defined( VK_USE_PLATFORM_DIRECTFB_EXT )
   //=== VK_EXT_directfb_surface ===
@@ -8487,10 +9013,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DirectFBSurfaceCreateFlagBitsEXT )
   {
     return "(void)";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_DIRECTFB_EXT*/
 
   //=== VK_KHR_ray_tracing_pipeline ===
@@ -8503,6 +9031,7 @@ namespace VULKAN_HPP_NAMESPACE
   };
   using RayTracingShaderGroupTypeNV = RayTracingShaderGroupTypeKHR;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( RayTracingShaderGroupTypeKHR value )
   {
     switch ( value )
@@ -8513,6 +9042,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   enum class ShaderGroupShaderKHR
   {
@@ -8522,6 +9052,7 @@ namespace VULKAN_HPP_NAMESPACE
     eIntersection = VK_SHADER_GROUP_SHADER_INTERSECTION_KHR
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ShaderGroupShaderKHR value )
   {
     switch ( value )
@@ -8533,6 +9064,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
 #if defined( VK_USE_PLATFORM_FUCHSIA )
   //=== VK_FUCHSIA_buffer_collection ===
@@ -8546,6 +9078,7 @@ namespace VULKAN_HPP_NAMESPACE
     eProtectedOptional = VK_IMAGE_CONSTRAINTS_INFO_PROTECTED_OPTIONAL_FUCHSIA
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageConstraintsInfoFlagBitsFUCHSIA value )
   {
     switch ( value )
@@ -8558,15 +9091,18 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#  endif
 
   enum class ImageFormatConstraintsFlagBitsFUCHSIA : VkImageFormatConstraintsFlagsFUCHSIA
   {
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageFormatConstraintsFlagBitsFUCHSIA )
   {
     return "(void)";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_FUCHSIA*/
 
 #if defined( VK_USE_PLATFORM_SCREEN_QNX )
@@ -8576,10 +9112,12 @@ namespace VULKAN_HPP_NAMESPACE
   {
   };
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ScreenSurfaceCreateFlagBitsQNX )
   {
     return "(void)";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_SCREEN_QNX*/
 
   //=== VK_EXT_subpass_merge_feedback ===
@@ -8602,6 +9140,7 @@ namespace VULKAN_HPP_NAMESPACE
     eNotMergedUnspecified                 = VK_SUBPASS_MERGE_STATUS_NOT_MERGED_UNSPECIFIED_EXT
   };
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SubpassMergeStatusEXT value )
   {
     switch ( value )
@@ -8623,6 +9162,7 @@ namespace VULKAN_HPP_NAMESPACE
       default: return "invalid ( " + VULKAN_HPP_NAMESPACE::toHexString( static_cast<uint32_t>( value ) ) + " )";
     }
   }
+#endif
 
   template <typename T>
   struct IndexTypeValue
@@ -8722,6 +9262,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( FormatFeatureFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( FormatFeatureFlags value )
   {
     if ( !value )
@@ -8774,12 +9315,12 @@ namespace VULKAN_HPP_NAMESPACE
       result += "CositedChromaSamples | ";
     if ( value & FormatFeatureFlagBits::eSampledImageFilterMinmax )
       result += "SampledImageFilterMinmax | ";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
     if ( value & FormatFeatureFlagBits::eVideoDecodeOutputKHR )
       result += "VideoDecodeOutputKHR | ";
     if ( value & FormatFeatureFlagBits::eVideoDecodeDpbKHR )
       result += "VideoDecodeDpbKHR | ";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
     if ( value & FormatFeatureFlagBits::eAccelerationStructureVertexBufferKHR )
       result += "AccelerationStructureVertexBufferKHR | ";
     if ( value & FormatFeatureFlagBits::eSampledImageFilterCubicEXT )
@@ -8788,15 +9329,16 @@ namespace VULKAN_HPP_NAMESPACE
       result += "FragmentDensityMapEXT | ";
     if ( value & FormatFeatureFlagBits::eFragmentShadingRateAttachmentKHR )
       result += "FragmentShadingRateAttachmentKHR | ";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
     if ( value & FormatFeatureFlagBits::eVideoEncodeInputKHR )
       result += "VideoEncodeInputKHR | ";
     if ( value & FormatFeatureFlagBits::eVideoEncodeDpbKHR )
       result += "VideoEncodeDpbKHR | ";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using ImageCreateFlags = Flags<ImageCreateFlagBits>;
 
@@ -8837,6 +9379,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( ImageCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageCreateFlags value )
   {
     if ( !value )
@@ -8882,6 +9425,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using ImageUsageFlags = Flags<ImageUsageFlagBits>;
 
@@ -8895,15 +9439,15 @@ namespace VULKAN_HPP_NAMESPACE
                  VkFlags( ImageUsageFlagBits::eDepthStencilAttachment ) | VkFlags( ImageUsageFlagBits::eTransientAttachment ) |
                  VkFlags( ImageUsageFlagBits::eInputAttachment )
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
-                 | VkFlags( ImageUsageFlagBits::eVideoDecodeDstKHR ) | VkFlags( ImageUsageFlagBits::eVideoDecodeSrcKHR ) |
+               | VkFlags( ImageUsageFlagBits::eVideoDecodeDstKHR ) | VkFlags( ImageUsageFlagBits::eVideoDecodeSrcKHR ) |
                  VkFlags( ImageUsageFlagBits::eVideoDecodeDpbKHR )
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
-                 | VkFlags( ImageUsageFlagBits::eFragmentDensityMapEXT ) | VkFlags( ImageUsageFlagBits::eFragmentShadingRateAttachmentKHR )
+               | VkFlags( ImageUsageFlagBits::eFragmentDensityMapEXT ) | VkFlags( ImageUsageFlagBits::eFragmentShadingRateAttachmentKHR )
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
-                 | VkFlags( ImageUsageFlagBits::eVideoEncodeDstKHR ) | VkFlags( ImageUsageFlagBits::eVideoEncodeSrcKHR ) |
+               | VkFlags( ImageUsageFlagBits::eVideoEncodeDstKHR ) | VkFlags( ImageUsageFlagBits::eVideoEncodeSrcKHR ) |
                  VkFlags( ImageUsageFlagBits::eVideoEncodeDpbKHR )
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
-                 | VkFlags( ImageUsageFlagBits::eInvocationMaskHUAWEI ) | VkFlags( ImageUsageFlagBits::eSampleWeightQCOM ) |
+               | VkFlags( ImageUsageFlagBits::eInvocationMaskHUAWEI ) | VkFlags( ImageUsageFlagBits::eSampleWeightQCOM ) |
                  VkFlags( ImageUsageFlagBits::eSampleBlockMatchQCOM )
     };
   };
@@ -8928,6 +9472,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( ImageUsageFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageUsageFlags value )
   {
     if ( !value )
@@ -8950,26 +9495,26 @@ namespace VULKAN_HPP_NAMESPACE
       result += "TransientAttachment | ";
     if ( value & ImageUsageFlagBits::eInputAttachment )
       result += "InputAttachment | ";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
     if ( value & ImageUsageFlagBits::eVideoDecodeDstKHR )
       result += "VideoDecodeDstKHR | ";
     if ( value & ImageUsageFlagBits::eVideoDecodeSrcKHR )
       result += "VideoDecodeSrcKHR | ";
     if ( value & ImageUsageFlagBits::eVideoDecodeDpbKHR )
       result += "VideoDecodeDpbKHR | ";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
     if ( value & ImageUsageFlagBits::eFragmentDensityMapEXT )
       result += "FragmentDensityMapEXT | ";
     if ( value & ImageUsageFlagBits::eFragmentShadingRateAttachmentKHR )
       result += "FragmentShadingRateAttachmentKHR | ";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
     if ( value & ImageUsageFlagBits::eVideoEncodeDstKHR )
       result += "VideoEncodeDstKHR | ";
     if ( value & ImageUsageFlagBits::eVideoEncodeSrcKHR )
       result += "VideoEncodeSrcKHR | ";
     if ( value & ImageUsageFlagBits::eVideoEncodeDpbKHR )
       result += "VideoEncodeDpbKHR | ";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
     if ( value & ImageUsageFlagBits::eInvocationMaskHUAWEI )
       result += "InvocationMaskHUAWEI | ";
     if ( value & ImageUsageFlagBits::eSampleWeightQCOM )
@@ -8979,6 +9524,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using InstanceCreateFlags = Flags<InstanceCreateFlagBits>;
 
@@ -9011,6 +9557,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( InstanceCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( InstanceCreateFlags value )
   {
     if ( !value )
@@ -9022,6 +9569,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using MemoryHeapFlags = Flags<MemoryHeapFlagBits>;
 
@@ -9054,6 +9602,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( MemoryHeapFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( MemoryHeapFlags value )
   {
     if ( !value )
@@ -9067,6 +9616,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using MemoryPropertyFlags = Flags<MemoryPropertyFlagBits>;
 
@@ -9103,6 +9653,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( MemoryPropertyFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( MemoryPropertyFlags value )
   {
     if ( !value )
@@ -9130,6 +9681,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using QueueFlags = Flags<QueueFlagBits>;
 
@@ -9141,7 +9693,7 @@ namespace VULKAN_HPP_NAMESPACE
       allFlags = VkFlags( QueueFlagBits::eGraphics ) | VkFlags( QueueFlagBits::eCompute ) | VkFlags( QueueFlagBits::eTransfer ) |
                  VkFlags( QueueFlagBits::eSparseBinding ) | VkFlags( QueueFlagBits::eProtected )
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
-                 | VkFlags( QueueFlagBits::eVideoDecodeKHR ) | VkFlags( QueueFlagBits::eVideoEncodeKHR )
+               | VkFlags( QueueFlagBits::eVideoDecodeKHR ) | VkFlags( QueueFlagBits::eVideoEncodeKHR )
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
     };
   };
@@ -9166,6 +9718,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( QueueFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( QueueFlags value )
   {
     if ( !value )
@@ -9182,15 +9735,16 @@ namespace VULKAN_HPP_NAMESPACE
       result += "SparseBinding | ";
     if ( value & QueueFlagBits::eProtected )
       result += "Protected | ";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
     if ( value & QueueFlagBits::eVideoDecodeKHR )
       result += "VideoDecodeKHR | ";
     if ( value & QueueFlagBits::eVideoEncodeKHR )
       result += "VideoEncodeKHR | ";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using SampleCountFlags = Flags<SampleCountFlagBits>;
 
@@ -9225,6 +9779,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( SampleCountFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SampleCountFlags value )
   {
     if ( !value )
@@ -9248,13 +9803,16 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using DeviceCreateFlags = Flags<DeviceCreateFlagBits>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DeviceCreateFlags )
   {
     return "{}";
   }
+#endif
 
   using DeviceQueueCreateFlags = Flags<DeviceQueueCreateFlagBits>;
 
@@ -9287,6 +9845,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( DeviceQueueCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DeviceQueueCreateFlags value )
   {
     if ( !value )
@@ -9298,6 +9857,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using PipelineStageFlags = Flags<PipelineStageFlagBits>;
 
@@ -9342,6 +9902,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( PipelineStageFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineStageFlags value )
   {
     if ( !value )
@@ -9403,13 +9964,16 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using MemoryMapFlags = Flags<MemoryMapFlagBits>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( MemoryMapFlags )
   {
     return "{}";
   }
+#endif
 
   using ImageAspectFlags = Flags<ImageAspectFlagBits>;
 
@@ -9446,6 +10010,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( ImageAspectFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageAspectFlags value )
   {
     if ( !value )
@@ -9477,6 +10042,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using SparseImageFormatFlags = Flags<SparseImageFormatFlagBits>;
 
@@ -9510,6 +10076,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( SparseImageFormatFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SparseImageFormatFlags value )
   {
     if ( !value )
@@ -9525,6 +10092,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using SparseMemoryBindFlags = Flags<SparseMemoryBindFlagBits>;
 
@@ -9557,6 +10125,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( SparseMemoryBindFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SparseMemoryBindFlags value )
   {
     if ( !value )
@@ -9568,6 +10137,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using FenceCreateFlags = Flags<FenceCreateFlagBits>;
 
@@ -9600,6 +10170,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( FenceCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( FenceCreateFlags value )
   {
     if ( !value )
@@ -9611,13 +10182,16 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using SemaphoreCreateFlags = Flags<SemaphoreCreateFlagBits>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SemaphoreCreateFlags )
   {
     return "{}";
   }
+#endif
 
   using EventCreateFlags = Flags<EventCreateFlagBits>;
 
@@ -9650,6 +10224,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( EventCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( EventCreateFlags value )
   {
     if ( !value )
@@ -9661,6 +10236,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using QueryPipelineStatisticFlags = Flags<QueryPipelineStatisticFlagBits>;
 
@@ -9702,6 +10278,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( QueryPipelineStatisticFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( QueryPipelineStatisticFlags value )
   {
     if ( !value )
@@ -9733,13 +10310,16 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using QueryPoolCreateFlags = Flags<QueryPoolCreateFlagBits>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( QueryPoolCreateFlags )
   {
     return "{}";
   }
+#endif
 
   using QueryResultFlags = Flags<QueryResultFlagBits>;
 
@@ -9751,7 +10331,7 @@ namespace VULKAN_HPP_NAMESPACE
       allFlags = VkFlags( QueryResultFlagBits::e64 ) | VkFlags( QueryResultFlagBits::eWait ) | VkFlags( QueryResultFlagBits::eWithAvailability ) |
                  VkFlags( QueryResultFlagBits::ePartial )
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
-                 | VkFlags( QueryResultFlagBits::eWithStatusKHR )
+               | VkFlags( QueryResultFlagBits::eWithStatusKHR )
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
     };
   };
@@ -9776,6 +10356,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( QueryResultFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( QueryResultFlags value )
   {
     if ( !value )
@@ -9790,13 +10371,14 @@ namespace VULKAN_HPP_NAMESPACE
       result += "WithAvailability | ";
     if ( value & QueryResultFlagBits::ePartial )
       result += "Partial | ";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
     if ( value & QueryResultFlagBits::eWithStatusKHR )
       result += "WithStatusKHR | ";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using BufferCreateFlags = Flags<BufferCreateFlagBits>;
 
@@ -9831,6 +10413,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( BufferCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( BufferCreateFlags value )
   {
     if ( !value )
@@ -9850,6 +10433,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using BufferUsageFlags = Flags<BufferUsageFlagBits>;
 
@@ -9864,13 +10448,13 @@ namespace VULKAN_HPP_NAMESPACE
                  VkFlags( BufferUsageFlagBits::eIndexBuffer ) | VkFlags( BufferUsageFlagBits::eVertexBuffer ) |
                  VkFlags( BufferUsageFlagBits::eIndirectBuffer ) | VkFlags( BufferUsageFlagBits::eShaderDeviceAddress )
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
-                 | VkFlags( BufferUsageFlagBits::eVideoDecodeSrcKHR ) | VkFlags( BufferUsageFlagBits::eVideoDecodeDstKHR )
+               | VkFlags( BufferUsageFlagBits::eVideoDecodeSrcKHR ) | VkFlags( BufferUsageFlagBits::eVideoDecodeDstKHR )
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
-                 | VkFlags( BufferUsageFlagBits::eTransformFeedbackBufferEXT ) | VkFlags( BufferUsageFlagBits::eTransformFeedbackCounterBufferEXT ) |
+               | VkFlags( BufferUsageFlagBits::eTransformFeedbackBufferEXT ) | VkFlags( BufferUsageFlagBits::eTransformFeedbackCounterBufferEXT ) |
                  VkFlags( BufferUsageFlagBits::eConditionalRenderingEXT ) | VkFlags( BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR ) |
                  VkFlags( BufferUsageFlagBits::eAccelerationStructureStorageKHR ) | VkFlags( BufferUsageFlagBits::eShaderBindingTableKHR )
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
-                 | VkFlags( BufferUsageFlagBits::eVideoEncodeDstKHR ) | VkFlags( BufferUsageFlagBits::eVideoEncodeSrcKHR )
+               | VkFlags( BufferUsageFlagBits::eVideoEncodeDstKHR ) | VkFlags( BufferUsageFlagBits::eVideoEncodeSrcKHR )
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
     };
   };
@@ -9895,6 +10479,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( BufferUsageFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( BufferUsageFlags value )
   {
     if ( !value )
@@ -9921,12 +10506,12 @@ namespace VULKAN_HPP_NAMESPACE
       result += "IndirectBuffer | ";
     if ( value & BufferUsageFlagBits::eShaderDeviceAddress )
       result += "ShaderDeviceAddress | ";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
     if ( value & BufferUsageFlagBits::eVideoDecodeSrcKHR )
       result += "VideoDecodeSrcKHR | ";
     if ( value & BufferUsageFlagBits::eVideoDecodeDstKHR )
       result += "VideoDecodeDstKHR | ";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
     if ( value & BufferUsageFlagBits::eTransformFeedbackBufferEXT )
       result += "TransformFeedbackBufferEXT | ";
     if ( value & BufferUsageFlagBits::eTransformFeedbackCounterBufferEXT )
@@ -9939,22 +10524,25 @@ namespace VULKAN_HPP_NAMESPACE
       result += "AccelerationStructureStorageKHR | ";
     if ( value & BufferUsageFlagBits::eShaderBindingTableKHR )
       result += "ShaderBindingTableKHR | ";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
     if ( value & BufferUsageFlagBits::eVideoEncodeDstKHR )
       result += "VideoEncodeDstKHR | ";
     if ( value & BufferUsageFlagBits::eVideoEncodeSrcKHR )
       result += "VideoEncodeSrcKHR | ";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using BufferViewCreateFlags = Flags<BufferViewCreateFlagBits>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( BufferViewCreateFlags )
   {
     return "{}";
   }
+#endif
 
   using ImageViewCreateFlags = Flags<ImageViewCreateFlagBits>;
 
@@ -9987,6 +10575,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( ImageViewCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageViewCreateFlags value )
   {
     if ( !value )
@@ -10000,13 +10589,16 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using ShaderModuleCreateFlags = Flags<ShaderModuleCreateFlagBits>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ShaderModuleCreateFlags )
   {
     return "{}";
   }
+#endif
 
   using PipelineCacheCreateFlags = Flags<PipelineCacheCreateFlagBits>;
 
@@ -10042,6 +10634,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( PipelineCacheCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineCacheCreateFlags value )
   {
     if ( !value )
@@ -10053,6 +10646,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using ColorComponentFlags = Flags<ColorComponentFlagBits>;
 
@@ -10086,6 +10680,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( ColorComponentFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ColorComponentFlags value )
   {
     if ( !value )
@@ -10103,6 +10698,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using CullModeFlags = Flags<CullModeFlagBits>;
 
@@ -10136,6 +10732,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( CullModeFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CullModeFlags value )
   {
     if ( !value )
@@ -10149,6 +10746,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using PipelineColorBlendStateCreateFlags = Flags<PipelineColorBlendStateCreateFlagBits>;
 
@@ -10184,6 +10782,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( PipelineColorBlendStateCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineColorBlendStateCreateFlags value )
   {
     if ( !value )
@@ -10195,6 +10794,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using PipelineCreateFlags = Flags<PipelineCreateFlagBits>;
 
@@ -10239,6 +10839,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( PipelineCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineCreateFlags value )
   {
     if ( !value )
@@ -10296,6 +10897,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using PipelineDepthStencilStateCreateFlags = Flags<PipelineDepthStencilStateCreateFlagBits>;
 
@@ -10332,6 +10934,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( PipelineDepthStencilStateCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineDepthStencilStateCreateFlags value )
   {
     if ( !value )
@@ -10345,20 +10948,25 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using PipelineDynamicStateCreateFlags = Flags<PipelineDynamicStateCreateFlagBits>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineDynamicStateCreateFlags )
   {
     return "{}";
   }
+#endif
 
   using PipelineInputAssemblyStateCreateFlags = Flags<PipelineInputAssemblyStateCreateFlagBits>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineInputAssemblyStateCreateFlags )
   {
     return "{}";
   }
+#endif
 
   using PipelineLayoutCreateFlags = Flags<PipelineLayoutCreateFlagBits>;
 
@@ -10394,6 +11002,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( PipelineLayoutCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineLayoutCreateFlags value )
   {
     if ( !value )
@@ -10405,20 +11014,25 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using PipelineMultisampleStateCreateFlags = Flags<PipelineMultisampleStateCreateFlagBits>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineMultisampleStateCreateFlags )
   {
     return "{}";
   }
+#endif
 
   using PipelineRasterizationStateCreateFlags = Flags<PipelineRasterizationStateCreateFlagBits>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineRasterizationStateCreateFlags )
   {
     return "{}";
   }
+#endif
 
   using PipelineShaderStageCreateFlags = Flags<PipelineShaderStageCreateFlagBits>;
 
@@ -10454,6 +11068,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( PipelineShaderStageCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineShaderStageCreateFlags value )
   {
     if ( !value )
@@ -10467,27 +11082,34 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using PipelineTessellationStateCreateFlags = Flags<PipelineTessellationStateCreateFlagBits>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineTessellationStateCreateFlags )
   {
     return "{}";
   }
+#endif
 
   using PipelineVertexInputStateCreateFlags = Flags<PipelineVertexInputStateCreateFlagBits>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineVertexInputStateCreateFlags )
   {
     return "{}";
   }
+#endif
 
   using PipelineViewportStateCreateFlags = Flags<PipelineViewportStateCreateFlagBits>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineViewportStateCreateFlags )
   {
     return "{}";
   }
+#endif
 
   using ShaderStageFlags = Flags<ShaderStageFlagBits>;
 
@@ -10526,6 +11148,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( ShaderStageFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ShaderStageFlags value )
   {
     if ( !value )
@@ -10565,6 +11188,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using SamplerCreateFlags = Flags<SamplerCreateFlagBits>;
 
@@ -10598,6 +11222,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( SamplerCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SamplerCreateFlags value )
   {
     if ( !value )
@@ -10615,6 +11240,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using DescriptorPoolCreateFlags = Flags<DescriptorPoolCreateFlagBits>;
 
@@ -10651,6 +11277,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( DescriptorPoolCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DescriptorPoolCreateFlags value )
   {
     if ( !value )
@@ -10666,13 +11293,16 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using DescriptorPoolResetFlags = Flags<DescriptorPoolResetFlagBits>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DescriptorPoolResetFlags )
   {
     return "{}";
   }
+#endif
 
   using DescriptorSetLayoutCreateFlags = Flags<DescriptorSetLayoutCreateFlagBits>;
 
@@ -10709,6 +11339,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( DescriptorSetLayoutCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DescriptorSetLayoutCreateFlags value )
   {
     if ( !value )
@@ -10724,6 +11355,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using AccessFlags = Flags<AccessFlagBits>;
 
@@ -10767,6 +11399,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( AccessFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AccessFlags value )
   {
     if ( !value )
@@ -10832,6 +11465,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using AttachmentDescriptionFlags = Flags<AttachmentDescriptionFlagBits>;
 
@@ -10867,6 +11501,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( AttachmentDescriptionFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AttachmentDescriptionFlags value )
   {
     if ( !value )
@@ -10878,6 +11513,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using DependencyFlags = Flags<DependencyFlagBits>;
 
@@ -10910,6 +11546,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( DependencyFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DependencyFlags value )
   {
     if ( !value )
@@ -10925,6 +11562,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using FramebufferCreateFlags = Flags<FramebufferCreateFlagBits>;
 
@@ -10957,6 +11595,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( FramebufferCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( FramebufferCreateFlags value )
   {
     if ( !value )
@@ -10968,6 +11607,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using RenderPassCreateFlags = Flags<RenderPassCreateFlagBits>;
 
@@ -11000,6 +11640,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( RenderPassCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( RenderPassCreateFlags value )
   {
     if ( !value )
@@ -11011,6 +11652,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using SubpassDescriptionFlags = Flags<SubpassDescriptionFlagBits>;
 
@@ -11050,6 +11692,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( SubpassDescriptionFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SubpassDescriptionFlags value )
   {
     if ( !value )
@@ -11073,6 +11716,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using CommandPoolCreateFlags = Flags<CommandPoolCreateFlagBits>;
 
@@ -11106,6 +11750,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( CommandPoolCreateFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CommandPoolCreateFlags value )
   {
     if ( !value )
@@ -11121,6 +11766,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using CommandPoolResetFlags = Flags<CommandPoolResetFlagBits>;
 
@@ -11153,6 +11799,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( CommandPoolResetFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CommandPoolResetFlags value )
   {
     if ( !value )
@@ -11164,6 +11811,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using CommandBufferResetFlags = Flags<CommandBufferResetFlagBits>;
 
@@ -11199,6 +11847,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( CommandBufferResetFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CommandBufferResetFlags value )
   {
     if ( !value )
@@ -11210,6 +11859,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using CommandBufferUsageFlags = Flags<CommandBufferUsageFlagBits>;
 
@@ -11246,6 +11896,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( CommandBufferUsageFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CommandBufferUsageFlags value )
   {
     if ( !value )
@@ -11261,6 +11912,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using QueryControlFlags = Flags<QueryControlFlagBits>;
 
@@ -11293,6 +11945,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( QueryControlFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( QueryControlFlags value )
   {
     if ( !value )
@@ -11304,6 +11957,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using StencilFaceFlags = Flags<StencilFaceFlagBits>;
 
@@ -11336,6 +11990,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( StencilFaceFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( StencilFaceFlags value )
   {
     if ( !value )
@@ -11349,6 +12004,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   //=== VK_VERSION_1_1 ===
 
@@ -11386,6 +12042,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( SubgroupFeatureFlags( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SubgroupFeatureFlags value )
   {
     if ( !value )
@@ -11413,6 +12070,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using PeerMemoryFeatureFlags = Flags<PeerMemoryFeatureFlagBits>;
 
@@ -11448,6 +12106,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using PeerMemoryFeatureFlagsKHR = PeerMemoryFeatureFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PeerMemoryFeatureFlags value )
   {
     if ( !value )
@@ -11465,6 +12124,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using MemoryAllocateFlags = Flags<MemoryAllocateFlagBits>;
 
@@ -11500,6 +12160,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using MemoryAllocateFlagsKHR = MemoryAllocateFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( MemoryAllocateFlags value )
   {
     if ( !value )
@@ -11515,24 +12176,29 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using CommandPoolTrimFlags = Flags<CommandPoolTrimFlagBits>;
 
   using CommandPoolTrimFlagsKHR = CommandPoolTrimFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CommandPoolTrimFlags )
   {
     return "{}";
   }
+#endif
 
   using DescriptorUpdateTemplateCreateFlags = Flags<DescriptorUpdateTemplateCreateFlagBits>;
 
   using DescriptorUpdateTemplateCreateFlagsKHR = DescriptorUpdateTemplateCreateFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DescriptorUpdateTemplateCreateFlags )
   {
     return "{}";
   }
+#endif
 
   using ExternalMemoryHandleTypeFlags = Flags<ExternalMemoryHandleTypeFlagBits>;
 
@@ -11546,13 +12212,13 @@ namespace VULKAN_HPP_NAMESPACE
                  VkFlags( ExternalMemoryHandleTypeFlagBits::eD3D11TextureKmt ) | VkFlags( ExternalMemoryHandleTypeFlagBits::eD3D12Heap ) |
                  VkFlags( ExternalMemoryHandleTypeFlagBits::eD3D12Resource ) | VkFlags( ExternalMemoryHandleTypeFlagBits::eDmaBufEXT )
 #if defined( VK_USE_PLATFORM_ANDROID_KHR )
-                 | VkFlags( ExternalMemoryHandleTypeFlagBits::eAndroidHardwareBufferANDROID )
+               | VkFlags( ExternalMemoryHandleTypeFlagBits::eAndroidHardwareBufferANDROID )
 #endif /*VK_USE_PLATFORM_ANDROID_KHR*/
-                 | VkFlags( ExternalMemoryHandleTypeFlagBits::eHostAllocationEXT ) | VkFlags( ExternalMemoryHandleTypeFlagBits::eHostMappedForeignMemoryEXT )
+               | VkFlags( ExternalMemoryHandleTypeFlagBits::eHostAllocationEXT ) | VkFlags( ExternalMemoryHandleTypeFlagBits::eHostMappedForeignMemoryEXT )
 #if defined( VK_USE_PLATFORM_FUCHSIA )
-                 | VkFlags( ExternalMemoryHandleTypeFlagBits::eZirconVmoFUCHSIA )
+               | VkFlags( ExternalMemoryHandleTypeFlagBits::eZirconVmoFUCHSIA )
 #endif /*VK_USE_PLATFORM_FUCHSIA*/
-                 | VkFlags( ExternalMemoryHandleTypeFlagBits::eRdmaAddressNV )
+               | VkFlags( ExternalMemoryHandleTypeFlagBits::eRdmaAddressNV )
     };
   };
 
@@ -11581,6 +12247,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using ExternalMemoryHandleTypeFlagsKHR = ExternalMemoryHandleTypeFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ExternalMemoryHandleTypeFlags value )
   {
     if ( !value )
@@ -11603,23 +12270,24 @@ namespace VULKAN_HPP_NAMESPACE
       result += "D3D12Resource | ";
     if ( value & ExternalMemoryHandleTypeFlagBits::eDmaBufEXT )
       result += "DmaBufEXT | ";
-#if defined( VK_USE_PLATFORM_ANDROID_KHR )
+#  if defined( VK_USE_PLATFORM_ANDROID_KHR )
     if ( value & ExternalMemoryHandleTypeFlagBits::eAndroidHardwareBufferANDROID )
       result += "AndroidHardwareBufferANDROID | ";
-#endif /*VK_USE_PLATFORM_ANDROID_KHR*/
+#  endif /*VK_USE_PLATFORM_ANDROID_KHR*/
     if ( value & ExternalMemoryHandleTypeFlagBits::eHostAllocationEXT )
       result += "HostAllocationEXT | ";
     if ( value & ExternalMemoryHandleTypeFlagBits::eHostMappedForeignMemoryEXT )
       result += "HostMappedForeignMemoryEXT | ";
-#if defined( VK_USE_PLATFORM_FUCHSIA )
+#  if defined( VK_USE_PLATFORM_FUCHSIA )
     if ( value & ExternalMemoryHandleTypeFlagBits::eZirconVmoFUCHSIA )
       result += "ZirconVmoFUCHSIA | ";
-#endif /*VK_USE_PLATFORM_FUCHSIA*/
+#  endif /*VK_USE_PLATFORM_FUCHSIA*/
     if ( value & ExternalMemoryHandleTypeFlagBits::eRdmaAddressNV )
       result += "RdmaAddressNV | ";
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using ExternalMemoryFeatureFlags = Flags<ExternalMemoryFeatureFlagBits>;
 
@@ -11658,6 +12326,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using ExternalMemoryFeatureFlagsKHR = ExternalMemoryFeatureFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ExternalMemoryFeatureFlags value )
   {
     if ( !value )
@@ -11673,6 +12342,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using ExternalFenceHandleTypeFlags = Flags<ExternalFenceHandleTypeFlagBits>;
 
@@ -11711,6 +12381,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using ExternalFenceHandleTypeFlagsKHR = ExternalFenceHandleTypeFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ExternalFenceHandleTypeFlags value )
   {
     if ( !value )
@@ -11728,6 +12399,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using ExternalFenceFeatureFlags = Flags<ExternalFenceFeatureFlagBits>;
 
@@ -11765,6 +12437,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using ExternalFenceFeatureFlagsKHR = ExternalFenceFeatureFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ExternalFenceFeatureFlags value )
   {
     if ( !value )
@@ -11778,6 +12451,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using FenceImportFlags = Flags<FenceImportFlagBits>;
 
@@ -11812,6 +12486,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using FenceImportFlagsKHR = FenceImportFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( FenceImportFlags value )
   {
     if ( !value )
@@ -11823,6 +12498,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using SemaphoreImportFlags = Flags<SemaphoreImportFlagBits>;
 
@@ -11857,6 +12533,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using SemaphoreImportFlagsKHR = SemaphoreImportFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SemaphoreImportFlags value )
   {
     if ( !value )
@@ -11868,6 +12545,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using ExternalSemaphoreHandleTypeFlags = Flags<ExternalSemaphoreHandleTypeFlagBits>;
 
@@ -11880,7 +12558,7 @@ namespace VULKAN_HPP_NAMESPACE
                  VkFlags( ExternalSemaphoreHandleTypeFlagBits::eOpaqueWin32Kmt ) | VkFlags( ExternalSemaphoreHandleTypeFlagBits::eD3D12Fence ) |
                  VkFlags( ExternalSemaphoreHandleTypeFlagBits::eSyncFd )
 #if defined( VK_USE_PLATFORM_FUCHSIA )
-                 | VkFlags( ExternalSemaphoreHandleTypeFlagBits::eZirconEventFUCHSIA )
+               | VkFlags( ExternalSemaphoreHandleTypeFlagBits::eZirconEventFUCHSIA )
 #endif /*VK_USE_PLATFORM_FUCHSIA*/
     };
   };
@@ -11910,6 +12588,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using ExternalSemaphoreHandleTypeFlagsKHR = ExternalSemaphoreHandleTypeFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ExternalSemaphoreHandleTypeFlags value )
   {
     if ( !value )
@@ -11926,13 +12605,14 @@ namespace VULKAN_HPP_NAMESPACE
       result += "D3D12Fence | ";
     if ( value & ExternalSemaphoreHandleTypeFlagBits::eSyncFd )
       result += "SyncFd | ";
-#if defined( VK_USE_PLATFORM_FUCHSIA )
+#  if defined( VK_USE_PLATFORM_FUCHSIA )
     if ( value & ExternalSemaphoreHandleTypeFlagBits::eZirconEventFUCHSIA )
       result += "ZirconEventFUCHSIA | ";
-#endif /*VK_USE_PLATFORM_FUCHSIA*/
+#  endif /*VK_USE_PLATFORM_FUCHSIA*/
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using ExternalSemaphoreFeatureFlags = Flags<ExternalSemaphoreFeatureFlagBits>;
 
@@ -11970,6 +12650,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using ExternalSemaphoreFeatureFlagsKHR = ExternalSemaphoreFeatureFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ExternalSemaphoreFeatureFlags value )
   {
     if ( !value )
@@ -11983,6 +12664,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   //=== VK_VERSION_1_2 ===
 
@@ -12020,6 +12702,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using DescriptorBindingFlagsEXT = DescriptorBindingFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DescriptorBindingFlags value )
   {
     if ( !value )
@@ -12037,6 +12720,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using ResolveModeFlags = Flags<ResolveModeFlagBits>;
 
@@ -12072,6 +12756,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using ResolveModeFlagsKHR = ResolveModeFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ResolveModeFlags value )
   {
     if ( !value )
@@ -12089,6 +12774,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using SemaphoreWaitFlags = Flags<SemaphoreWaitFlagBits>;
 
@@ -12123,6 +12809,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using SemaphoreWaitFlagsKHR = SemaphoreWaitFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SemaphoreWaitFlags value )
   {
     if ( !value )
@@ -12134,6 +12821,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   //=== VK_VERSION_1_3 ===
 
@@ -12174,6 +12862,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using PipelineCreationFeedbackFlagsEXT = PipelineCreationFeedbackFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineCreationFeedbackFlags value )
   {
     if ( !value )
@@ -12189,6 +12878,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using ToolPurposeFlags = Flags<ToolPurposeFlagBits>;
 
@@ -12225,6 +12915,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using ToolPurposeFlagsEXT = ToolPurposeFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ToolPurposeFlags value )
   {
     if ( !value )
@@ -12248,15 +12939,18 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using PrivateDataSlotCreateFlags = Flags<PrivateDataSlotCreateFlagBits>;
 
   using PrivateDataSlotCreateFlagsEXT = PrivateDataSlotCreateFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PrivateDataSlotCreateFlags )
   {
     return "{}";
   }
+#endif
 
   using PipelineStageFlags2 = Flags<PipelineStageFlagBits2>;
 
@@ -12278,9 +12972,9 @@ namespace VULKAN_HPP_NAMESPACE
                  VkFlags64( PipelineStageFlagBits2::eClear ) | VkFlags64( PipelineStageFlagBits2::eIndexInput ) |
                  VkFlags64( PipelineStageFlagBits2::eVertexAttributeInput ) | VkFlags64( PipelineStageFlagBits2::ePreRasterizationShaders )
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
-                 | VkFlags64( PipelineStageFlagBits2::eVideoDecodeKHR ) | VkFlags64( PipelineStageFlagBits2::eVideoEncodeKHR )
+               | VkFlags64( PipelineStageFlagBits2::eVideoDecodeKHR ) | VkFlags64( PipelineStageFlagBits2::eVideoEncodeKHR )
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
-                 | VkFlags64( PipelineStageFlagBits2::eTransformFeedbackEXT ) | VkFlags64( PipelineStageFlagBits2::eConditionalRenderingEXT ) |
+               | VkFlags64( PipelineStageFlagBits2::eTransformFeedbackEXT ) | VkFlags64( PipelineStageFlagBits2::eConditionalRenderingEXT ) |
                  VkFlags64( PipelineStageFlagBits2::eCommandPreprocessNV ) | VkFlags64( PipelineStageFlagBits2::eFragmentShadingRateAttachmentKHR ) |
                  VkFlags64( PipelineStageFlagBits2::eAccelerationStructureBuildKHR ) | VkFlags64( PipelineStageFlagBits2::eRayTracingShaderKHR ) |
                  VkFlags64( PipelineStageFlagBits2::eFragmentDensityProcessEXT ) | VkFlags64( PipelineStageFlagBits2::eTaskShaderNV ) |
@@ -12311,6 +13005,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using PipelineStageFlags2KHR = PipelineStageFlags2;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineStageFlags2 value )
   {
     if ( !value )
@@ -12365,12 +13060,12 @@ namespace VULKAN_HPP_NAMESPACE
       result += "VertexAttributeInput | ";
     if ( value & PipelineStageFlagBits2::ePreRasterizationShaders )
       result += "PreRasterizationShaders | ";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
     if ( value & PipelineStageFlagBits2::eVideoDecodeKHR )
       result += "VideoDecodeKHR | ";
     if ( value & PipelineStageFlagBits2::eVideoEncodeKHR )
       result += "VideoEncodeKHR | ";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
     if ( value & PipelineStageFlagBits2::eTransformFeedbackEXT )
       result += "TransformFeedbackEXT | ";
     if ( value & PipelineStageFlagBits2::eConditionalRenderingEXT )
@@ -12398,6 +13093,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using AccessFlags2 = Flags<AccessFlagBits2>;
 
@@ -12416,10 +13112,10 @@ namespace VULKAN_HPP_NAMESPACE
                  VkFlags64( AccessFlagBits2::eShaderSampledRead ) | VkFlags64( AccessFlagBits2::eShaderStorageRead ) |
                  VkFlags64( AccessFlagBits2::eShaderStorageWrite )
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
-                 | VkFlags64( AccessFlagBits2::eVideoDecodeReadKHR ) | VkFlags64( AccessFlagBits2::eVideoDecodeWriteKHR ) |
+               | VkFlags64( AccessFlagBits2::eVideoDecodeReadKHR ) | VkFlags64( AccessFlagBits2::eVideoDecodeWriteKHR ) |
                  VkFlags64( AccessFlagBits2::eVideoEncodeReadKHR ) | VkFlags64( AccessFlagBits2::eVideoEncodeWriteKHR )
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
-                 | VkFlags64( AccessFlagBits2::eTransformFeedbackWriteEXT ) | VkFlags64( AccessFlagBits2::eTransformFeedbackCounterReadEXT ) |
+               | VkFlags64( AccessFlagBits2::eTransformFeedbackWriteEXT ) | VkFlags64( AccessFlagBits2::eTransformFeedbackCounterReadEXT ) |
                  VkFlags64( AccessFlagBits2::eTransformFeedbackCounterWriteEXT ) | VkFlags64( AccessFlagBits2::eConditionalRenderingReadEXT ) |
                  VkFlags64( AccessFlagBits2::eCommandPreprocessReadNV ) | VkFlags64( AccessFlagBits2::eCommandPreprocessWriteNV ) |
                  VkFlags64( AccessFlagBits2::eFragmentShadingRateAttachmentReadKHR ) | VkFlags64( AccessFlagBits2::eAccelerationStructureReadKHR ) |
@@ -12451,6 +13147,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using AccessFlags2KHR = AccessFlags2;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AccessFlags2 value )
   {
     if ( !value )
@@ -12497,7 +13194,7 @@ namespace VULKAN_HPP_NAMESPACE
       result += "ShaderStorageRead | ";
     if ( value & AccessFlagBits2::eShaderStorageWrite )
       result += "ShaderStorageWrite | ";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
     if ( value & AccessFlagBits2::eVideoDecodeReadKHR )
       result += "VideoDecodeReadKHR | ";
     if ( value & AccessFlagBits2::eVideoDecodeWriteKHR )
@@ -12506,7 +13203,7 @@ namespace VULKAN_HPP_NAMESPACE
       result += "VideoEncodeReadKHR | ";
     if ( value & AccessFlagBits2::eVideoEncodeWriteKHR )
       result += "VideoEncodeWriteKHR | ";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
     if ( value & AccessFlagBits2::eTransformFeedbackWriteEXT )
       result += "TransformFeedbackWriteEXT | ";
     if ( value & AccessFlagBits2::eTransformFeedbackCounterReadEXT )
@@ -12536,6 +13233,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using SubmitFlags = Flags<SubmitFlagBits>;
 
@@ -12570,6 +13268,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using SubmitFlagsKHR = SubmitFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SubmitFlags value )
   {
     if ( !value )
@@ -12581,6 +13280,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using RenderingFlags = Flags<RenderingFlagBits>;
 
@@ -12616,6 +13316,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using RenderingFlagsKHR = RenderingFlags;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( RenderingFlags value )
   {
     if ( !value )
@@ -12631,6 +13332,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using FormatFeatureFlags2 = Flags<FormatFeatureFlagBits2>;
 
@@ -12656,14 +13358,14 @@ namespace VULKAN_HPP_NAMESPACE
                  VkFlags64( FormatFeatureFlagBits2::eStorageReadWithoutFormat ) | VkFlags64( FormatFeatureFlagBits2::eStorageWriteWithoutFormat ) |
                  VkFlags64( FormatFeatureFlagBits2::eSampledImageDepthComparison )
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
-                 | VkFlags64( FormatFeatureFlagBits2::eVideoDecodeOutputKHR ) | VkFlags64( FormatFeatureFlagBits2::eVideoDecodeDpbKHR )
+               | VkFlags64( FormatFeatureFlagBits2::eVideoDecodeOutputKHR ) | VkFlags64( FormatFeatureFlagBits2::eVideoDecodeDpbKHR )
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
-                 | VkFlags64( FormatFeatureFlagBits2::eAccelerationStructureVertexBufferKHR ) | VkFlags64( FormatFeatureFlagBits2::eFragmentDensityMapEXT ) |
+               | VkFlags64( FormatFeatureFlagBits2::eAccelerationStructureVertexBufferKHR ) | VkFlags64( FormatFeatureFlagBits2::eFragmentDensityMapEXT ) |
                  VkFlags64( FormatFeatureFlagBits2::eFragmentShadingRateAttachmentKHR )
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
-                 | VkFlags64( FormatFeatureFlagBits2::eVideoEncodeInputKHR ) | VkFlags64( FormatFeatureFlagBits2::eVideoEncodeDpbKHR )
+               | VkFlags64( FormatFeatureFlagBits2::eVideoEncodeInputKHR ) | VkFlags64( FormatFeatureFlagBits2::eVideoEncodeDpbKHR )
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
-                 | VkFlags64( FormatFeatureFlagBits2::eLinearColorAttachmentNV ) | VkFlags64( FormatFeatureFlagBits2::eWeightImageQCOM ) |
+               | VkFlags64( FormatFeatureFlagBits2::eLinearColorAttachmentNV ) | VkFlags64( FormatFeatureFlagBits2::eWeightImageQCOM ) |
                  VkFlags64( FormatFeatureFlagBits2::eWeightSampledImageQCOM ) | VkFlags64( FormatFeatureFlagBits2::eBlockMatchingQCOM ) |
                  VkFlags64( FormatFeatureFlagBits2::eBoxFilterSampledQCOM )
     };
@@ -12691,6 +13393,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using FormatFeatureFlags2KHR = FormatFeatureFlags2;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( FormatFeatureFlags2 value )
   {
     if ( !value )
@@ -12751,24 +13454,24 @@ namespace VULKAN_HPP_NAMESPACE
       result += "StorageWriteWithoutFormat | ";
     if ( value & FormatFeatureFlagBits2::eSampledImageDepthComparison )
       result += "SampledImageDepthComparison | ";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
     if ( value & FormatFeatureFlagBits2::eVideoDecodeOutputKHR )
       result += "VideoDecodeOutputKHR | ";
     if ( value & FormatFeatureFlagBits2::eVideoDecodeDpbKHR )
       result += "VideoDecodeDpbKHR | ";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
     if ( value & FormatFeatureFlagBits2::eAccelerationStructureVertexBufferKHR )
       result += "AccelerationStructureVertexBufferKHR | ";
     if ( value & FormatFeatureFlagBits2::eFragmentDensityMapEXT )
       result += "FragmentDensityMapEXT | ";
     if ( value & FormatFeatureFlagBits2::eFragmentShadingRateAttachmentKHR )
       result += "FragmentShadingRateAttachmentKHR | ";
-#if defined( VK_ENABLE_BETA_EXTENSIONS )
+#  if defined( VK_ENABLE_BETA_EXTENSIONS )
     if ( value & FormatFeatureFlagBits2::eVideoEncodeInputKHR )
       result += "VideoEncodeInputKHR | ";
     if ( value & FormatFeatureFlagBits2::eVideoEncodeDpbKHR )
       result += "VideoEncodeDpbKHR | ";
-#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
     if ( value & FormatFeatureFlagBits2::eLinearColorAttachmentNV )
       result += "LinearColorAttachmentNV | ";
     if ( value & FormatFeatureFlagBits2::eWeightImageQCOM )
@@ -12782,6 +13485,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   //=== VK_KHR_surface ===
 
@@ -12817,6 +13521,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( CompositeAlphaFlagsKHR( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( CompositeAlphaFlagsKHR value )
   {
     if ( !value )
@@ -12834,6 +13539,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   //=== VK_KHR_swapchain ===
 
@@ -12872,6 +13578,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( SwapchainCreateFlagsKHR( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SwapchainCreateFlagsKHR value )
   {
     if ( !value )
@@ -12887,6 +13594,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using DeviceGroupPresentModeFlagsKHR = Flags<DeviceGroupPresentModeFlagBitsKHR>;
 
@@ -12923,6 +13631,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( DeviceGroupPresentModeFlagsKHR( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DeviceGroupPresentModeFlagsKHR value )
   {
     if ( !value )
@@ -12940,15 +13649,18 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   //=== VK_KHR_display ===
 
   using DisplayModeCreateFlagsKHR = Flags<DisplayModeCreateFlagBitsKHR>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DisplayModeCreateFlagsKHR )
   {
     return "{}";
   }
+#endif
 
   using DisplayPlaneAlphaFlagsKHR = Flags<DisplayPlaneAlphaFlagBitsKHR>;
 
@@ -12985,6 +13697,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( DisplayPlaneAlphaFlagsKHR( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DisplayPlaneAlphaFlagsKHR value )
   {
     if ( !value )
@@ -13002,13 +13715,16 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using DisplaySurfaceCreateFlagsKHR = Flags<DisplaySurfaceCreateFlagBitsKHR>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DisplaySurfaceCreateFlagsKHR )
   {
     return "{}";
   }
+#endif
 
   using SurfaceTransformFlagsKHR = Flags<SurfaceTransformFlagBitsKHR>;
 
@@ -13048,6 +13764,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( SurfaceTransformFlagsKHR( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SurfaceTransformFlagsKHR value )
   {
     if ( !value )
@@ -13075,16 +13792,19 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
 #if defined( VK_USE_PLATFORM_XLIB_KHR )
   //=== VK_KHR_xlib_surface ===
 
   using XlibSurfaceCreateFlagsKHR = Flags<XlibSurfaceCreateFlagBitsKHR>;
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( XlibSurfaceCreateFlagsKHR )
   {
     return "{}";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_XLIB_KHR*/
 
 #if defined( VK_USE_PLATFORM_XCB_KHR )
@@ -13092,10 +13812,12 @@ namespace VULKAN_HPP_NAMESPACE
 
   using XcbSurfaceCreateFlagsKHR = Flags<XcbSurfaceCreateFlagBitsKHR>;
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( XcbSurfaceCreateFlagsKHR )
   {
     return "{}";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_XCB_KHR*/
 
 #if defined( VK_USE_PLATFORM_WAYLAND_KHR )
@@ -13103,10 +13825,12 @@ namespace VULKAN_HPP_NAMESPACE
 
   using WaylandSurfaceCreateFlagsKHR = Flags<WaylandSurfaceCreateFlagBitsKHR>;
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( WaylandSurfaceCreateFlagsKHR )
   {
     return "{}";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_WAYLAND_KHR*/
 
 #if defined( VK_USE_PLATFORM_ANDROID_KHR )
@@ -13114,10 +13838,12 @@ namespace VULKAN_HPP_NAMESPACE
 
   using AndroidSurfaceCreateFlagsKHR = Flags<AndroidSurfaceCreateFlagBitsKHR>;
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AndroidSurfaceCreateFlagsKHR )
   {
     return "{}";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_ANDROID_KHR*/
 
 #if defined( VK_USE_PLATFORM_WIN32_KHR )
@@ -13125,10 +13851,12 @@ namespace VULKAN_HPP_NAMESPACE
 
   using Win32SurfaceCreateFlagsKHR = Flags<Win32SurfaceCreateFlagBitsKHR>;
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( Win32SurfaceCreateFlagsKHR )
   {
     return "{}";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_WIN32_KHR*/
 
   //=== VK_EXT_debug_report ===
@@ -13165,6 +13893,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( DebugReportFlagsEXT( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DebugReportFlagsEXT value )
   {
     if ( !value )
@@ -13184,6 +13913,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
   //=== VK_KHR_video_queue ===
@@ -13197,7 +13927,7 @@ namespace VULKAN_HPP_NAMESPACE
     {
       allFlags = VkFlags( VideoCodecOperationFlagBitsKHR::eInvalid )
 #  if defined( VK_ENABLE_BETA_EXTENSIONS )
-                 | VkFlags( VideoCodecOperationFlagBitsKHR::eEncodeH264EXT ) | VkFlags( VideoCodecOperationFlagBitsKHR::eEncodeH265EXT ) |
+               | VkFlags( VideoCodecOperationFlagBitsKHR::eEncodeH264EXT ) | VkFlags( VideoCodecOperationFlagBitsKHR::eEncodeH265EXT ) |
                  VkFlags( VideoCodecOperationFlagBitsKHR::eDecodeH264EXT ) | VkFlags( VideoCodecOperationFlagBitsKHR::eDecodeH265EXT )
 #  endif /*VK_ENABLE_BETA_EXTENSIONS*/
     };
@@ -13226,13 +13956,14 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoCodecOperationFlagsKHR( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoCodecOperationFlagsKHR value )
   {
     if ( !value )
       return "{}";
 
     std::string result;
-#  if defined( VK_ENABLE_BETA_EXTENSIONS )
+#    if defined( VK_ENABLE_BETA_EXTENSIONS )
     if ( value & VideoCodecOperationFlagBitsKHR::eEncodeH264EXT )
       result += "EncodeH264EXT | ";
     if ( value & VideoCodecOperationFlagBitsKHR::eEncodeH265EXT )
@@ -13241,10 +13972,11 @@ namespace VULKAN_HPP_NAMESPACE
       result += "DecodeH264EXT | ";
     if ( value & VideoCodecOperationFlagBitsKHR::eDecodeH265EXT )
       result += "DecodeH265EXT | ";
-#  endif /*VK_ENABLE_BETA_EXTENSIONS*/
+#    endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 
   using VideoChromaSubsamplingFlagsKHR = Flags<VideoChromaSubsamplingFlagBitsKHR>;
 
@@ -13282,6 +14014,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoChromaSubsamplingFlagsKHR( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoChromaSubsamplingFlagsKHR value )
   {
     if ( !value )
@@ -13299,6 +14032,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 
   using VideoComponentBitDepthFlagsKHR = Flags<VideoComponentBitDepthFlagBitsKHR>;
 
@@ -13335,6 +14069,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoComponentBitDepthFlagsKHR( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoComponentBitDepthFlagsKHR value )
   {
     if ( !value )
@@ -13350,6 +14085,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 
   using VideoCapabilityFlagsKHR = Flags<VideoCapabilityFlagBitsKHR>;
 
@@ -13385,6 +14121,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoCapabilityFlagsKHR( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoCapabilityFlagsKHR value )
   {
     if ( !value )
@@ -13398,6 +14135,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 
   using VideoSessionCreateFlagsKHR = Flags<VideoSessionCreateFlagBitsKHR>;
 
@@ -13433,6 +14171,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoSessionCreateFlagsKHR( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoSessionCreateFlagsKHR value )
   {
     if ( !value )
@@ -13444,20 +14183,25 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 
   using VideoBeginCodingFlagsKHR = Flags<VideoBeginCodingFlagBitsKHR>;
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoBeginCodingFlagsKHR )
   {
     return "{}";
   }
+#  endif
 
   using VideoEndCodingFlagsKHR = Flags<VideoEndCodingFlagBitsKHR>;
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEndCodingFlagsKHR )
   {
     return "{}";
   }
+#  endif
 
   using VideoCodingControlFlagsKHR = Flags<VideoCodingControlFlagBitsKHR>;
 
@@ -13493,6 +14237,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoCodingControlFlagsKHR( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoCodingControlFlagsKHR value )
   {
     if ( !value )
@@ -13504,6 +14249,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 
   using VideoCodingQualityPresetFlagsKHR = Flags<VideoCodingQualityPresetFlagBitsKHR>;
 
@@ -13540,6 +14286,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoCodingQualityPresetFlagsKHR( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoCodingQualityPresetFlagsKHR value )
   {
     if ( !value )
@@ -13555,6 +14302,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
@@ -13595,6 +14343,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoDecodeCapabilityFlagsKHR( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoDecodeCapabilityFlagsKHR value )
   {
     if ( !value )
@@ -13608,6 +14357,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 
   using VideoDecodeFlagsKHR = Flags<VideoDecodeFlagBitsKHR>;
 
@@ -13640,6 +14390,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoDecodeFlagsKHR( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoDecodeFlagsKHR value )
   {
     if ( !value )
@@ -13651,16 +14402,19 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
   //=== VK_EXT_transform_feedback ===
 
   using PipelineRasterizationStateStreamCreateFlagsEXT = Flags<PipelineRasterizationStateStreamCreateFlagBitsEXT>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineRasterizationStateStreamCreateFlagsEXT )
   {
     return "{}";
   }
+#endif
 
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
   //=== VK_EXT_video_encode_h264 ===
@@ -13712,6 +14466,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoEncodeH264CapabilityFlagsEXT( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH264CapabilityFlagsEXT value )
   {
     if ( !value )
@@ -13771,6 +14526,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 
   using VideoEncodeH264InputModeFlagsEXT = Flags<VideoEncodeH264InputModeFlagBitsEXT>;
 
@@ -13807,6 +14563,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoEncodeH264InputModeFlagsEXT( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH264InputModeFlagsEXT value )
   {
     if ( !value )
@@ -13822,6 +14579,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 
   using VideoEncodeH264OutputModeFlagsEXT = Flags<VideoEncodeH264OutputModeFlagBitsEXT>;
 
@@ -13858,6 +14616,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoEncodeH264OutputModeFlagsEXT( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH264OutputModeFlagsEXT value )
   {
     if ( !value )
@@ -13873,6 +14632,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 
   using VideoEncodeH264RateControlStructureFlagsEXT = Flags<VideoEncodeH264RateControlStructureFlagBitsEXT>;
 
@@ -13910,6 +14670,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoEncodeH264RateControlStructureFlagsEXT( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH264RateControlStructureFlagsEXT value )
   {
     if ( !value )
@@ -13923,6 +14684,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
@@ -13976,6 +14738,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoEncodeH265CapabilityFlagsEXT( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH265CapabilityFlagsEXT value )
   {
     if ( !value )
@@ -14037,6 +14800,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 
   using VideoEncodeH265InputModeFlagsEXT = Flags<VideoEncodeH265InputModeFlagBitsEXT>;
 
@@ -14073,6 +14837,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoEncodeH265InputModeFlagsEXT( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH265InputModeFlagsEXT value )
   {
     if ( !value )
@@ -14088,6 +14853,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 
   using VideoEncodeH265OutputModeFlagsEXT = Flags<VideoEncodeH265OutputModeFlagBitsEXT>;
 
@@ -14124,6 +14890,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoEncodeH265OutputModeFlagsEXT( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH265OutputModeFlagsEXT value )
   {
     if ( !value )
@@ -14139,6 +14906,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 
   using VideoEncodeH265CtbSizeFlagsEXT = Flags<VideoEncodeH265CtbSizeFlagBitsEXT>;
 
@@ -14175,6 +14943,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoEncodeH265CtbSizeFlagsEXT( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH265CtbSizeFlagsEXT value )
   {
     if ( !value )
@@ -14190,6 +14959,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 
   using VideoEncodeH265TransformBlockSizeFlagsEXT = Flags<VideoEncodeH265TransformBlockSizeFlagBitsEXT>;
 
@@ -14227,6 +14997,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoEncodeH265TransformBlockSizeFlagsEXT( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH265TransformBlockSizeFlagsEXT value )
   {
     if ( !value )
@@ -14244,6 +15015,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 
   using VideoEncodeH265RateControlStructureFlagsEXT = Flags<VideoEncodeH265RateControlStructureFlagBitsEXT>;
 
@@ -14281,6 +15053,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoEncodeH265RateControlStructureFlagsEXT( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH265RateControlStructureFlagsEXT value )
   {
     if ( !value )
@@ -14294,6 +15067,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
@@ -14335,6 +15109,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoDecodeH264PictureLayoutFlagsEXT( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoDecodeH264PictureLayoutFlagsEXT value )
   {
     if ( !value )
@@ -14348,6 +15123,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
 #if defined( VK_USE_PLATFORM_GGP )
@@ -14355,10 +15131,12 @@ namespace VULKAN_HPP_NAMESPACE
 
   using StreamDescriptorSurfaceCreateFlagsGGP = Flags<StreamDescriptorSurfaceCreateFlagBitsGGP>;
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( StreamDescriptorSurfaceCreateFlagsGGP )
   {
     return "{}";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_GGP*/
 
   //=== VK_NV_external_memory_capabilities ===
@@ -14398,6 +15176,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( ExternalMemoryHandleTypeFlagsNV( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ExternalMemoryHandleTypeFlagsNV value )
   {
     if ( !value )
@@ -14415,6 +15194,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using ExternalMemoryFeatureFlagsNV = Flags<ExternalMemoryFeatureFlagBitsNV>;
 
@@ -14451,6 +15231,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( ExternalMemoryFeatureFlagsNV( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ExternalMemoryFeatureFlagsNV value )
   {
     if ( !value )
@@ -14466,16 +15247,19 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
 #if defined( VK_USE_PLATFORM_VI_NN )
   //=== VK_NN_vi_surface ===
 
   using ViSurfaceCreateFlagsNN = Flags<ViSurfaceCreateFlagBitsNN>;
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ViSurfaceCreateFlagsNN )
   {
     return "{}";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_VI_NN*/
 
   //=== VK_EXT_conditional_rendering ===
@@ -14514,6 +15298,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( ConditionalRenderingFlagsEXT( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ConditionalRenderingFlagsEXT value )
   {
     if ( !value )
@@ -14525,6 +15310,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   //=== VK_EXT_display_surface_counter ===
 
@@ -14559,6 +15345,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( SurfaceCounterFlagsEXT( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( SurfaceCounterFlagsEXT value )
   {
     if ( !value )
@@ -14570,42 +15357,51 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   //=== VK_NV_viewport_swizzle ===
 
   using PipelineViewportSwizzleStateCreateFlagsNV = Flags<PipelineViewportSwizzleStateCreateFlagBitsNV>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineViewportSwizzleStateCreateFlagsNV )
   {
     return "{}";
   }
+#endif
 
   //=== VK_EXT_discard_rectangles ===
 
   using PipelineDiscardRectangleStateCreateFlagsEXT = Flags<PipelineDiscardRectangleStateCreateFlagBitsEXT>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineDiscardRectangleStateCreateFlagsEXT )
   {
     return "{}";
   }
+#endif
 
   //=== VK_EXT_conservative_rasterization ===
 
   using PipelineRasterizationConservativeStateCreateFlagsEXT = Flags<PipelineRasterizationConservativeStateCreateFlagBitsEXT>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineRasterizationConservativeStateCreateFlagsEXT )
   {
     return "{}";
   }
+#endif
 
   //=== VK_EXT_depth_clip_enable ===
 
   using PipelineRasterizationDepthClipStateCreateFlagsEXT = Flags<PipelineRasterizationDepthClipStateCreateFlagBitsEXT>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineRasterizationDepthClipStateCreateFlagsEXT )
   {
     return "{}";
   }
+#endif
 
   //=== VK_KHR_performance_query ===
 
@@ -14644,6 +15440,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( PerformanceCounterDescriptionFlagsKHR( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PerformanceCounterDescriptionFlagsKHR value )
   {
     if ( !value )
@@ -14657,23 +15454,28 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using AcquireProfilingLockFlagsKHR = Flags<AcquireProfilingLockFlagBitsKHR>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AcquireProfilingLockFlagsKHR )
   {
     return "{}";
   }
+#endif
 
 #if defined( VK_USE_PLATFORM_IOS_MVK )
   //=== VK_MVK_ios_surface ===
 
   using IOSSurfaceCreateFlagsMVK = Flags<IOSSurfaceCreateFlagBitsMVK>;
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( IOSSurfaceCreateFlagsMVK )
   {
     return "{}";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_IOS_MVK*/
 
 #if defined( VK_USE_PLATFORM_MACOS_MVK )
@@ -14681,10 +15483,12 @@ namespace VULKAN_HPP_NAMESPACE
 
   using MacOSSurfaceCreateFlagsMVK = Flags<MacOSSurfaceCreateFlagBitsMVK>;
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( MacOSSurfaceCreateFlagsMVK )
   {
     return "{}";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_MACOS_MVK*/
 
   //=== VK_EXT_debug_utils ===
@@ -14724,6 +15528,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( DebugUtilsMessageSeverityFlagsEXT( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DebugUtilsMessageSeverityFlagsEXT value )
   {
     if ( !value )
@@ -14741,6 +15546,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using DebugUtilsMessageTypeFlagsEXT = Flags<DebugUtilsMessageTypeFlagBitsEXT>;
 
@@ -14777,6 +15583,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( DebugUtilsMessageTypeFlagsEXT( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DebugUtilsMessageTypeFlagsEXT value )
   {
     if ( !value )
@@ -14792,29 +15599,36 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using DebugUtilsMessengerCallbackDataFlagsEXT = Flags<DebugUtilsMessengerCallbackDataFlagBitsEXT>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DebugUtilsMessengerCallbackDataFlagsEXT )
   {
     return "{}";
   }
+#endif
 
   using DebugUtilsMessengerCreateFlagsEXT = Flags<DebugUtilsMessengerCreateFlagBitsEXT>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DebugUtilsMessengerCreateFlagsEXT )
   {
     return "{}";
   }
+#endif
 
   //=== VK_NV_fragment_coverage_to_color ===
 
   using PipelineCoverageToColorStateCreateFlagsNV = Flags<PipelineCoverageToColorStateCreateFlagBitsNV>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineCoverageToColorStateCreateFlagsNV )
   {
     return "{}";
   }
+#endif
 
   //=== VK_KHR_acceleration_structure ===
 
@@ -14851,6 +15665,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using GeometryFlagsNV = GeometryFlagsKHR;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( GeometryFlagsKHR value )
   {
     if ( !value )
@@ -14864,6 +15679,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using GeometryInstanceFlagsKHR = Flags<GeometryInstanceFlagBitsKHR>;
 
@@ -14902,6 +15718,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using GeometryInstanceFlagsNV = GeometryInstanceFlagsKHR;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( GeometryInstanceFlagsKHR value )
   {
     if ( !value )
@@ -14919,6 +15736,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using BuildAccelerationStructureFlagsKHR = Flags<BuildAccelerationStructureFlagBitsKHR>;
 
@@ -14958,6 +15776,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   using BuildAccelerationStructureFlagsNV = BuildAccelerationStructureFlagsKHR;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( BuildAccelerationStructureFlagsKHR value )
   {
     if ( !value )
@@ -14979,6 +15798,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using AccelerationStructureCreateFlagsKHR = Flags<AccelerationStructureCreateFlagBitsKHR>;
 
@@ -15014,6 +15834,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( AccelerationStructureCreateFlagsKHR( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AccelerationStructureCreateFlagsKHR value )
   {
     if ( !value )
@@ -15027,43 +15848,52 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   //=== VK_NV_framebuffer_mixed_samples ===
 
   using PipelineCoverageModulationStateCreateFlagsNV = Flags<PipelineCoverageModulationStateCreateFlagBitsNV>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineCoverageModulationStateCreateFlagsNV )
   {
     return "{}";
   }
+#endif
 
   //=== VK_EXT_validation_cache ===
 
   using ValidationCacheCreateFlagsEXT = Flags<ValidationCacheCreateFlagBitsEXT>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ValidationCacheCreateFlagsEXT )
   {
     return "{}";
   }
+#endif
 
   //=== VK_AMD_pipeline_compiler_control ===
 
   using PipelineCompilerControlFlagsAMD = Flags<PipelineCompilerControlFlagBitsAMD>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineCompilerControlFlagsAMD )
   {
     return "{}";
   }
+#endif
 
 #if defined( VK_USE_PLATFORM_FUCHSIA )
   //=== VK_FUCHSIA_imagepipe_surface ===
 
   using ImagePipeSurfaceCreateFlagsFUCHSIA = Flags<ImagePipeSurfaceCreateFlagBitsFUCHSIA>;
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImagePipeSurfaceCreateFlagsFUCHSIA )
   {
     return "{}";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_FUCHSIA*/
 
 #if defined( VK_USE_PLATFORM_METAL_EXT )
@@ -15071,38 +15901,46 @@ namespace VULKAN_HPP_NAMESPACE
 
   using MetalSurfaceCreateFlagsEXT = Flags<MetalSurfaceCreateFlagBitsEXT>;
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( MetalSurfaceCreateFlagsEXT )
   {
     return "{}";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_METAL_EXT*/
 
   //=== VK_AMD_shader_core_properties2 ===
 
   using ShaderCorePropertiesFlagsAMD = Flags<ShaderCorePropertiesFlagBitsAMD>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ShaderCorePropertiesFlagsAMD )
   {
     return "{}";
   }
+#endif
 
   //=== VK_NV_coverage_reduction_mode ===
 
   using PipelineCoverageReductionStateCreateFlagsNV = Flags<PipelineCoverageReductionStateCreateFlagBitsNV>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( PipelineCoverageReductionStateCreateFlagsNV )
   {
     return "{}";
   }
+#endif
 
   //=== VK_EXT_headless_surface ===
 
   using HeadlessSurfaceCreateFlagsEXT = Flags<HeadlessSurfaceCreateFlagBitsEXT>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( HeadlessSurfaceCreateFlagsEXT )
   {
     return "{}";
   }
+#endif
 
   //=== VK_NV_device_generated_commands ===
 
@@ -15137,6 +15975,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( IndirectStateFlagsNV( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( IndirectStateFlagsNV value )
   {
     if ( !value )
@@ -15148,6 +15987,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using IndirectCommandsLayoutUsageFlagsNV = Flags<IndirectCommandsLayoutUsageFlagBitsNV>;
 
@@ -15184,6 +16024,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( IndirectCommandsLayoutUsageFlagsNV( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( IndirectCommandsLayoutUsageFlagsNV value )
   {
     if ( !value )
@@ -15199,15 +16040,18 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   //=== VK_EXT_device_memory_report ===
 
   using DeviceMemoryReportFlagsEXT = Flags<DeviceMemoryReportFlagBitsEXT>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DeviceMemoryReportFlagsEXT )
   {
     return "{}";
   }
+#endif
 
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
   //=== VK_KHR_video_encode_queue ===
@@ -15243,6 +16087,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoEncodeFlagsKHR( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeFlagsKHR value )
   {
     if ( !value )
@@ -15254,6 +16099,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 
   using VideoEncodeCapabilityFlagsKHR = Flags<VideoEncodeCapabilityFlagBitsKHR>;
 
@@ -15289,6 +16135,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoEncodeCapabilityFlagsKHR( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeCapabilityFlagsKHR value )
   {
     if ( !value )
@@ -15300,6 +16147,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 
   using VideoEncodeRateControlFlagsKHR = Flags<VideoEncodeRateControlFlagBitsKHR>;
 
@@ -15335,6 +16183,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoEncodeRateControlFlagsKHR( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeRateControlFlagsKHR value )
   {
     if ( !value )
@@ -15346,6 +16195,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 
   using VideoEncodeRateControlModeFlagsKHR = Flags<VideoEncodeRateControlModeFlagBitsKHR>;
 
@@ -15382,6 +16232,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( VideoEncodeRateControlModeFlagsKHR( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeRateControlModeFlagsKHR value )
   {
     if ( !value )
@@ -15391,6 +16242,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
   //=== VK_NV_device_diagnostics_config ===
@@ -15431,6 +16283,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( DeviceDiagnosticsConfigFlagsNV( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DeviceDiagnosticsConfigFlagsNV value )
   {
     if ( !value )
@@ -15448,6 +16301,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
 #if defined( VK_USE_PLATFORM_METAL_EXT )
   //=== VK_EXT_metal_objects ===
@@ -15488,6 +16342,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( ExportMetalObjectTypeFlagsEXT( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ExportMetalObjectTypeFlagsEXT value )
   {
     if ( !value )
@@ -15509,6 +16364,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_METAL_EXT*/
 
   //=== VK_EXT_graphics_pipeline_library ===
@@ -15549,6 +16405,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( GraphicsPipelineLibraryFlagsEXT( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( GraphicsPipelineLibraryFlagsEXT value )
   {
     if ( !value )
@@ -15566,22 +16423,27 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   //=== VK_NV_ray_tracing_motion_blur ===
 
   using AccelerationStructureMotionInfoFlagsNV = Flags<AccelerationStructureMotionInfoFlagBitsNV>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AccelerationStructureMotionInfoFlagsNV )
   {
     return "{}";
   }
+#endif
 
   using AccelerationStructureMotionInstanceFlagsNV = Flags<AccelerationStructureMotionInstanceFlagBitsNV>;
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( AccelerationStructureMotionInstanceFlagsNV )
   {
     return "{}";
   }
+#endif
 
   //=== VK_EXT_image_compression_control ===
 
@@ -15620,6 +16482,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( ImageCompressionFlagsEXT( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageCompressionFlagsEXT value )
   {
     if ( !value )
@@ -15635,6 +16498,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
   using ImageCompressionFixedRateFlagsEXT = Flags<ImageCompressionFixedRateFlagBitsEXT>;
 
@@ -15682,6 +16546,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( ImageCompressionFixedRateFlagsEXT( bits ) );
   }
 
+#if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageCompressionFixedRateFlagsEXT value )
   {
     if ( !value )
@@ -15739,16 +16604,19 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#endif
 
 #if defined( VK_USE_PLATFORM_DIRECTFB_EXT )
   //=== VK_EXT_directfb_surface ===
 
   using DirectFBSurfaceCreateFlagsEXT = Flags<DirectFBSurfaceCreateFlagBitsEXT>;
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( DirectFBSurfaceCreateFlagsEXT )
   {
     return "{}";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_DIRECTFB_EXT*/
 
 #if defined( VK_USE_PLATFORM_FUCHSIA )
@@ -15756,10 +16624,12 @@ namespace VULKAN_HPP_NAMESPACE
 
   using ImageFormatConstraintsFlagsFUCHSIA = Flags<ImageFormatConstraintsFlagBitsFUCHSIA>;
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageFormatConstraintsFlagsFUCHSIA )
   {
     return "{}";
   }
+#  endif
 
   using ImageConstraintsInfoFlagsFUCHSIA = Flags<ImageConstraintsInfoFlagBitsFUCHSIA>;
 
@@ -15797,6 +16667,7 @@ namespace VULKAN_HPP_NAMESPACE
     return ~( ImageConstraintsInfoFlagsFUCHSIA( bits ) );
   }
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ImageConstraintsInfoFlagsFUCHSIA value )
   {
     if ( !value )
@@ -15816,6 +16687,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     return "{ " + result.substr( 0, result.size() - 3 ) + " }";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_FUCHSIA*/
 
 #if defined( VK_USE_PLATFORM_SCREEN_QNX )
@@ -15823,10 +16695,12 @@ namespace VULKAN_HPP_NAMESPACE
 
   using ScreenSurfaceCreateFlagsQNX = Flags<ScreenSurfaceCreateFlagBitsQNX>;
 
+#  if !defined( VULKAN_HPP_NO_TO_STRING )
   VULKAN_HPP_INLINE std::string to_string( ScreenSurfaceCreateFlagsQNX )
   {
     return "{}";
   }
+#  endif
 #endif /*VK_USE_PLATFORM_SCREEN_QNX*/
 
 }  // namespace VULKAN_HPP_NAMESPACE


### PR DESCRIPTION


Also extend the samples to hold some local version of the needed to_string functions in case VULKAN_HPP_NO_TO_STRING is defined.