### PR TITLE
Add missing includes

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -138,6 +138,8 @@ void VulkanHppGenerator::generateExtensionInspectionFile() const
 
 #include <map>
 #include <set>
+#include <string>
+#include <vector>
 #include <vulkan/${api}.hpp>
 
 namespace VULKAN_HPP_NAMESPACE

--- a/vulkan/vulkan_extension_inspection.hpp
+++ b/vulkan/vulkan_extension_inspection.hpp
@@ -10,6 +10,8 @@
 
 #include <map>
 #include <set>
+#include <string>
+#include <vector>
 #include <vulkan/vulkan.hpp>
 
 namespace VULKAN_HPP_NAMESPACE

--- a/vulkan/vulkansc_extension_inspection.hpp
+++ b/vulkan/vulkansc_extension_inspection.hpp
@@ -10,6 +10,8 @@
 
 #include <map>
 #include <set>
+#include <string>
+#include <vector>
 #include <vulkan/vulkansc.hpp>
 
 namespace VULKAN_HPP_NAMESPACE


### PR DESCRIPTION
Hi! This adds some missing includes to `vulkan_extension_inspection.hpp` - when disabling enhanced mode they're not pulled in from `vulkan.hpp`, resulting in build errors in `vulkan.cppm`. Thanks!