### PR TITLE
Update workflow deps

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -18,7 +18,7 @@ jobs:
         cxx_standard: [11, 14, 17, 20]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -21,7 +21,7 @@ jobs:
         cxx_standard: [11, 14, 17, 20]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -16,7 +16,7 @@ jobs:
         build_type: [Debug, Release]
         cxx_standard: [11, 14, 17, 20]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 

--- a/.github/workflows/set-version-tag.yml
+++ b/.github/workflows/set-version-tag.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     

--- a/.github/workflows/update-header-pr.yml
+++ b/.github/workflows/update-header-pr.yml
@@ -15,7 +15,7 @@ jobs:
         cxx_standard: [11]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     
@@ -65,7 +65,7 @@ jobs:
         git clean -xf
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@v5
       with:
         commit-message: Update Vulkan-Headers to ${{ env.VK_HEADER_GIT_TAG }}
         title: Update Vulkan-Headers to ${{ env.VK_HEADER_GIT_TAG }}

--- a/.github/workflows/update-header-pr.yml
+++ b/.github/workflows/update-header-pr.yml
@@ -38,8 +38,8 @@ jobs:
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build
-            -DSAMPLES_BUILD=OFF
-            -DTESTS_BUILD=OFF
+            -DVULKAN_HPP_SAMPLES_BUILD=OFF
+            -DVULKAN_HPP_TESTS_BUILD=OFF
             -DVULKAN_HPP_RUN_GENERATOR=ON
             -DCMAKE_CXX_COMPILER=${{matrix.cxx_compiler}}
             -DCMAKE_CXX_STANDARD=${{matrix.cxx_standard}}


### PR DESCRIPTION
Update the used workflows to their newest version to suppress deprecation warnings as in https://github.com/KhronosGroup/Vulkan-Hpp/actions/runs/6319631419

Smoke test for the update-headers-pr seems to still run as before
https://github.com/theHamsta/Vulkan-Hpp/actions/runs/6325102376/job/17175926924

Also replace
```
            -DSAMPLES_BUILD=OFF
            -DTESTS_BUILD=OFF
```
with the actually existing CMake options.