### PR TITLE
Update actions/checkout in GitHub Actions

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -15,14 +15,13 @@ jobs:
         cxx_standard: [11, 14, 17, 20]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
 
     - name: Install libraries
       run: |
         brew install clang-format molten-vk
-
-    - name: Update Submodules
-      run: git submodule update --init --recursive
 
     - name: Install Ninja
       uses: ashutoshvarma/setup-ninja@master

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -22,13 +22,12 @@ jobs:
         cxx_standard: [11, 14, 17, 20]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
     
     - name: Install libraries
       run: sudo apt update && sudo apt install libgl-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev
-
-    - name: Update Submodules
-      run: git submodule update --init --recursive
 
     - name: Install Ninja
       uses: ashutoshvarma/setup-ninja@master

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -16,10 +16,9 @@ jobs:
         build_type: [Debug, Release]
         cxx_standard: [11, 14, 17, 20]
     steps:
-    - uses: actions/checkout@v2
-    
-    - name: Update Submodules
-      run: git submodule update --init --recursive
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
 
     - name: Setup MSVC
       uses: TheMrMilchmann/setup-msvc-dev@v1

--- a/.github/workflows/set-version-tag.yml
+++ b/.github/workflows/set-version-tag.yml
@@ -9,11 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
     
     - name: Update Submodules
       run: |
-        git submodule update --init --recursive
         cd Vulkan-Headers
         VK_HEADER_GIT_TAG=$(git tag --points-at HEAD | head -n1)
         git checkout $VK_HEADER_GIT_TAG

--- a/.github/workflows/update-header-pr.yml
+++ b/.github/workflows/update-header-pr.yml
@@ -15,14 +15,15 @@ jobs:
         cxx_standard: [11]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
     
     - name: Install libraries
       run: sudo apt install clang-format-15
 
     - name: Update Submodules
       run: |
-        git submodule update --init --recursive
         cd Vulkan-Headers
         VK_HEADER_GIT_TAG=$(git describe --always --tags $(git rev-list --tags) | grep 'v[0-9]\.' | head -n1)
         echo "New revision of Vulkan-Headers: $VK_HEADER_GIT_TAG"


### PR DESCRIPTION
From https://github.com/KhronosGroup/Vulkan-Hpp/actions/runs/3932322410

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, ashutoshvarma/setup-ninja@master. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.