### PR TITLE
Introduce additional constructor for unions holding a fixed size array of data.

### DIFF
--- a/RAII_Samples/13_InitVertexBuffer/13_InitVertexBuffer.cpp
+++ b/RAII_Samples/13_InitVertexBuffer/13_InitVertexBuffer.cpp
@@ -103,7 +103,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     assert( imageIndex < swapChainData.images.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
 
     commandBuffer.begin( {} );

--- a/RAII_Samples/15_DrawCube/15_DrawCube.cpp
+++ b/RAII_Samples/15_DrawCube/15_DrawCube.cpp
@@ -128,7 +128,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     commandBuffer.begin( {} );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
     vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
     commandBuffer.beginRenderPass( renderPassBeginInfo, vk::SubpassContents::eInline );

--- a/RAII_Samples/DrawTexturedCube/DrawTexturedCube.cpp
+++ b/RAII_Samples/DrawTexturedCube/DrawTexturedCube.cpp
@@ -125,7 +125,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     // commandBuffer.begin() has already been called above!
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
     vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
 

--- a/RAII_Samples/DynamicUniform/DynamicUniform.cpp
+++ b/RAII_Samples/DynamicUniform/DynamicUniform.cpp
@@ -150,7 +150,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     commandBuffer.begin( {} );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
     vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
     commandBuffer.beginRenderPass( renderPassBeginInfo, vk::SubpassContents::eInline );

--- a/RAII_Samples/ImmutableSampler/ImmutableSampler.cpp
+++ b/RAII_Samples/ImmutableSampler/ImmutableSampler.cpp
@@ -152,7 +152,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     assert( imageIndex < swapChainData.images.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
     vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
     commandBuffer.beginRenderPass( renderPassBeginInfo, vk::SubpassContents::eInline );

--- a/RAII_Samples/InputAttachment/InputAttachment.cpp
+++ b/RAII_Samples/InputAttachment/InputAttachment.cpp
@@ -216,7 +216,7 @@ int                 main( int /*argc*/, char ** /*argv*/ )
     assert( imageIndex < swapChainData.images.size() );
 
     vk::ClearValue clearValue;
-    clearValue.color = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValue.color = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValue );
     commandBuffer.beginRenderPass( renderPassBeginInfo, vk::SubpassContents::eInline );
     commandBuffer.bindPipeline( vk::PipelineBindPoint::eGraphics, *graphicsPipeline );

--- a/RAII_Samples/MultipleSets/MultipleSets.cpp
+++ b/RAII_Samples/MultipleSets/MultipleSets.cpp
@@ -215,7 +215,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     assert( imageIndex < swapChainData.images.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
     vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
     commandBuffer.beginRenderPass( renderPassBeginInfo, vk::SubpassContents::eInline );

--- a/RAII_Samples/OcclusionQuery/OcclusionQuery.cpp
+++ b/RAII_Samples/OcclusionQuery/OcclusionQuery.cpp
@@ -142,7 +142,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     commandBuffer.resetQueryPool( *queryPool, 0, 2 );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
     commandBuffer.beginRenderPass(
       vk::RenderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D(), surfaceData.extent ), clearValues ),

--- a/RAII_Samples/PipelineCache/PipelineCache.cpp
+++ b/RAII_Samples/PipelineCache/PipelineCache.cpp
@@ -306,7 +306,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     assert( imageIndex < swapChainData.images.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
 
     commandBuffer.beginRenderPass(

--- a/RAII_Samples/PipelineDerivative/PipelineDerivative.cpp
+++ b/RAII_Samples/PipelineDerivative/PipelineDerivative.cpp
@@ -229,7 +229,7 @@ void main()
     assert( imageIndex < swapChainData.images.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
 
     commandBuffer.beginRenderPass(

--- a/RAII_Samples/PushConstants/PushConstants.cpp
+++ b/RAII_Samples/PushConstants/PushConstants.cpp
@@ -189,7 +189,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     assert( imageIndex < swapChainData.images.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
 
     vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );

--- a/RAII_Samples/PushDescriptors/PushDescriptors.cpp
+++ b/RAII_Samples/PushDescriptors/PushDescriptors.cpp
@@ -149,7 +149,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     assert( imageIndex < swapChainData.images.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
     vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
     commandBuffer.beginRenderPass( renderPassBeginInfo, vk::SubpassContents::eInline );

--- a/RAII_Samples/RayTracing/RayTracing.cpp
+++ b/RAII_Samples/RayTracing/RayTracing.cpp
@@ -1092,7 +1092,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     shaderBindingTableBufferData.upload( shaderHandleStorage );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
 
     // Main loop

--- a/RAII_Samples/SecondaryCommandBuffer/SecondaryCommandBuffer.cpp
+++ b/RAII_Samples/SecondaryCommandBuffer/SecondaryCommandBuffer.cpp
@@ -180,7 +180,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     }
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
 
     vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );

--- a/RAII_Samples/SeparateImageSampler/SeparateImageSampler.cpp
+++ b/RAII_Samples/SeparateImageSampler/SeparateImageSampler.cpp
@@ -205,7 +205,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     assert( imageIndex < swapChainData.images.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
 
     vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );

--- a/RAII_Samples/Template/Template.cpp
+++ b/RAII_Samples/Template/Template.cpp
@@ -120,7 +120,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     assert( imageIndex < swapChainData.images.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
     vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
 

--- a/RAII_Samples/TexelBuffer/TexelBuffer.cpp
+++ b/RAII_Samples/TexelBuffer/TexelBuffer.cpp
@@ -146,7 +146,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     commandBuffer.begin( vk::CommandBufferBeginInfo() );
 
     vk::ClearValue clearValue;
-    clearValue.color = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValue.color = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValue );
 
     commandBuffer.beginRenderPass( renderPassBeginInfo, vk::SubpassContents::eInline );

--- a/samples/13_InitVertexBuffer/13_InitVertexBuffer.cpp
+++ b/samples/13_InitVertexBuffer/13_InitVertexBuffer.cpp
@@ -88,7 +88,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     assert( currentBuffer.value < framebuffers.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
 
     commandBuffer.begin( vk::CommandBufferBeginInfo( vk::CommandBufferUsageFlags() ) );

--- a/samples/15_DrawCube/15_DrawCube.cpp
+++ b/samples/15_DrawCube/15_DrawCube.cpp
@@ -112,7 +112,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     commandBuffer.begin( vk::CommandBufferBeginInfo( vk::CommandBufferUsageFlags() ) );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
     vk::RenderPassBeginInfo renderPassBeginInfo(
       renderPass, framebuffers[currentBuffer.value], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );

--- a/samples/DrawTexturedCube/DrawTexturedCube.cpp
+++ b/samples/DrawTexturedCube/DrawTexturedCube.cpp
@@ -119,7 +119,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     // commandBuffer.begin() has already been called above!
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
     vk::RenderPassBeginInfo renderPassBeginInfo(
       renderPass, framebuffers[currentBuffer.value], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );

--- a/samples/DynamicUniform/DynamicUniform.cpp
+++ b/samples/DynamicUniform/DynamicUniform.cpp
@@ -151,7 +151,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     commandBuffer.begin( vk::CommandBufferBeginInfo( vk::CommandBufferUsageFlags() ) );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
     vk::RenderPassBeginInfo renderPassBeginInfo(
       renderPass, framebuffers[currentBuffer.value], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );

--- a/samples/ImmutableSampler/ImmutableSampler.cpp
+++ b/samples/ImmutableSampler/ImmutableSampler.cpp
@@ -143,7 +143,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     assert( currentBuffer.value < framebuffers.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
     vk::RenderPassBeginInfo renderPassBeginInfo(
       renderPass, framebuffers[currentBuffer.value], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );

--- a/samples/InputAttachment/InputAttachment.cpp
+++ b/samples/InputAttachment/InputAttachment.cpp
@@ -134,7 +134,7 @@ int                 main( int /*argc*/, char ** /*argv*/ )
 
     commandBuffer.clearColorImage( inputImage,
                                    vk::ImageLayout::eTransferDstOptimal,
-                                   vk::ClearColorValue( std::array<float, 4>( { { 1.0f, 1.0f, 0.0f, 0.0f } } ) ),
+                                   vk::ClearColorValue( 1.0f, 1.0f, 0.0f, 0.0f ),
                                    vk::ImageSubresourceRange( vk::ImageAspectFlagBits::eColor, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS ) );
 
     // Set the image layout to SHADER_READONLY_OPTIMAL for use by the shaders
@@ -220,7 +220,7 @@ int                 main( int /*argc*/, char ** /*argv*/ )
     uint32_t currentBuffer = nexImage.value;
 
     vk::ClearValue clearValue;
-    clearValue.color = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValue.color = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     commandBuffer.beginRenderPass(
       vk::RenderPassBeginInfo( renderPass, framebuffers[currentBuffer], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValue ),
       vk::SubpassContents::eInline );

--- a/samples/MultipleSets/MultipleSets.cpp
+++ b/samples/MultipleSets/MultipleSets.cpp
@@ -199,7 +199,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     assert( currentBuffer.value < framebuffers.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
     vk::RenderPassBeginInfo renderPassBeginInfo(
       renderPass, framebuffers[currentBuffer.value], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );

--- a/samples/OcclusionQuery/OcclusionQuery.cpp
+++ b/samples/OcclusionQuery/OcclusionQuery.cpp
@@ -129,7 +129,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     commandBuffer.resetQueryPool( queryPool, 0, 2 );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
     commandBuffer.beginRenderPass(
       vk::RenderPassBeginInfo( renderPass, framebuffers[currentBuffer.value], vk::Rect2D( vk::Offset2D(), surfaceData.extent ), clearValues ),

--- a/samples/PipelineCache/PipelineCache.cpp
+++ b/samples/PipelineCache/PipelineCache.cpp
@@ -300,7 +300,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     assert( currentBuffer.value < framebuffers.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
 
     commandBuffer.beginRenderPass(

--- a/samples/PipelineDerivative/PipelineDerivative.cpp
+++ b/samples/PipelineDerivative/PipelineDerivative.cpp
@@ -239,7 +239,7 @@ void main()
     assert( currentBuffer.value < framebuffers.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
 
     commandBuffer.beginRenderPass(

--- a/samples/PushConstants/PushConstants.cpp
+++ b/samples/PushConstants/PushConstants.cpp
@@ -184,7 +184,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     assert( currentBuffer.value < framebuffers.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
 
     vk::RenderPassBeginInfo renderPassBeginInfo(

--- a/samples/PushDescriptors/PushDescriptors.cpp
+++ b/samples/PushDescriptors/PushDescriptors.cpp
@@ -148,7 +148,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     assert( currentBuffer.value < framebuffers.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
     vk::RenderPassBeginInfo renderPassBeginInfo(
       renderPass, framebuffers[currentBuffer.value], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );

--- a/samples/RayTracing/RayTracing.cpp
+++ b/samples/RayTracing/RayTracing.cpp
@@ -1084,7 +1084,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     shaderBindingTableBufferData.upload( device, shaderHandleStorage );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
 
     // Main loop

--- a/samples/SecondaryCommandBuffer/SecondaryCommandBuffer.cpp
+++ b/samples/SecondaryCommandBuffer/SecondaryCommandBuffer.cpp
@@ -176,7 +176,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     }
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
 
     vk::RenderPassBeginInfo renderPassBeginInfo(

--- a/samples/SeparateImageSampler/SeparateImageSampler.cpp
+++ b/samples/SeparateImageSampler/SeparateImageSampler.cpp
@@ -201,7 +201,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     assert( currentBuffer.value < framebuffers.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
 
     vk::RenderPassBeginInfo renderPassBeginInfo(

--- a/samples/Template/Template.cpp
+++ b/samples/Template/Template.cpp
@@ -116,7 +116,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     assert( currentBuffer.value < framebuffers.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
-    clearValues[0].color        = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
     vk::RenderPassBeginInfo renderPassBeginInfo(
       renderPass, framebuffers[currentBuffer.value], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );

--- a/samples/TexelBuffer/TexelBuffer.cpp
+++ b/samples/TexelBuffer/TexelBuffer.cpp
@@ -149,7 +149,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     commandBuffer.begin( vk::CommandBufferBeginInfo() );
 
     vk::ClearValue clearValue;
-    clearValue.color = vk::ClearColorValue( std::array<float, 4>( { { 0.2f, 0.2f, 0.2f, 0.2f } } ) );
+    clearValue.color = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     vk::RenderPassBeginInfo renderPassBeginInfo(
       renderPass, framebuffers[currentBuffer.value], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValue );
 

--- a/vulkan/vulkan_enums.hpp
+++ b/vulkan/vulkan_enums.hpp
@@ -1708,9 +1708,9 @@ namespace VULKAN_HPP_NAMESPACE
     static VULKAN_HPP_CONST_OR_CONSTEXPR QueueFlags allFlags  = QueueFlagBits::eGraphics | QueueFlagBits::eCompute | QueueFlagBits::eTransfer |
                                                                QueueFlagBits::eSparseBinding | QueueFlagBits::eProtected
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
-                                                               | QueueFlagBits::eVideoDecodeKHR | QueueFlagBits::eVideoEncodeKHR
+                                                             | QueueFlagBits::eVideoDecodeKHR | QueueFlagBits::eVideoEncodeKHR
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
-                                                               | QueueFlagBits::eOpticalFlowNV;
+                                                             | QueueFlagBits::eOpticalFlowNV;
   };
 
   enum class SampleCountFlagBits : VkSampleCountFlags
@@ -1984,7 +1984,7 @@ namespace VULKAN_HPP_NAMESPACE
     static VULKAN_HPP_CONST_OR_CONSTEXPR QueryResultFlags allFlags  = QueryResultFlagBits::e64 | QueryResultFlagBits::eWait |
                                                                      QueryResultFlagBits::eWithAvailability | QueryResultFlagBits::ePartial
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
-                                                                     | QueryResultFlagBits::eWithStatusKHR
+                                                                   | QueryResultFlagBits::eWithStatusKHR
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
       ;
   };


### PR DESCRIPTION
Also changed usage in all the samples, although the previous version does still work.