### PR TITLE
Use vk::Format that matches coloredCubeData in DynamicUniform RAII sample

### DIFF
--- a/RAII_Samples/DynamicUniform/DynamicUniform.cpp
+++ b/RAII_Samples/DynamicUniform/DynamicUniform.cpp
@@ -132,7 +132,7 @@ int main( int /*argc*/, char ** /*argv*/ )
                                                                               fragmentShaderModule,
                                                                               nullptr,
                                                                               sizeof( coloredCubeData[0] ),
-                                                                              { { vk::Format::eR32G32B32A32Sfloat, 0 }, { vk::Format::eR32G32Sfloat, 16 } },
+                                                                              { { vk::Format::eR32G32B32A32Sfloat, 0 }, { vk::Format::eR32G32B32A32Sfloat, 16 } },
                                                                               vk::FrontFace::eClockwise,
                                                                               true,
                                                                               pipelineLayout,


### PR DESCRIPTION
Hi! The samples in this repository are a gem to anyone learning Vulkan.
I stumbled upon a subtle logical error.
The chosen `vk::Format` in the DynamicUniform RAII sample does not match `coloredCubeData`, which results in some information about color being discarded.
The corresponding [sample](https://github.com/KhronosGroup/Vulkan-Hpp/blob/4cb522cc511de9826b0691361ef2c786d3582b07/samples/DynamicUniform/DynamicUniform.cpp#L140) from the `vk` namespace uses the correct format.
Since these code snippets carry educational purpose, we should fix this issue to avoid confusion.