### PR TITLE
Extend command generation to support not returning some return stuff and not templatizing a void pointer.

### DIFF
--- a/VulkanHppGenerator.hpp
+++ b/VulkanHppGenerator.hpp
@@ -36,6 +36,12 @@ public:
 
   constexpr explicit Flags( MaskType flags ) noexcept : m_mask( flags ) {}
 
+  constexpr Flags<BitType> & operator|=( Flags<BitType> const & rhs ) noexcept
+  {
+    m_mask |= rhs.m_mask;
+    return *this;
+  }
+
   constexpr bool operator!() const noexcept
   {
     return !m_mask;
@@ -66,7 +72,9 @@ enum class CommandFlavourFlagBits : uint8_t
   chained       = 1 << 1,
   singular      = 1 << 2,
   unique        = 1 << 3,
-  withAllocator = 1 << 4
+  withAllocator = 1 << 4,
+  noReturn      = 1 << 5,
+  keepVoidPtr   = 1 << 6
 };
 using CommandFlavourFlags = Flags<CommandFlavourFlagBits>;
 
@@ -479,7 +487,8 @@ private:
                                              bool                     nonConstPointerAsNullptr,
                                              std::set<size_t> const & singularParams,
                                              std::set<size_t> const & templatedParams,
-                                             bool                     raiiHandleMemberFunction ) const;
+                                             bool                     raiiHandleMemberFunction,
+                                             CommandFlavourFlags      flavourFlags ) const;
   std::string generateCallArgumentsRAIIFactory( std::vector<ParamData> const & params,
                                                 size_t                         initialSkipCount,
                                                 std::set<size_t> const &       skippedParams,
@@ -489,7 +498,8 @@ private:
                                             size_t                         paramIndex,
                                             bool                           nonConstPointerAsNullptr,
                                             std::set<size_t> const &       singularParams,
-                                            std::set<size_t> const &       templatedParams ) const;
+                                            std::set<size_t> const &       templatedParams,
+                                            CommandFlavourFlags            flavourFlags ) const;
   std::string generateCallArgumentEnhancedConstPointer( ParamData const &        param,
                                                         size_t                   paramIndex,
                                                         std::set<size_t> const & singularParams,
@@ -498,7 +508,10 @@ private:
                                                            size_t                   paramIndex,
                                                            bool                     nonConstPointerAsNullptr,
                                                            std::set<size_t> const & singularParams ) const;
-  std::string generateCallArgumentEnhancedValue( std::vector<ParamData> const & params, size_t paramIndex, std::set<size_t> const & singularParams ) const;
+  std::string generateCallArgumentEnhancedValue( std::vector<ParamData> const & params,
+                                                 size_t                         paramIndex,
+                                                 std::set<size_t> const &       singularParams,
+                                                 CommandFlavourFlags            flavourFlags ) const;
   std::string generateCallSequence( std::string const &                       name,
                                     CommandData const &                       commandData,
                                     std::vector<size_t> const &               returnParams,

--- a/vulkan/vulkan_funcs.hpp
+++ b/vulkan/vulkan_funcs.hpp
@@ -19496,6 +19496,17 @@ namespace VULKAN_HPP_NAMESPACE
   }
 
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+  template <typename Dispatch>
+  VULKAN_HPP_INLINE void Device::getDescriptorEXT( const VULKAN_HPP_NAMESPACE::DescriptorGetInfoEXT & descriptorInfo,
+                                                   size_t                                             dataSize,
+                                                   void *                                             pDescriptor,
+                                                   Dispatch const &                                   d ) const VULKAN_HPP_NOEXCEPT
+  {
+    VULKAN_HPP_ASSERT( d.getVkHeaderVersion() == VK_HEADER_VERSION );
+
+    d.vkGetDescriptorEXT( m_device, reinterpret_cast<const VkDescriptorGetInfoEXT *>( &descriptorInfo ), dataSize, pDescriptor );
+  }
+
   template <typename DescriptorType, typename Dispatch>
   VULKAN_HPP_NODISCARD VULKAN_HPP_INLINE DescriptorType Device::getDescriptorEXT( const VULKAN_HPP_NAMESPACE::DescriptorGetInfoEXT & descriptorInfo,
                                                                                   Dispatch const & d ) const VULKAN_HPP_NOEXCEPT

--- a/vulkan/vulkan_handles.hpp
+++ b/vulkan/vulkan_handles.hpp
@@ -12578,6 +12578,11 @@ namespace VULKAN_HPP_NAMESPACE
                            void *                                             pDescriptor,
                            Dispatch const & d                                 VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) const VULKAN_HPP_NOEXCEPT;
 #ifndef VULKAN_HPP_DISABLE_ENHANCED_MODE
+    template <typename Dispatch = VULKAN_HPP_DEFAULT_DISPATCHER_TYPE>
+    void getDescriptorEXT( const VULKAN_HPP_NAMESPACE::DescriptorGetInfoEXT & descriptorInfo,
+                           size_t                                             dataSize,
+                           void *                                             pDescriptor,
+                           Dispatch const & d                                 VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) const VULKAN_HPP_NOEXCEPT;
     template <typename DescriptorType, typename Dispatch = VULKAN_HPP_DEFAULT_DISPATCHER_TYPE>
     VULKAN_HPP_NODISCARD DescriptorType getDescriptorEXT( const VULKAN_HPP_NAMESPACE::DescriptorGetInfoEXT & descriptorInfo,
                                                           Dispatch const & d VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) const VULKAN_HPP_NOEXCEPT;

--- a/vulkan/vulkan_raii.hpp
+++ b/vulkan/vulkan_raii.hpp
@@ -4203,6 +4203,8 @@ namespace VULKAN_HPP_NAMESPACE
 
       //=== VK_EXT_descriptor_buffer ===
 
+      void getDescriptorEXT( const VULKAN_HPP_NAMESPACE::DescriptorGetInfoEXT & descriptorInfo, size_t dataSize, void * pDescriptor ) const VULKAN_HPP_NOEXCEPT;
+
       template <typename DescriptorType>
       VULKAN_HPP_NODISCARD DescriptorType getDescriptorEXT( const VULKAN_HPP_NAMESPACE::DescriptorGetInfoEXT & descriptorInfo ) const VULKAN_HPP_NOEXCEPT;
 
@@ -19149,6 +19151,16 @@ namespace VULKAN_HPP_NAMESPACE
         static_cast<VkDevice>( m_device ), static_cast<VkDescriptorSetLayout>( m_descriptorSetLayout ), binding, reinterpret_cast<VkDeviceSize *>( &offset ) );
 
       return offset;
+    }
+
+    VULKAN_HPP_INLINE void Device::getDescriptorEXT( const VULKAN_HPP_NAMESPACE::DescriptorGetInfoEXT & descriptorInfo,
+                                                     size_t                                             dataSize,
+                                                     void *                                             pDescriptor ) const VULKAN_HPP_NOEXCEPT
+    {
+      VULKAN_HPP_ASSERT( getDispatcher()->vkGetDescriptorEXT && "Function <vkGetDescriptorEXT> requires <VK_EXT_descriptor_buffer>" );
+
+      getDispatcher()->vkGetDescriptorEXT(
+        static_cast<VkDevice>( m_device ), reinterpret_cast<const VkDescriptorGetInfoEXT *>( &descriptorInfo ), dataSize, pDescriptor );
     }
 
     template <typename DescriptorType>


### PR DESCRIPTION
Used to add some special handling capabilities for specific commands.

Resolves #1655.