### PR TITLE
ci: fix update-header-pr (tags were not fetched)

### DIFF
--- a/.github/workflows/update-header-pr.yml
+++ b/.github/workflows/update-header-pr.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Update Submodules
       run: |
         cd Vulkan-Headers
+        git fetch --all --tags
         VK_HEADER_GIT_TAG=$(git describe --always --tags $(git rev-list --tags) | grep 'v[0-9]\.' | head -n1)
         echo "New revision of Vulkan-Headers: $VK_HEADER_GIT_TAG"
         git checkout $VK_HEADER_GIT_TAG


### PR DESCRIPTION
- Run without `git fetch --all --tags`: https://github.com/theHamsta/Vulkan-Hpp/actions/runs/4221771719/jobs/7329463344
- Run with `git fetch --all --tags`: https://github.com/theHamsta/Vulkan-Hpp/actions/runs/4221781287/jobs/7329484407 resulting in this PR https://github.com/theHamsta/Vulkan-Hpp/pull/19