### PR TITLE
ci: bump setup-msvc-dev to v2

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -21,7 +21,7 @@ jobs:
         submodules: recursive
 
     - name: Setup MSVC
-      uses: TheMrMilchmann/setup-msvc-dev@v1
+      uses: TheMrMilchmann/setup-msvc-dev@v2
       with:
         arch: ${{matrix.architecture}}
       


### PR DESCRIPTION
This avoids a deprecation warning about Node.js 12 as shown here https://github.com/KhronosGroup/Vulkan-Hpp/actions/runs/4222600167