### PR TITLE
Use the actual CMAKE_CXX_STANDARD provided by the workflow.

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -12,13 +12,11 @@ jobs:
     strategy:
       matrix:
         build_type: [Debug, Release]
-        compiler:
-          - {cxx: "g++-9", c: "gcc-9"}
-          - {cxx: "g++-10", c: "gcc-10"}
-          - {cxx: "g++-11", c: "gcc-11"}
-          - {cxx: "clang++-13", c: "clang-13"}
-          - {cxx: "clang++-14", c: "clang-14"}
-        cxx_standard: [11, 14, 17, 20, 23]
+        compiler: [clang++-13, clang++-14, g++-9, g++-10, g++-11]
+        cxx_standard: [11, 14, 17, 20]
+        include:
+          - compiler: g++-11
+            cxx_standard: 23
 
     steps:
     - uses: actions/checkout@v4
@@ -42,8 +40,7 @@ jobs:
             -DVULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC=ON
             -DVULKAN_HPP_TESTS_BUILD_WITH_LOCAL_VULKAN_HPP=ON
             -DVULKAN_HPP_RUN_GENERATOR=ON
-            -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
-            -DCMAKE_C_COMPILER=${{matrix.compiler.c}}
+            -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
             -DCMAKE_CXX_STANDARD=${{matrix.cxx_standard}}
             -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
             

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+if ( NOT CMAKE_CXX_STANDARD )
+	set( CMAKE_CXX_STANDARD 11 )
+endif()
+
 # all the options for this project
 option( VULKAN_HPP_PRECOMPILE "Precompile vulkan.hpp and vulkan_raii.hpp for sample builds" ON )
 option( VULKAN_HPP_RUN_GENERATOR "Run the HPP generator" OFF )
@@ -121,7 +125,6 @@ function( vulkan_hpp__setup_library )
 		vulkan_hpp__setup_platform( NAME ${TARGET_NAME} )
 		vulkan_hpp__setup_vulkan_include( NAME ${TARGET_NAME} )
 		vulkan_hpp__setup_warning_level( NAME ${TARGET_NAME} )
-		set_target_properties( ${TARGET_NAME} PROPERTIES CXX_STANDARD 11 )
 		set_target_properties( ${TARGET_NAME} PROPERTIES CXX_STANDARD_REQUIRED ON )
 	endif()
 	set_target_properties( ${TARGET_NAME} PROPERTIES FOLDER ${TARGET_FOLDER} )
@@ -145,7 +148,7 @@ function( vulkan_hpp__setup_sample )
 	vulkan_hpp__setup_vulkan_include( NAME ${TARGET_NAME} )
 	vulkan_hpp__setup_warning_level( NAME ${TARGET_NAME} )
 
-	set_target_properties( ${TARGET_NAME} PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON )
+	set_target_properties( ${TARGET_NAME} PROPERTIES CXX_STANDARD_REQUIRED ON )
 
 	if( TARGET_FOLDER )
 		set_target_properties( ${TARGET_NAME} PROPERTIES FOLDER "${TARGET_FOLDER}" )
@@ -252,7 +255,7 @@ function( vulkan_hpp__setup_test )
 		message( FATAL_ERROR "NAME must be defined in vulkan_hpp__setup_test" )
 	endif()
 	if( NOT TARGET_CXX_STANDARD )
-		set( TARGET_CXX_STANDARD 11 )
+		set( TARGET_CXX_STANDARD ${CMAKE_CXX_STANDARD} )
 	endif()
 
 	vulkan_hpp__setup_project( NAME ${TARGET_NAME} )


### PR DESCRIPTION
Note: under Linux, none of clang++13, clang++14, g++-9, and g++-10 could successfully compile for C++23!