### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ To build the local samples and tests you'll have to clone this repository and ru
 
 Optional: To update the Vulkan-Hpp and its submodules execute ```git pull --recurse-submodules```.
 
+### Installing vulkan-hpp using vcpkg
+
+You can download and install vulkan-hpp using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+```bash
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install vulkan-hpp
+```
+
+The vulkan-hpp port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ### Optional Features
 
 #### Formatting


### PR DESCRIPTION
vulkan-hpp is available as a port in vcpkg, a C++ library manager that simplifies installation for vulkan-hpp and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build vulkan-hpp, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/vulkan-hpp/portfile.cmake). We try to keep the library maintained as close as possible to the original library.