### PR TITLE
Add missing braces in union constructors on array members.

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -10024,7 +10024,7 @@ std::string VulkanHppGenerator::generateUnion( std::pair<std::string, StructureD
 
         static const std::string constructorBySequenceTemplate = R"(
     VULKAN_HPP_CONSTEXPR ${unionName}( ${arguments} )
-      : ${memberName}( { ${callArguments} } )
+      : ${memberName}{ { { ${callArguments} } } }
     {})";
 
         constructors += "\n" + replaceWithMap( constructorBySequenceTemplate,


### PR DESCRIPTION
Resolves #1465.