### PR TITLE
Mark vk::ResultValue::asTuple() & as deprecated, introduce vk::ResultValue::asTuple() &&

### DIFF
--- a/snippets/ResultValue.hpp
+++ b/snippets/ResultValue.hpp
@@ -40,12 +40,20 @@
       , value(std::move(v))
     {}
 
-    std::tuple<Result, UniqueHandle<Type, Dispatch>> asTuple()
+    VULKAN_HPP_DEPRECATED(
+      "asTuple() on an l-value is deprecated, as it implicitly moves the UniqueHandle out of the ResultValue. Use asTuple() on an r-value instead, requiring to explicitly move the UniqueHandle." )
+      std::tuple<Result, UniqueHandle<Type, Dispatch>>
+      asTuple() &
     {
       return std::make_tuple( result, std::move( value ) );
     }
 
-    Result                        result;
+    std::tuple<Result, UniqueHandle<Type, Dispatch>> asTuple() &&
+    {
+      return std::make_tuple( result, std::move( value ) );
+    }
+
+    Result                       result;
     UniqueHandle<Type, Dispatch>  value;
   };
 
@@ -61,7 +69,15 @@
       , value( std::move( v ) )
     {}
 
-    std::tuple<Result, std::vector<UniqueHandle<Type, Dispatch>>> asTuple()
+    VULKAN_HPP_DEPRECATED(
+      "asTuple() on an l-value is deprecated, as it implicitly moves the UniqueHandle out of the ResultValue. Use asTuple() on an r-value instead, requiring to explicitly move the UniqueHandle." )
+      std::tuple<Result, std::vector<UniqueHandle<Type, Dispatch>>>
+      asTuple() &
+    {
+      return std::make_tuple( result, std::move( value ) );
+    }
+
+    std::tuple<Result, std::vector<UniqueHandle<Type, Dispatch>>> asTuple() &&
     {
       return std::make_tuple( result, std::move( value ) );
     }

--- a/tests/UniqueHandle/UniqueHandle.cpp
+++ b/tests/UniqueHandle/UniqueHandle.cpp
@@ -262,6 +262,13 @@ int main( int /*argc*/, char ** /*argv*/ )
     );
 
     // create a GraphicsPipeline
+    vk::ResultValue<vk::UniquePipeline> rv = device->createGraphicsPipelineUnique( *pipelineCache, graphicsPipelineCreateInfo );
+#if 17 <= VULKAN_HPP_CPP_VERSION
+    auto [r, v] = std::move( rv );
+#endif
+    // auto trv = rv.asTuple();    // asTuple() on an l-value is deprecated !!
+    auto trv1 = std::move( rv ).asTuple();
+
     vk::UniquePipeline graphicsPipeline = device->createGraphicsPipelineUnique( *pipelineCache, graphicsPipelineCreateInfo ).value;
 
     vk::UniquePipeline graphicsPipeline2 =

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -6788,7 +6788,15 @@ namespace VULKAN_HPP_NAMESPACE
     {
     }
 
-    std::tuple<Result, UniqueHandle<Type, Dispatch>> asTuple()
+    VULKAN_HPP_DEPRECATED(
+      "asTuple() on an l-value is deprecated, as it implicitly moves the UniqueHandle out of the ResultValue. Use asTuple() on an r-value instead, requiring to explicitly move the UniqueHandle." )
+
+    std::tuple<Result, UniqueHandle<Type, Dispatch>> asTuple() &
+    {
+      return std::make_tuple( result, std::move( value ) );
+    }
+
+    std::tuple<Result, UniqueHandle<Type, Dispatch>> asTuple() &&
     {
       return std::make_tuple( result, std::move( value ) );
     }
@@ -6810,7 +6818,15 @@ namespace VULKAN_HPP_NAMESPACE
     {
     }
 
-    std::tuple<Result, std::vector<UniqueHandle<Type, Dispatch>>> asTuple()
+    VULKAN_HPP_DEPRECATED(
+      "asTuple() on an l-value is deprecated, as it implicitly moves the UniqueHandle out of the ResultValue. Use asTuple() on an r-value instead, requiring to explicitly move the UniqueHandle." )
+
+    std::tuple<Result, std::vector<UniqueHandle<Type, Dispatch>>> asTuple() &
+    {
+      return std::make_tuple( result, std::move( value ) );
+    }
+
+    std::tuple<Result, std::vector<UniqueHandle<Type, Dispatch>>> asTuple() &&
     {
       return std::make_tuple( result, std::move( value ) );
     }


### PR DESCRIPTION
Resolves #1577.

Before this change, when assigning an l-value of type `vk::ResultValue<vk::UniqueStuff>` to a `std::tuple<vk::Result,vk::UniqueStuff>` using the `asTuple()`-function, the `vk::UniqueStuff` was implicitly moved from the `vk::ResultValue` to the `std::tuple`.
As that might be unexpected behaviour, that function is marked as deprecated.
Instead, a corresponding `asTuple()`-function working on an r-value is introduced. Using that requires the user to explicitly `std::move` the `vk::ResultValue`.

That is, instead of
`auto trv = rv.asTuple();`
you need to code as
`auto trv = std::move( rv ).asTuple();`

Note, though, that independently of this change, with C++17 you can just use designated initializers like this:
`auto [r,v] = std::move(rv);`