### PR TITLE
Bug fixes for `vulkan.cppm`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,20 @@ set( TINYXML2_SOURCES ${VULKAN_HPP_TINYXML2_SRC_DIR}/tinyxml2.cpp )
 set( TINYXML2_HEADERS ${VULKAN_HPP_TINYXML2_SRC_DIR}/tinyxml2.h )
 source_group( TinyXML2 FILES ${TINYXML2_HEADERS} ${TINYXML2_SOURCES} )
 
+# Build Vulkan-Hpp as a module
+if( VULKAN_HPP_ENABLE_EXPERIMENTAL_CPP20_MODULES )
+	# create a target to provide VulkanHpp as C++20 module
+	add_library( VulkanHppModule )
+	set_target_properties( VulkanHppModule PROPERTIES
+		CXX_STANDARD_REQUIRED ON
+		CXX_EXTENSIONS OFF )
+	target_compile_features( VulkanHppModule PUBLIC cxx_std_20 )
+	target_sources( VulkanHppModule
+		PUBLIC
+		FILE_SET vulkan_module_file BASE_DIRS ${CMAKE_SOURCE_DIR} TYPE CXX_MODULES FILES vulkan/vulkan.cppm )
+	target_include_directories( VulkanHppModule PUBLIC ${CMAKE_SOURCE_DIR} )
+	target_include_directories( VulkanHppModule PUBLIC "${CMAKE_SOURCE_DIR}/Vulkan-Headers/include" )
+endif()
 
 # The generator project !
 project( VulkanHppGenerator LANGUAGES CXX )
@@ -404,19 +418,4 @@ if( ${VULKAN_HPP_INSTALL} )
 	)
 	install( FILES ${VK_GENERATED_VULKAN_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vulkan )
 
-endif()
-
-# Build Vulkan-Hpp as a module
-if( VULKAN_HPP_ENABLE_EXPERIMENTAL_CPP20_MODULES )
-	# create a target to provide VulkanHpp as C++20 module
-	add_library( VulkanHppModule )
-	set_target_properties( VulkanHppModule PROPERTIES
-		CXX_STANDARD_REQUIRED ON
-		CXX_EXTENSIONS OFF )
-	target_compile_features( VulkanHppModule PUBLIC cxx_std_20 )
-	target_sources( VulkanHppModule
-		PUBLIC
-		FILE_SET vulkan_module_file BASE_DIRS ${CMAKE_SOURCE_DIR} TYPE CXX_MODULES FILES vulkan/vulkan.cppm )
-	target_include_directories( VulkanHppModule PUBLIC ${CMAKE_SOURCE_DIR} )
-	target_include_directories( VulkanHppModule PUBLIC "${CMAKE_SOURCE_DIR}/Vulkan-Headers/include" )
 endif()

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -4742,9 +4742,9 @@ std::string VulkanHppGenerator::generateConstexprDefines() const
     return ${implementation};
   }
 )" };
-  auto const constexprCallTemplate     = std::string{ R"(  ${deprecated}VULKAN_HPP_CONSTEXPR auto ${constName} = ${callee}( ${arguments} );
+  auto const constexprCallTemplate     = std::string{ R"(  ${deprecated}VULKAN_HPP_CONSTEXPR_INLINE auto ${constName} = ${callee}( ${arguments} );
 )" };
-  auto const constexprValueTemplate    = std::string{ R"(  ${deprecated}VULKAN_HPP_CONSTEXPR ${type} ${constName} = ${value};
+  auto const constexprValueTemplate    = std::string{ R"(  ${deprecated}VULKAN_HPP_CONSTEXPR_INLINE ${type} ${constName} = ${value};
 )" };
   auto const deprecatedAttribute       = std::string{ R"(VULKAN_HPP_DEPRECATED("${reason}") )" };
 

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -718,7 +718,7 @@ export namespace VULKAN_HPP_NAMESPACE
 {
   ${usings}
 
-  export namespace VULKAN_HPP_RAII_NAMESPACE {
+  namespace VULKAN_HPP_RAII_NAMESPACE {
     ${raiiUsings}
   } // namespace VULKAN_HPP_RAII_NAMESPACE
 } // namespace VULKAN_HPP_NAMESPACE
@@ -5313,7 +5313,7 @@ std::string VulkanHppGenerator::generateCppModuleUsings() const
   auto const [enterDisableEnhanced, leaveDisableEnhanced] = generateProtection( "VULKAN_HPP_DISABLE_ENHANCED_MODE", false );
   usings += "\n" + enterDisableEnhanced + replaceWithMap( usingTemplate, { { "className", "StructExtends" } } ) + leaveDisableEnhanced + "\n";
 
-  auto const [enterDynamicLoader, leaveDynamicLoader] = generateProtection( "VULKAN_HPP_DYNAMIC_LOADER_TOOL" );
+  auto const [enterDynamicLoader, leaveDynamicLoader] = generateProtection( "VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL" );
   usings += "\n" + enterDynamicLoader + replaceWithMap( usingTemplate, { { "className", "DynamicLoader" } } ) + leaveDynamicLoader + "\n";
 
   usings += replaceWithMap( usingTemplate, { { "className", "DispatchLoaderDynamic" } } ) + "\n";

--- a/snippets/defines.hpp
+++ b/snippets/defines.hpp
@@ -86,6 +86,14 @@ constexpr int False = 0;
 #  define VULKAN_HPP_CONST_OR_CONSTEXPR const
 #endif
 
+#if !defined( VULKAN_HPP_CONSTEXPR_INLINE )
+#  if 201606L <= __cpp_inline_variables
+#    define VULKAN_HPP_CONSTEXPR_INLINE VULKAN_HPP_CONSTEXPR inline
+#  else
+#    define VULKAN_HPP_CONSTEXPR_INLINE VULKAN_HPP_CONSTEXPR
+#  endif
+#endif
+
 #if !defined( VULKAN_HPP_NOEXCEPT )
 #  if defined( _MSC_VER ) && ( _MSC_VER <= 1800 )
 #    define VULKAN_HPP_NOEXCEPT

--- a/tests/Cpp20Modules/CMakeLists.txt
+++ b/tests/Cpp20Modules/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required( VERSION 3.25 )
 
 vulkan_hpp__setup_test( NAME Cpp20Modules CXX_STANDARD 20 LIBRARIES VulkanHppModule )
 
-if( NOT ( VULKAN_HPP_SAMPLES_BUILD_ONLY_DYNAMIC AND VULKAN_HPP_SAMPLES_BUILD_WITH_LOCAL_VULKAN_HPP ) )
+if( NOT VULKAN_HPP_SAMPLES_BUILD_ONLY_DYNAMIC )
 	target_link_libraries( Cpp20Modules PRIVATE Vulkan::Vulkan )
+	set_target_properties( Cpp20Modules PROPERTIES 
+		CXX_EXTENSIONS OFF
+	)
 endif()

--- a/vulkan/vulkan.cppm
+++ b/vulkan/vulkan.cppm
@@ -2764,9 +2764,9 @@ export namespace VULKAN_HPP_NAMESPACE
   using VULKAN_HPP_NAMESPACE::StructExtends;
 #endif /*VULKAN_HPP_DISABLE_ENHANCED_MODE*/
 
-#if defined( VULKAN_HPP_DYNAMIC_LOADER_TOOL )
+#if defined( VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL )
   using VULKAN_HPP_NAMESPACE::DynamicLoader;
-#endif /*VULKAN_HPP_DYNAMIC_LOADER_TOOL*/
+#endif /*VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL*/
 
   using VULKAN_HPP_NAMESPACE::DispatchLoaderDynamic;
 
@@ -2809,7 +2809,7 @@ export namespace VULKAN_HPP_NAMESPACE
   using VULKAN_HPP_NAMESPACE::isObsoletedExtension;
   using VULKAN_HPP_NAMESPACE::isPromotedExtension;
 
-  export namespace VULKAN_HPP_RAII_NAMESPACE
+  namespace VULKAN_HPP_RAII_NAMESPACE
   {
     //======================
     //=== RAII HARDCODED ===
@@ -2912,7 +2912,7 @@ export namespace VULKAN_HPP_NAMESPACE
     using VULKAN_HPP_RAII_NAMESPACE::BufferCollectionFUCHSIA;
 #endif /*VK_USE_PLATFORM_FUCHSIA*/
 
-    //=== VK_EXT_opacity_micromap ===
+       //=== VK_EXT_opacity_micromap ===
     using VULKAN_HPP_RAII_NAMESPACE::MicromapEXT;
 
     //=== VK_NV_optical_flow ===

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -212,6 +212,14 @@ constexpr int False = 0;
 #  define VULKAN_HPP_CONST_OR_CONSTEXPR const
 #endif
 
+#if !defined( VULKAN_HPP_CONSTEXPR_INLINE )
+#  if 201606L <= __cpp_inline_variables
+#    define VULKAN_HPP_CONSTEXPR_INLINE VULKAN_HPP_CONSTEXPR inline
+#  else
+#    define VULKAN_HPP_CONSTEXPR_INLINE VULKAN_HPP_CONSTEXPR
+#  endif
+#endif
+
 #if !defined( VULKAN_HPP_NOEXCEPT )
 #  if defined( _MSC_VER ) && ( _MSC_VER <= 1800 )
 #    define VULKAN_HPP_NOEXCEPT
@@ -6930,32 +6938,32 @@ namespace VULKAN_HPP_NAMESPACE
   //=========================================
   //=== CONSTEXPR CONSTANTs AND FUNCTIONs ===
   //=========================================
-  VULKAN_HPP_CONSTEXPR uint32_t AttachmentUnused                 = VK_ATTACHMENT_UNUSED;
-  VULKAN_HPP_CONSTEXPR uint32_t False                            = VK_FALSE;
-  VULKAN_HPP_CONSTEXPR float    LodClampNone                     = VK_LOD_CLAMP_NONE;
-  VULKAN_HPP_CONSTEXPR uint32_t LuidSize                         = VK_LUID_SIZE;
-  VULKAN_HPP_CONSTEXPR uint32_t MaxDescriptionSize               = VK_MAX_DESCRIPTION_SIZE;
-  VULKAN_HPP_CONSTEXPR uint32_t MaxDeviceGroupSize               = VK_MAX_DEVICE_GROUP_SIZE;
-  VULKAN_HPP_CONSTEXPR uint32_t MaxDriverInfoSize                = VK_MAX_DRIVER_INFO_SIZE;
-  VULKAN_HPP_CONSTEXPR uint32_t MaxDriverNameSize                = VK_MAX_DRIVER_NAME_SIZE;
-  VULKAN_HPP_CONSTEXPR uint32_t MaxExtensionNameSize             = VK_MAX_EXTENSION_NAME_SIZE;
-  VULKAN_HPP_CONSTEXPR uint32_t MaxGlobalPrioritySizeKhr         = VK_MAX_GLOBAL_PRIORITY_SIZE_KHR;
-  VULKAN_HPP_CONSTEXPR uint32_t MaxMemoryHeaps                   = VK_MAX_MEMORY_HEAPS;
-  VULKAN_HPP_CONSTEXPR uint32_t MaxMemoryTypes                   = VK_MAX_MEMORY_TYPES;
-  VULKAN_HPP_CONSTEXPR uint32_t MaxPhysicalDeviceNameSize        = VK_MAX_PHYSICAL_DEVICE_NAME_SIZE;
-  VULKAN_HPP_CONSTEXPR uint32_t MaxShaderModuleIdentifierSizeExt = VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT;
-  VULKAN_HPP_CONSTEXPR uint32_t QueueFamilyExternal              = VK_QUEUE_FAMILY_EXTERNAL;
-  VULKAN_HPP_CONSTEXPR uint32_t QueueFamilyForeignExt            = VK_QUEUE_FAMILY_FOREIGN_EXT;
-  VULKAN_HPP_CONSTEXPR uint32_t QueueFamilyIgnored               = VK_QUEUE_FAMILY_IGNORED;
-  VULKAN_HPP_CONSTEXPR uint32_t Remaining3DSlicesExt             = VK_REMAINING_3D_SLICES_EXT;
-  VULKAN_HPP_CONSTEXPR uint32_t RemainingArrayLayers             = VK_REMAINING_ARRAY_LAYERS;
-  VULKAN_HPP_CONSTEXPR uint32_t RemainingMipLevels               = VK_REMAINING_MIP_LEVELS;
-  VULKAN_HPP_CONSTEXPR uint32_t ShaderUnusedKhr                  = VK_SHADER_UNUSED_KHR;
-  VULKAN_HPP_CONSTEXPR uint32_t SubpassExternal                  = VK_SUBPASS_EXTERNAL;
-  VULKAN_HPP_CONSTEXPR uint32_t True                             = VK_TRUE;
-  VULKAN_HPP_CONSTEXPR uint32_t UuidSize                         = VK_UUID_SIZE;
-  VULKAN_HPP_CONSTEXPR uint64_t WholeSize                        = VK_WHOLE_SIZE;
-  VULKAN_HPP_CONSTEXPR uint32_t HeaderVersion                    = VK_HEADER_VERSION;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t AttachmentUnused                 = VK_ATTACHMENT_UNUSED;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t False                            = VK_FALSE;
+  VULKAN_HPP_CONSTEXPR_INLINE float    LodClampNone                     = VK_LOD_CLAMP_NONE;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t LuidSize                         = VK_LUID_SIZE;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t MaxDescriptionSize               = VK_MAX_DESCRIPTION_SIZE;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t MaxDeviceGroupSize               = VK_MAX_DEVICE_GROUP_SIZE;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t MaxDriverInfoSize                = VK_MAX_DRIVER_INFO_SIZE;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t MaxDriverNameSize                = VK_MAX_DRIVER_NAME_SIZE;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t MaxExtensionNameSize             = VK_MAX_EXTENSION_NAME_SIZE;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t MaxGlobalPrioritySizeKhr         = VK_MAX_GLOBAL_PRIORITY_SIZE_KHR;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t MaxMemoryHeaps                   = VK_MAX_MEMORY_HEAPS;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t MaxMemoryTypes                   = VK_MAX_MEMORY_TYPES;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t MaxPhysicalDeviceNameSize        = VK_MAX_PHYSICAL_DEVICE_NAME_SIZE;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t MaxShaderModuleIdentifierSizeExt = VK_MAX_SHADER_MODULE_IDENTIFIER_SIZE_EXT;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t QueueFamilyExternal              = VK_QUEUE_FAMILY_EXTERNAL;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t QueueFamilyForeignExt            = VK_QUEUE_FAMILY_FOREIGN_EXT;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t QueueFamilyIgnored               = VK_QUEUE_FAMILY_IGNORED;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t Remaining3DSlicesExt             = VK_REMAINING_3D_SLICES_EXT;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t RemainingArrayLayers             = VK_REMAINING_ARRAY_LAYERS;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t RemainingMipLevels               = VK_REMAINING_MIP_LEVELS;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t ShaderUnusedKhr                  = VK_SHADER_UNUSED_KHR;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t SubpassExternal                  = VK_SUBPASS_EXTERNAL;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t True                             = VK_TRUE;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t UuidSize                         = VK_UUID_SIZE;
+  VULKAN_HPP_CONSTEXPR_INLINE uint64_t WholeSize                        = VK_WHOLE_SIZE;
+  VULKAN_HPP_CONSTEXPR_INLINE uint32_t HeaderVersion                    = VK_HEADER_VERSION;
 
   template <typename T, typename = typename std::enable_if<std::is_integral<T>::value>::type>
   VULKAN_HPP_CONSTEXPR uint32_t apiVersionMajor( T const version )
@@ -7015,12 +7023,12 @@ namespace VULKAN_HPP_NAMESPACE
     return ( (uint32_t)(version)&0xFFFU );
   }
 
-  VULKAN_HPP_CONSTEXPR auto ApiVersion            = makeApiVersion( 0, 1, 0, 0 );
-  VULKAN_HPP_CONSTEXPR auto ApiVersion10          = makeApiVersion( 0, 1, 0, 0 );
-  VULKAN_HPP_CONSTEXPR auto ApiVersion11          = makeApiVersion( 0, 1, 1, 0 );
-  VULKAN_HPP_CONSTEXPR auto ApiVersion12          = makeApiVersion( 0, 1, 2, 0 );
-  VULKAN_HPP_CONSTEXPR auto ApiVersion13          = makeApiVersion( 0, 1, 3, 0 );
-  VULKAN_HPP_CONSTEXPR auto HeaderVersionComplete = makeApiVersion( 0, 1, 3, VK_HEADER_VERSION );
+  VULKAN_HPP_CONSTEXPR_INLINE auto ApiVersion            = makeApiVersion( 0, 1, 0, 0 );
+  VULKAN_HPP_CONSTEXPR_INLINE auto ApiVersion10          = makeApiVersion( 0, 1, 0, 0 );
+  VULKAN_HPP_CONSTEXPR_INLINE auto ApiVersion11          = makeApiVersion( 0, 1, 1, 0 );
+  VULKAN_HPP_CONSTEXPR_INLINE auto ApiVersion12          = makeApiVersion( 0, 1, 2, 0 );
+  VULKAN_HPP_CONSTEXPR_INLINE auto ApiVersion13          = makeApiVersion( 0, 1, 3, 0 );
+  VULKAN_HPP_CONSTEXPR_INLINE auto HeaderVersionComplete = makeApiVersion( 0, 1, 3, VK_HEADER_VERSION );
 
 }  // namespace VULKAN_HPP_NAMESPACE
 


### PR DESCRIPTION
Resolves #1614 and partially resolves #1615. 

- Removed nested `export` keyword for `vk::raii` namespace in C++ module file
- Fixed macro in `vulkan.cppm` for `vk::DynamicLoader`: changed from `VULKAN_HPP_DYNAMIC_LOADER_TOOL` to `VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL`  
- Moved `VulkanHppModule` library target before generator in top-level `CMakeLists.txt`
- Fixed `CMakeLists.txt` for `Cpp20Modules` executable target