### PR TITLE
Fix clang bugs

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -405,6 +405,7 @@ void VulkanHppGenerator::generateVulkanRAIIHppFile() const
 #  define VULKAN_RAII_HPP
 
 #include <memory>
+#include <utility>  // std::exchange, std::forward
 #include <vulkan/vulkan.hpp>
 
 #if !defined( VULKAN_HPP_RAII_NAMESPACE )

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -516,7 +516,7 @@ void VulkanHppGenerator::generateVulkanToStringHppFile() const
 
 #include <vulkan/vulkan_enums.hpp>
 
-#if ( ( 20 <= VULKAN_HPP_CPP_VERSION ) && __has_include( <format> ) )
+#if __cpp_lib_format
 #  include <format>   // std::format
 #else
 #  include <sstream>  // std::stringstream
@@ -5034,7 +5034,7 @@ std::string VulkanHppGenerator::generateEnumsToString() const
 
   VULKAN_HPP_INLINE std::string toHexString( uint32_t value )
   {
-#if ( ( 20 <= VULKAN_HPP_CPP_VERSION ) && __has_include( <format> ) )
+#if __cpp_lib_format
     return std::format( "{:x}", value );
 #else
     std::stringstream stream;

--- a/vulkan/vulkan_raii.hpp
+++ b/vulkan/vulkan_raii.hpp
@@ -9,6 +9,7 @@
 #define VULKAN_RAII_HPP
 
 #include <memory>
+#include <utility>  // std::exchange, std::forward
 #include <vulkan/vulkan.hpp>
 
 #if !defined( VULKAN_HPP_RAII_NAMESPACE )

--- a/vulkan/vulkan_to_string.hpp
+++ b/vulkan/vulkan_to_string.hpp
@@ -10,7 +10,7 @@
 
 #include <vulkan/vulkan_enums.hpp>
 
-#if ( ( 20 <= VULKAN_HPP_CPP_VERSION ) && __has_include( <format> ) )
+#if __cpp_lib_format
 #  include <format>  // std::format
 #else
 #  include <sstream>  // std::stringstream
@@ -2949,7 +2949,7 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string toHexString( uint32_t value )
   {
-#if ( ( 20 <= VULKAN_HPP_CPP_VERSION ) && __has_include( <format> ) )
+#if __cpp_lib_format
     return std::format( "{:x}", value );
 #else
     std::stringstream stream;


### PR DESCRIPTION
Fixes compilation using clang. 

- For clang-16 on Linux using libstdc++. Include <utility> for `std::exchange` 
```
In file included from /home/stephan/projects/Vulkan-Hpp/debug/RAII_Samples/SurfaceFormats/CMakeFiles/RAII_SurfaceFormats.dir/cmake_pch.hxx:5:
/home/stephan/projects/Vulkan-Hpp/vulkan/vulkan_raii.hpp:28:14: error: no template named 'exchange' in namespace 'std'; did you mean simply 'exchange'?
      return std::exchange<T>( obj, std::forward<U>( newValue ) );
             ^~~~~
/home/stephan/projects/Vulkan-Hpp/vulkan/vulkan_raii.hpp:25:49: note: 'exchange' declared here
    VULKAN_HPP_CONSTEXPR_14 VULKAN_HPP_INLINE T exchange( T & obj, U && newValue )
                                                ^
/home/stephan/projects/Vulkan-Hpp/vulkan/vulkan_raii.hpp:28:14: error: no template named 'exchange' in namespace 'std'; did you mean simply 'exchange'?
      return std::exchange<T>( obj, std::forward<U>( newValue ) );
             ^~~~~
/home/stephan/projects/Vulkan-Hpp/vulkan/vulkan_raii.hpp:25:49: note: 'exchange' declared here
    VULKAN_HPP_CONSTEXPR_14 VULKAN_HPP_INLINE T exchange( T & obj, U && newValue )

```
- For clang-13 on Mac using libc++. Use more reliable feature test macro for `std::format`. Fixes #1394