### PR TITLE
Guard vk::raii names in vulkan.cppm just as in vulkan_raii.hpp.

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -725,9 +725,11 @@ export namespace VULKAN_HPP_NAMESPACE
 {
   ${usings}
 
+#if !defined( VULKAN_HPP_DISABLE_ENHANCED_MODE ) && !defined( VULKAN_HPP_NO_EXCEPTIONS )
   namespace VULKAN_HPP_RAII_NAMESPACE {
     ${raiiUsings}
   } // namespace VULKAN_HPP_RAII_NAMESPACE
+#endif
 } // namespace VULKAN_HPP_NAMESPACE
 )";
 

--- a/vulkan/vulkan.cppm
+++ b/vulkan/vulkan.cppm
@@ -2929,6 +2929,7 @@ export namespace VULKAN_HPP_NAMESPACE
   using VULKAN_HPP_NAMESPACE::isObsoletedExtension;
   using VULKAN_HPP_NAMESPACE::isPromotedExtension;
 
+#if !defined( VULKAN_HPP_DISABLE_ENHANCED_MODE ) && !defined( VULKAN_HPP_NO_EXCEPTIONS )
   namespace VULKAN_HPP_RAII_NAMESPACE
   {
     //======================
@@ -3027,10 +3028,10 @@ export namespace VULKAN_HPP_NAMESPACE
     //=== VK_NV_device_generated_commands ===
     using VULKAN_HPP_RAII_NAMESPACE::IndirectCommandsLayoutNV;
 
-#if defined( VK_USE_PLATFORM_FUCHSIA )
+#  if defined( VK_USE_PLATFORM_FUCHSIA )
     //=== VK_FUCHSIA_buffer_collection ===
     using VULKAN_HPP_RAII_NAMESPACE::BufferCollectionFUCHSIA;
-#endif /*VK_USE_PLATFORM_FUCHSIA*/
+#  endif /*VK_USE_PLATFORM_FUCHSIA*/
 
     //=== VK_EXT_opacity_micromap ===
     using VULKAN_HPP_RAII_NAMESPACE::MicromapEXT;
@@ -3043,4 +3044,5 @@ export namespace VULKAN_HPP_NAMESPACE
     using VULKAN_HPP_RAII_NAMESPACE::ShaderEXTs;
 
   }  // namespace VULKAN_HPP_RAII_NAMESPACE
+#endif
 }  // namespace VULKAN_HPP_NAMESPACE

--- a/vulkan/vulkansc.cppm
+++ b/vulkan/vulkansc.cppm
@@ -1403,6 +1403,7 @@ export namespace VULKAN_HPP_NAMESPACE
   using VULKAN_HPP_NAMESPACE::isObsoletedExtension;
   using VULKAN_HPP_NAMESPACE::isPromotedExtension;
 
+#if !defined( VULKAN_HPP_DISABLE_ENHANCED_MODE ) && !defined( VULKAN_HPP_NO_EXCEPTIONS )
   namespace VULKAN_HPP_RAII_NAMESPACE
   {
     //======================
@@ -1471,10 +1472,11 @@ export namespace VULKAN_HPP_NAMESPACE
     //=== VK_EXT_debug_utils ===
     using VULKAN_HPP_RAII_NAMESPACE::DebugUtilsMessengerEXT;
 
-#if defined( VK_USE_PLATFORM_SCI )
+#  if defined( VK_USE_PLATFORM_SCI )
     //=== VK_NV_external_sci_sync2 ===
     using VULKAN_HPP_RAII_NAMESPACE::SemaphoreSciSyncPoolNV;
-#endif /*VK_USE_PLATFORM_SCI*/
+#  endif /*VK_USE_PLATFORM_SCI*/
 
   }  // namespace VULKAN_HPP_RAII_NAMESPACE
+#endif
 }  // namespace VULKAN_HPP_NAMESPACE


### PR DESCRIPTION
#Resolves #1648.