### PR TITLE
fix: add support for C++20 modules for CMake 3.27.0/3.27.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,15 @@
 
 if( VULKAN_HPP_ENABLE_EXPERIMENTAL_CPP20_MODULES )
 	cmake_minimum_required( VERSION 3.25 )
-	if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.26 )
-		# CMake 3.26; need to handle future versions here
+	if ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.28 )
+		message(FATAL_ERROR "VULKAN_HPP_ENABLE_EXPERIMENTAL_CPP20_MODULES is currently not supported for CMake version ${CMAKE_VERSION}!"
+		" To add support inform yourself about the state of the feature at https://github.com/Kitware/CMake/blob/master/Help/dev/experimental.rst"
+		" and add the corresponding value of CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API to Vulkan-Hpp's CMakeLists.txt")
+	elseif ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.27 )
+		# CMake 3.27/3.27.1
+		set( CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API aa1f7df0-828a-4fcd-9afc-2dc80491aca7 )
+	elseif ( ${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.26 )
+		# CMake 3.26
 		set( CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API 2182bf5c-ef0d-489a-91da-49dbc3090d2a )
 	else()
 		# CMake 3.25


### PR DESCRIPTION
When using `VULKAN_HPP_ENABLE_EXPERIMENTAL_CPP20_MODULES=ON` with CMake 3.27.0 or 3.27.1, you will get a very confusing error message:
```
CMake Error at CMakeLists.txt:346 (target_sources):
  target_sources File set TYPE may only be "HEADERS"
```

This is because the value of `CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API` is not updated to the correct value, disabling all experimental CMake features.

This PR adds the value for 3.27.X and triggers an error for higher CMake versions where this feature needs to be revised and `CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API` if the feature is still experimental.

The error message will look similar to this one (simulated for CMake 3.27.1)
```
CMake Error at CMakeLists.txt:30 (message):
  VULKAN_HPP_ENABLE_EXPERIMENTAL_CPP20_MODULES is currently not supported for
  CMake version 3.27.1! To add support inform yourself about the state of the
  feature at
  https://github.com/Kitware/CMake/blob/master/Help/dev/experimental.rst and
  add the corresponding value of CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API to
  Vulkan-Hpp's CMakeLists.txt
```

The value for `CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API` can be found here https://github.com/Kitware/CMake/blob/v3.27.0/Help/dev/experimental.rst. It already has changed for the next CMake version in https://github.com/Kitware/CMake/commit/57ef353d222d7618f8fb872487aa70e205e56020. The most recent value is documented here https://github.com/Kitware/CMake/blob/master/Help/dev/experimental.rst