### PR TITLE
Extend default case in throwResultException to also get the actual message.

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -9938,7 +9938,7 @@ std::string VulkanHppGenerator::generateThrowResultException() const
       switch ( result )
       {
 ${cases}
-        default: throw SystemError( make_error_code( result ) );
+        default: throw SystemError( make_error_code( result ), message );
       }
     }
   })";

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -6579,7 +6579,7 @@ namespace VULKAN_HPP_NAMESPACE
         case Result::eErrorInvalidVideoStdParametersKHR: throw InvalidVideoStdParametersKHRError( message );
 #  endif /*VK_ENABLE_BETA_EXTENSIONS*/
         case Result::eErrorCompressionExhaustedEXT: throw CompressionExhaustedEXTError( message );
-        default: throw SystemError( make_error_code( result ) );
+        default: throw SystemError( make_error_code( result ), message );
       }
     }
   }  // namespace


### PR DESCRIPTION
Resolves #1542.