### PR TITLE
Move explicitly defaulted copy assignment operators of structs into !defined(VULKAN_HPP_NO_STRUCT_CONSTRUCTORS) section

### DIFF
--- a/VulkanHppGenerator.hpp
+++ b/VulkanHppGenerator.hpp
@@ -886,7 +886,6 @@ private:
   std::string generateStaticAssertions() const;
   std::string generateStaticAssertions( std::vector<RequireData> const & requireData, std::string const & title ) const;
   std::string generateStruct( std::pair<std::string, StructureData> const & structure, std::set<std::string> & listedStructs ) const;
-  std::string generateStructAssignmentOperators( std::pair<std::string, StructureData> const & structure ) const;
   std::string generateStructCompareOperators( std::pair<std::string, StructureData> const & structure ) const;
   std::string generateStructConstructors( std::pair<std::string, StructureData> const & structData ) const;
   std::string generateStructConstructorsEnhanced( std::pair<std::string, StructureData> const & structData ) const;


### PR DESCRIPTION
To explicitly default the copy assignment operator is only needed, if there are other constructors. Otherwise, some compilers warn about it.

Resolves #1397.