### PR TITLE
Introduce function StructureChain::assign to assign a complete struct in a StructureChain without modifying the chaining.

### DIFF
--- a/snippets/StructureChain.hpp
+++ b/snippets/StructureChain.hpp
@@ -127,6 +127,17 @@
       return std::tie( get<T0>(), get<T1>(), get<Ts>()... );
     }
 
+    // assign a complete structure to the StructureChain without modifying the chaining
+    template <typename T = typename std::tuple_element<0, std::tuple<ChainElements...>>::type, size_t Which = 0>
+    StructureChain & assign( const T & rhs ) VULKAN_HPP_NOEXCEPT
+    {
+      T &    lhs   = get<T, Which>();
+      void * pNext = lhs.pNext;
+      lhs          = rhs;
+      lhs.pNext    = pNext;
+	  return *this;
+    }
+
     template <typename ClassType, size_t Which = 0>
     typename std::enable_if<
       std::is_same<ClassType, typename std::tuple_element<0, std::tuple<ChainElements...>>::type>::value &&

--- a/tests/StructureChain/StructureChain.cpp
+++ b/tests/StructureChain/StructureChain.cpp
@@ -67,6 +67,19 @@ int main( int /*argc*/, char ** /*argv*/ )
                        vk::PhysicalDevicePushDescriptorPropertiesKHR>
       sc7;
 
+#if !defined(NDEBUG)
+    void * pNext = sc7.get<vk::PhysicalDeviceIDProperties>().pNext;
+#endif
+    sc7.assign<vk::PhysicalDeviceIDProperties>( {} );
+    assert( pNext == sc7.get<vk::PhysicalDeviceIDProperties>().pNext );
+
+#if !defined(NDEBUG)
+    void * pNext1 = sc7.get<vk::PhysicalDeviceMaintenance3Properties>().pNext;
+    sc7.assign<vk::PhysicalDeviceMaintenance3Properties>( {} ).assign<vk::PhysicalDeviceIDProperties>( {} );
+    assert( pNext == sc7.get<vk::PhysicalDeviceIDProperties>().pNext );
+    assert( pNext1 == sc7.get<vk::PhysicalDeviceMaintenance3Properties>().pNext );
+#endif
+
     // some checks on unmodified chains
     assert( sc7.isLinked<vk::PhysicalDeviceProperties2>() );
     assert( sc7.isLinked<vk::PhysicalDeviceMaintenance3Properties>() );

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -1053,6 +1053,17 @@ namespace VULKAN_HPP_NAMESPACE
       return std::tie( get<T0>(), get<T1>(), get<Ts>()... );
     }
 
+    // assign a complete structure to the StructureChain without modifying the chaining
+    template <typename T = typename std::tuple_element<0, std::tuple<ChainElements...>>::type, size_t Which = 0>
+    StructureChain & assign( const T & rhs ) VULKAN_HPP_NOEXCEPT
+    {
+      T &    lhs   = get<T, Which>();
+      void * pNext = lhs.pNext;
+      lhs          = rhs;
+      lhs.pNext    = pNext;
+      return *this;
+    }
+
     template <typename ClassType, size_t Which = 0>
     typename std::enable_if<std::is_same<ClassType, typename std::tuple_element<0, std::tuple<ChainElements...>>::type>::value && ( Which == 0 ), bool>::type
       isLinked() const VULKAN_HPP_NOEXCEPT


### PR DESCRIPTION
Resolves #1575.
Resolves #1586.