### PR TITLE
fix: make VULKAN_HPP_RUN_GENERATOR work again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ if (VULKAN_HPP_RUN_GENERATOR)
     OUTPUT "${vulkan_hpp}"
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
     COMMENT "run ${PROJECT_NAME}"
-    DEPENDS ${PROJECT_NAME} "${vk_spec}")
+    DEPENDS "${vk_spec}")
 
   add_custom_target(build_vulkan_hpp ALL
     DEPENDS "${vulkan_hpp}" "${vk_spec}")


### PR DESCRIPTION
Apparently, the self dependency prevents that
the custom_command is executed.