### PR TITLE
ci: only run ci-macos on PRs (like ci-ubuntu/ci-windows)

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -1,7 +1,10 @@
 
 name: CI MacOS
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches: [ main ]
+
 jobs:
   build:
     runs-on: macos-11


### PR DESCRIPTION
MacOS wasn't probably intended to be special. Run MacOS CI only on PRs like Windows and Ubuntu

Now they are all the same
![image](https://user-images.githubusercontent.com/7189118/220065191-90207b07-23a4-4018-831f-f035b9b1e2a2.png)
