### PR TITLE
Fix validation layer warning on minImageCount of 2.

### DIFF
--- a/RAII_Samples/05_InitSwapchain/05_InitSwapchain.cpp
+++ b/RAII_Samples/05_InitSwapchain/05_InitSwapchain.cpp
@@ -120,7 +120,7 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     vk::SwapchainCreateInfoKHR swapChainCreateInfo( vk::SwapchainCreateFlagsKHR(),
                                                     *surface,
-                                                    surfaceCapabilities.minImageCount,
+                                                    vk::su::clamp( 3u, surfaceCapabilities.minImageCount, surfaceCapabilities.maxImageCount ),
                                                     format,
                                                     vk::ColorSpaceKHR::eSrgbNonlinear,
                                                     swapchainExtent,

--- a/RAII_Samples/utils/utils.hpp
+++ b/RAII_Samples/utils/utils.hpp
@@ -367,7 +367,7 @@ namespace vk
           vk::PresentModeKHR         presentMode = vk::su::pickPresentMode( physicalDevice.getSurfacePresentModesKHR( *surface ) );
           vk::SwapchainCreateInfoKHR swapChainCreateInfo( {},
                                                           *surface,
-                                                          surfaceCapabilities.minImageCount,
+                                                          vk::su::clamp( 3u, surfaceCapabilities.minImageCount, surfaceCapabilities.maxImageCount ),
                                                           colorFormat,
                                                           surfaceFormat.colorSpace,
                                                           swapchainExtent,

--- a/samples/05_InitSwapchain/05_InitSwapchain.cpp
+++ b/samples/05_InitSwapchain/05_InitSwapchain.cpp
@@ -123,7 +123,7 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     vk::SwapchainCreateInfoKHR swapChainCreateInfo( vk::SwapchainCreateFlagsKHR(),
                                                     surface,
-                                                    surfaceCapabilities.minImageCount,
+                                                    vk::su::clamp( 3u, surfaceCapabilities.minImageCount, surfaceCapabilities.maxImageCount ),
                                                     format,
                                                     vk::ColorSpaceKHR::eSrgbNonlinear,
                                                     swapchainExtent,
@@ -161,7 +161,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       imageViews.push_back( device.createImageView( imageViewCreateInfo ) );
     }
 
-    // destroy the imageViews, the swapChain,and the surface
+    // destroy the imageViews, the swapChain, and the surface
     for ( auto & imageView : imageViews )
     {
       device.destroyImageView( imageView );

--- a/samples/utils/utils.cpp
+++ b/samples/utils/utils.cpp
@@ -833,7 +833,7 @@ namespace vk
       vk::PresentModeKHR         presentMode = vk::su::pickPresentMode( physicalDevice.getSurfacePresentModesKHR( surface ) );
       vk::SwapchainCreateInfoKHR swapChainCreateInfo( {},
                                                       surface,
-                                                      surfaceCapabilities.minImageCount,
+                                                      vk::su::clamp( 3u, surfaceCapabilities.minImageCount, surfaceCapabilities.maxImageCount ),
                                                       colorFormat,
                                                       surfaceFormat.colorSpace,
                                                       swapchainExtent,


### PR DESCRIPTION
Resolves validation layer best-practices warning:
`A Swapchain is being created with minImageCount set to 2, which means double buffering is going to be used. Using double buffering and vsync locks rendering to an integer fraction of the vsync rate. In turn, reducing the performance of the application if rendering is slower than vsync. Consider setting minImageCount to 3 to use triple buffering to maximize performance in such cases.`