### PR TITLE
Fix wrong usage of 'structureChains' in generating functions returning a StructureChain and a vector of data.

### DIFF
--- a/VulkanHppGenerator.hpp
+++ b/VulkanHppGenerator.hpp
@@ -540,6 +540,7 @@ private:
                                     size_t                                    initialSkipCount,
                                     std::set<size_t> const &                  singularParams,
                                     std::set<size_t> const &                  templatedParams,
+                                    std::vector<size_t> const &               chainedReturnParams,
                                     CommandFlavourFlags                       flavourFlags,
                                     bool                                      raii ) const;
   std::string generateChainTemplates( std::vector<size_t> const & returnParams, bool chained ) const;
@@ -936,6 +937,7 @@ private:
   bool isSupportedFeature( std::string const & name ) const;
   bool isTypeRequired( std::string const & type ) const;
   bool isTypeUsed( std::string const & type ) const;
+  bool needsStructureChainResize( std::map<size_t, VectorParamData> const & vectorParams, std::vector<size_t> const & chainedReturnParams ) const;
   std::pair<bool, std::map<size_t, std::vector<size_t>>> needsVectorSizeCheck( std::vector<ParamData> const &            params,
                                                                                std::map<size_t, VectorParamData> const & vectorParams,
                                                                                std::vector<size_t> const &               returnParams,

--- a/tests/EnableBetaExtensions/EnableBetaExtensions.cpp
+++ b/tests/EnableBetaExtensions/EnableBetaExtensions.cpp
@@ -18,7 +18,13 @@
 #define VK_ENABLE_BETA_EXTENSIONS
 #include <vulkan/vulkan.hpp>
 
-int main(int /*argc*/, char** /*argv*/)
+int main( int /*argc*/, char ** /*argv*/ )
 {
+  vk::Device device;
+
+  vk::VideoEncodeSessionParametersGetInfoKHR videoSessionParametersInfo;
+  auto                                       stuff = device.getEncodedVideoSessionParametersKHR<vk::VideoEncodeSessionParametersFeedbackInfoKHR,
+                                                          vk::VideoEncodeH264SessionParametersFeedbackInfoEXT,
+                                                          vk::VideoEncodeH265SessionParametersFeedbackInfoEXT>( videoSessionParametersInfo );
   return 0;
 }

--- a/vulkan/vulkan_funcs.hpp
+++ b/vulkan/vulkan_funcs.hpp
@@ -18660,12 +18660,7 @@ namespace VULKAN_HPP_NAMESPACE
                                                         nullptr );
       if ( ( result == VK_SUCCESS ) && dataSize )
       {
-        structureChains.resize( dataSize );
         data.resize( dataSize );
-        for ( size_t i = 0; i < dataSize; i++ )
-        {
-          data[i].pNext = structureChains[i].template get<void>().pNext;
-        }
         result = d.vkGetEncodedVideoSessionParametersKHR( m_device,
                                                           reinterpret_cast<const VkVideoEncodeSessionParametersGetInfoKHR *>( &videoSessionParametersInfo ),
                                                           reinterpret_cast<VkVideoEncodeSessionParametersFeedbackInfoKHR *>( &feedbackInfo ),
@@ -18709,12 +18704,7 @@ namespace VULKAN_HPP_NAMESPACE
                                                         nullptr );
       if ( ( result == VK_SUCCESS ) && dataSize )
       {
-        structureChains.resize( dataSize );
         data.resize( dataSize );
-        for ( size_t i = 0; i < dataSize; i++ )
-        {
-          data[i].pNext = structureChains[i].template get<void>().pNext;
-        }
         result = d.vkGetEncodedVideoSessionParametersKHR( m_device,
                                                           reinterpret_cast<const VkVideoEncodeSessionParametersGetInfoKHR *>( &videoSessionParametersInfo ),
                                                           reinterpret_cast<VkVideoEncodeSessionParametersFeedbackInfoKHR *>( &feedbackInfo ),

--- a/vulkan/vulkan_raii.hpp
+++ b/vulkan/vulkan_raii.hpp
@@ -18567,12 +18567,7 @@ namespace VULKAN_HPP_NAMESPACE
           nullptr );
         if ( ( result == VK_SUCCESS ) && dataSize )
         {
-          structureChains.resize( dataSize );
           data.resize( dataSize );
-          for ( size_t i = 0; i < dataSize; i++ )
-          {
-            data[i].pNext = structureChains[i].template get<void>().pNext;
-          }
           result = getDispatcher()->vkGetEncodedVideoSessionParametersKHR(
             static_cast<VkDevice>( m_device ),
             reinterpret_cast<const VkVideoEncodeSessionParametersGetInfoKHR *>( &videoSessionParametersInfo ),


### PR DESCRIPTION
Resolves #1589.