### PR TITLE
Introduce implicit cast operators for vk::UniqueHandles, vk::SharedHandles and vk::raii::Handles

### DIFF
--- a/RAII_Samples/04_InitCommandBuffer/04_InitCommandBuffer.cpp
+++ b/RAII_Samples/04_InitCommandBuffer/04_InitCommandBuffer.cpp
@@ -43,7 +43,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::raii::CommandPool     commandPool( device, commandPoolCreateInfo );
 
     // allocate a CommandBuffer from the CommandPool
-    vk::CommandBufferAllocateInfo commandBufferAllocateInfo( *commandPool, vk::CommandBufferLevel::ePrimary, 1 );
+    vk::CommandBufferAllocateInfo commandBufferAllocateInfo( commandPool, vk::CommandBufferLevel::ePrimary, 1 );
     vk::raii::CommandBuffer       commandBuffer = std::move( vk::raii::CommandBuffers( device, commandBufferAllocateInfo ).front() );
 
     /* VULKAN_HPP_KEY_END */

--- a/RAII_Samples/05_InitSwapchain/05_InitSwapchain.cpp
+++ b/RAII_Samples/05_InitSwapchain/05_InitSwapchain.cpp
@@ -47,7 +47,7 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     // determine a queueFamilyIndex that suports present
     // first check if the graphicsQueueFamiliyIndex is good enough
-    uint32_t presentQueueFamilyIndex = physicalDevice.getSurfaceSupportKHR( graphicsQueueFamilyIndex, *surface )
+    uint32_t presentQueueFamilyIndex = physicalDevice.getSurfaceSupportKHR( graphicsQueueFamilyIndex, surface )
                                        ? graphicsQueueFamilyIndex
                                        : vk::su::checked_cast<uint32_t>( queueFamilyProperties.size() );
     if ( presentQueueFamilyIndex == queueFamilyProperties.size() )
@@ -57,7 +57,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       for ( size_t i = 0; i < queueFamilyProperties.size(); i++ )
       {
         if ( ( queueFamilyProperties[i].queueFlags & vk::QueueFlagBits::eGraphics ) &&
-             physicalDevice.getSurfaceSupportKHR( vk::su::checked_cast<uint32_t>( i ), *surface ) )
+             physicalDevice.getSurfaceSupportKHR( vk::su::checked_cast<uint32_t>( i ), surface ) )
         {
           graphicsQueueFamilyIndex = vk::su::checked_cast<uint32_t>( i );
           presentQueueFamilyIndex  = graphicsQueueFamilyIndex;
@@ -70,7 +70,7 @@ int main( int /*argc*/, char ** /*argv*/ )
         // family index that supports present
         for ( size_t i = 0; i < queueFamilyProperties.size(); i++ )
         {
-          if ( physicalDevice.getSurfaceSupportKHR( vk::su::checked_cast<uint32_t>( i ), *surface ) )
+          if ( physicalDevice.getSurfaceSupportKHR( vk::su::checked_cast<uint32_t>( i ), surface ) )
           {
             presentQueueFamilyIndex = vk::su::checked_cast<uint32_t>( i );
             break;
@@ -87,11 +87,11 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::raii::Device device = vk::raii::su::makeDevice( physicalDevice, graphicsQueueFamilyIndex, vk::su::getDeviceExtensions() );
 
     // get the supported VkFormats
-    std::vector<vk::SurfaceFormatKHR> formats = physicalDevice.getSurfaceFormatsKHR( *surface );
+    std::vector<vk::SurfaceFormatKHR> formats = physicalDevice.getSurfaceFormatsKHR( surface );
     assert( !formats.empty() );
     vk::Format format = ( formats[0].format == vk::Format::eUndefined ) ? vk::Format::eB8G8R8A8Unorm : formats[0].format;
 
-    vk::SurfaceCapabilitiesKHR surfaceCapabilities = physicalDevice.getSurfaceCapabilitiesKHR( *surface );
+    vk::SurfaceCapabilitiesKHR surfaceCapabilities = physicalDevice.getSurfaceCapabilitiesKHR( surface );
     vk::Extent2D               swapchainExtent;
     if ( surfaceCapabilities.currentExtent.width == std::numeric_limits<uint32_t>::max() )
     {
@@ -119,7 +119,7 @@ int main( int /*argc*/, char ** /*argv*/ )
                                                                                                          : vk::CompositeAlphaFlagBitsKHR::eOpaque;
 
     vk::SwapchainCreateInfoKHR swapChainCreateInfo( vk::SwapchainCreateFlagsKHR(),
-                                                    *surface,
+                                                    surface,
                                                     vk::su::clamp( 3u, surfaceCapabilities.minImageCount, surfaceCapabilities.maxImageCount ),
                                                     format,
                                                     vk::ColorSpaceKHR::eSrgbNonlinear,

--- a/RAII_Samples/06_InitDepthBuffer/06_InitDepthBuffer.cpp
+++ b/RAII_Samples/06_InitDepthBuffer/06_InitDepthBuffer.cpp
@@ -87,9 +87,9 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     vk::MemoryAllocateInfo memoryAllocateInfo( memoryRequirements.size, typeIndex );
     vk::raii::DeviceMemory depthMemory( device, memoryAllocateInfo );
-    depthImage.bindMemory( *depthMemory, 0 );
+    depthImage.bindMemory( depthMemory, 0 );
 
-    vk::ImageViewCreateInfo imageViewCreateInfo( {}, *depthImage, vk::ImageViewType::e2D, depthFormat, {}, { vk::ImageAspectFlagBits::eDepth, 0, 1, 0, 1 } );
+    vk::ImageViewCreateInfo imageViewCreateInfo( {}, depthImage, vk::ImageViewType::e2D, depthFormat, {}, { vk::ImageAspectFlagBits::eDepth, 0, 1, 0, 1 } );
     vk::raii::ImageView     depthView( device, imageViewCreateInfo );
 
     // while all vk::raii objects are automatically destroyed on scope leave, the Image should to be destroyed before the bound DeviceMemory

--- a/RAII_Samples/07_InitUniformBuffer/07_InitUniformBuffer.cpp
+++ b/RAII_Samples/07_InitUniformBuffer/07_InitUniformBuffer.cpp
@@ -76,7 +76,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     memcpy( pData, &mvpc, sizeof( mvpc ) );
     uniformDataMemory.unmapMemory();
 
-    uniformDataBuffer.bindMemory( *uniformDataMemory, 0 );
+    uniformDataBuffer.bindMemory( uniformDataMemory, 0 );
 
     // while all vk::raii objects are automatically destroyed on scope leave, the Buffer should to be destroyed before the bound DeviceMemory
     // but the standard destruction order would destroy the DeviceMemory before the Buffer, so destroy the Buffer here

--- a/RAII_Samples/09_InitDescriptorSet/09_InitDescriptorSet.cpp
+++ b/RAII_Samples/09_InitDescriptorSet/09_InitDescriptorSet.cpp
@@ -64,11 +64,11 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::raii::DescriptorPool     descriptorPool( device, descriptorPoolCreateInfo );
 
     // allocate a descriptor set
-    vk::DescriptorSetAllocateInfo descriptorSetAllocateInfo( *descriptorPool, *descriptorSetLayout );
+    vk::DescriptorSetAllocateInfo descriptorSetAllocateInfo( descriptorPool, *descriptorSetLayout );
     vk::raii::DescriptorSet       descriptorSet = std::move( vk::raii::DescriptorSets( device, descriptorSetAllocateInfo ).front() );
 
-    vk::DescriptorBufferInfo descriptorBufferInfo( *uniformBufferData.buffer, 0, sizeof( glm::mat4x4 ) );
-    vk::WriteDescriptorSet   writeDescriptorSet( *descriptorSet, 0, 0, vk::DescriptorType::eUniformBuffer, {}, descriptorBufferInfo );
+    vk::DescriptorBufferInfo descriptorBufferInfo( uniformBufferData.buffer, 0, sizeof( glm::mat4x4 ) );
+    vk::WriteDescriptorSet   writeDescriptorSet( descriptorSet, 0, 0, vk::DescriptorType::eUniformBuffer, {}, descriptorBufferInfo );
     device.updateDescriptorSets( writeDescriptorSet, nullptr );
 
     /* VULKAN_HPP_KEY_END */

--- a/RAII_Samples/10_InitRenderPass/10_InitRenderPass.cpp
+++ b/RAII_Samples/10_InitRenderPass/10_InitRenderPass.cpp
@@ -51,7 +51,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       vk::raii::su::findGraphicsAndPresentQueueFamilyIndex( physicalDevice, surfaceData.surface );
     vk::raii::Device device = vk::raii::su::makeDevice( physicalDevice, graphicsAndPresentQueueFamilyIndex.first, vk::su::getDeviceExtensions() );
 
-    vk::Format colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( *surfaceData.surface ) ).format;
+    vk::Format colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( surfaceData.surface ) ).format;
     vk::Format depthFormat = vk::Format::eD16Unorm;
 
     /* VULKAN_HPP_KEY_START */

--- a/RAII_Samples/12_InitFrameBuffers/12_InitFrameBuffers.cpp
+++ b/RAII_Samples/12_InitFrameBuffers/12_InitFrameBuffers.cpp
@@ -55,14 +55,14 @@ int main( int /*argc*/, char ** /*argv*/ )
     /* VULKAN_KEY_START */
 
     std::array<vk::ImageView, 2> attachments;
-    attachments[1] = *depthBufferData.imageView;
+    attachments[1] = depthBufferData.imageView;
 
     std::vector<vk::raii::Framebuffer> framebuffers;
     framebuffers.reserve( swapChainData.imageViews.size() );
     for ( auto const & view : swapChainData.imageViews )
     {
-      attachments[0] = *view;
-      vk::FramebufferCreateInfo framebufferCreateInfo( {}, *renderPass, attachments, surfaceData.extent.width, surfaceData.extent.height, 1 );
+      attachments[0] = view;
+      vk::FramebufferCreateInfo framebufferCreateInfo( {}, renderPass, attachments, surfaceData.extent.width, surfaceData.extent.height, 1 );
       framebuffers.push_back( vk::raii::Framebuffer( device, framebufferCreateInfo ) );
     }
 

--- a/RAII_Samples/13_InitVertexBuffer/13_InitVertexBuffer.cpp
+++ b/RAII_Samples/13_InitVertexBuffer/13_InitVertexBuffer.cpp
@@ -94,13 +94,13 @@ int main( int /*argc*/, char ** /*argv*/ )
     deviceMemory.unmapMemory();
 
     // and bind the device memory to the vertex buffer
-    vertexBuffer.bindMemory( *deviceMemory, 0 );
+    vertexBuffer.bindMemory( deviceMemory, 0 );
 
     vk::raii::Semaphore imageAcquiredSemaphore( device, vk::SemaphoreCreateInfo() );
 
     vk::Result result;
     uint32_t   imageIndex;
-    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, *imageAcquiredSemaphore );
+    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, imageAcquiredSemaphore );
     assert( result == vk::Result::eSuccess );
     assert( imageIndex < swapChainData.images.size() );
 
@@ -110,10 +110,10 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     commandBuffer.begin( {} );
 
-    vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
+    vk::RenderPassBeginInfo renderPassBeginInfo( renderPass, framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
     commandBuffer.beginRenderPass( renderPassBeginInfo, vk::SubpassContents::eInline );
 
-    commandBuffer.bindVertexBuffers( 0, { *vertexBuffer }, { 0 } );
+    commandBuffer.bindVertexBuffers( 0, { vertexBuffer }, { 0 } );
 
     commandBuffer.endRenderPass();
     commandBuffer.end();

--- a/RAII_Samples/14_InitPipeline/14_InitPipeline.cpp
+++ b/RAII_Samples/14_InitPipeline/14_InitPipeline.cpp
@@ -53,7 +53,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       vk::raii::su::findGraphicsAndPresentQueueFamilyIndex( physicalDevice, surfaceData.surface );
     vk::raii::Device device = vk::raii::su::makeDevice( physicalDevice, graphicsAndPresentQueueFamilyIndex.first, vk::su::getDeviceExtensions() );
 
-    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( *surfaceData.surface ) ).format;
+    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( surfaceData.surface ) ).format;
     vk::raii::RenderPass renderPass  = vk::raii::su::makeRenderPass( device, colorFormat, vk::Format::eD16Unorm );
 
     vk::raii::DescriptorSetLayout descriptorSetLayout =
@@ -68,8 +68,8 @@ int main( int /*argc*/, char ** /*argv*/ )
     /* VULKAN_KEY_START */
 
     std::array<vk::PipelineShaderStageCreateInfo, 2> pipelineShaderStageCreateInfos = {
-      vk::PipelineShaderStageCreateInfo( {}, vk::ShaderStageFlagBits::eVertex, *vertexShaderModule, "main" ),
-      vk::PipelineShaderStageCreateInfo( {}, vk::ShaderStageFlagBits::eFragment, *fragmentShaderModule, "main" )
+      vk::PipelineShaderStageCreateInfo( {}, vk::ShaderStageFlagBits::eVertex, vertexShaderModule, "main" ),
+      vk::PipelineShaderStageCreateInfo( {}, vk::ShaderStageFlagBits::eFragment, fragmentShaderModule, "main" )
     };
 
     vk::VertexInputBindingDescription                  vertexInputBindingDescription( 0, sizeof( coloredCubeData[0] ) );
@@ -147,8 +147,8 @@ int main( int /*argc*/, char ** /*argv*/ )
                                                                &pipelineDepthStencilStateCreateInfo,   // pDepthStencilState
                                                                &pipelineColorBlendStateCreateInfo,     // pColorBlendState
                                                                &pipelineDynamicStateCreateInfo,        // pDynamicState
-                                                               *pipelineLayout,                        // layout
-                                                               *renderPass                             // renderPass
+                                                               pipelineLayout,                         // layout
+                                                               renderPass                              // renderPass
     );
 
     vk::raii::Pipeline pipeline( device, nullptr, graphicsPipelineCreateInfo );

--- a/RAII_Samples/15_DrawCube/15_DrawCube.cpp
+++ b/RAII_Samples/15_DrawCube/15_DrawCube.cpp
@@ -79,7 +79,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       vk::raii::su::makeDescriptorSetLayout( device, { { vk::DescriptorType::eUniformBuffer, 1, vk::ShaderStageFlagBits::eVertex } } );
     vk::raii::PipelineLayout pipelineLayout( device, { {}, *descriptorSetLayout } );
 
-    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( *surfaceData.surface ) ).format;
+    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( surfaceData.surface ) ).format;
     vk::raii::RenderPass renderPass  = vk::raii::su::makeRenderPass( device, colorFormat, depthBufferData.format );
 
     glslang::InitializeProcess();
@@ -94,7 +94,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::raii::su::copyToDevice( vertexBufferData.deviceMemory, coloredCubeData, sizeof( coloredCubeData ) / sizeof( coloredCubeData[0] ) );
 
     vk::raii::DescriptorPool descriptorPool = vk::raii::su::makeDescriptorPool( device, { { vk::DescriptorType::eUniformBuffer, 1 } } );
-    vk::raii::DescriptorSet  descriptorSet  = std::move( vk::raii::DescriptorSets( device, { *descriptorPool, *descriptorSetLayout } ).front() );
+    vk::raii::DescriptorSet  descriptorSet  = std::move( vk::raii::DescriptorSets( device, { descriptorPool, *descriptorSetLayout } ).front() );
     vk::raii::su::updateDescriptorSets(
       device, descriptorSet, { { vk::DescriptorType::eUniformBuffer, uniformBufferData.buffer, VK_WHOLE_SIZE, nullptr } }, {} );
 
@@ -120,7 +120,7 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     vk::Result result;
     uint32_t   imageIndex;
-    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, *imageAcquiredSemaphore );
+    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, imageAcquiredSemaphore );
     assert( result == vk::Result::eSuccess );
     assert( imageIndex < swapChainData.images.size() );
 
@@ -129,12 +129,12 @@ int main( int /*argc*/, char ** /*argv*/ )
     std::array<vk::ClearValue, 2> clearValues;
     clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
-    vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
+    vk::RenderPassBeginInfo renderPassBeginInfo( renderPass, framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
     commandBuffer.beginRenderPass( renderPassBeginInfo, vk::SubpassContents::eInline );
-    commandBuffer.bindPipeline( vk::PipelineBindPoint::eGraphics, *graphicsPipeline );
-    commandBuffer.bindDescriptorSets( vk::PipelineBindPoint::eGraphics, *pipelineLayout, 0, { *descriptorSet }, nullptr );
+    commandBuffer.bindPipeline( vk::PipelineBindPoint::eGraphics, graphicsPipeline );
+    commandBuffer.bindDescriptorSets( vk::PipelineBindPoint::eGraphics, pipelineLayout, 0, { descriptorSet }, nullptr );
 
-    commandBuffer.bindVertexBuffers( 0, { *vertexBufferData.buffer }, { 0 } );
+    commandBuffer.bindVertexBuffers( 0, { vertexBufferData.buffer }, { 0 } );
     commandBuffer.setViewport(
       0, vk::Viewport( 0.0f, 0.0f, static_cast<float>( surfaceData.extent.width ), static_cast<float>( surfaceData.extent.height ), 0.0f, 1.0f ) );
     commandBuffer.setScissor( 0, vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ) );
@@ -149,7 +149,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::SubmitInfo         submitInfo( *imageAcquiredSemaphore, waitDestinationStageMask, *commandBuffer );
     graphicsQueue.submit( submitInfo, *drawFence );
 
-    while ( vk::Result::eTimeout == device.waitForFences( { *drawFence }, VK_TRUE, vk::su::FenceTimeout ) )
+    while ( vk::Result::eTimeout == device.waitForFences( { drawFence }, VK_TRUE, vk::su::FenceTimeout ) )
       ;
 
     vk::PresentInfoKHR presentInfoKHR( nullptr, *swapChainData.swapChain, imageIndex );

--- a/RAII_Samples/DebugUtilsObjectName/DebugUtilsObjectName.cpp
+++ b/RAII_Samples/DebugUtilsObjectName/DebugUtilsObjectName.cpp
@@ -47,7 +47,8 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     /* VULKAN_KEY_START */
 
-    vk::DebugUtilsObjectNameInfoEXT debugUtilsObjectNameInfo( vk::ObjectType::eImage, NON_DISPATCHABLE_HANDLE_TO_UINT64_CAST( VkImage, *image ), "Image name" );
+    vk::DebugUtilsObjectNameInfoEXT debugUtilsObjectNameInfo(
+      vk::ObjectType::eImage, NON_DISPATCHABLE_HANDLE_TO_UINT64_CAST( VkImage, static_cast<vk ::Image>( image ) ), "Image name" );
     device.setDebugUtilsObjectNameEXT( debugUtilsObjectNameInfo );
 
     /* VULKAN_KEY_END */

--- a/RAII_Samples/DrawTexturedCube/DrawTexturedCube.cpp
+++ b/RAII_Samples/DrawTexturedCube/DrawTexturedCube.cpp
@@ -76,7 +76,7 @@ int main( int /*argc*/, char ** /*argv*/ )
                                                { vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment } } );
     vk::raii::PipelineLayout pipelineLayout( device, { {}, *descriptorSetLayout } );
 
-    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( *surfaceData.surface ) ).format;
+    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( surfaceData.surface ) ).format;
     vk::raii::RenderPass renderPass  = vk::raii::su::makeRenderPass( device, colorFormat, depthBufferData.format );
 
     glslang::InitializeProcess();
@@ -92,7 +92,7 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     vk::raii::DescriptorPool descriptorPool =
       vk::raii::su::makeDescriptorPool( device, { { vk::DescriptorType::eUniformBuffer, 1 }, { vk::DescriptorType::eCombinedImageSampler, 1 } } );
-    vk::raii::DescriptorSet descriptorSet = std::move( vk::raii::DescriptorSets( device, { *descriptorPool, *descriptorSetLayout } ).front() );
+    vk::raii::DescriptorSet descriptorSet = std::move( vk::raii::DescriptorSets( device, { descriptorPool, *descriptorSetLayout } ).front() );
 
     vk::raii::su::updateDescriptorSets(
       device, descriptorSet, { { vk::DescriptorType::eUniformBuffer, uniformBufferData.buffer, VK_WHOLE_SIZE, nullptr } }, { textureData } );
@@ -105,7 +105,7 @@ int main( int /*argc*/, char ** /*argv*/ )
                                                                               fragmentShaderModule,
                                                                               nullptr,
                                                                               sizeof( texturedCubeData[0] ),
-                                                                              { { vk::Format::eR32G32B32A32Sfloat, 0 }, { vk::Format::eR32G32Sfloat, 16 } },
+                                                                                   { { vk::Format::eR32G32B32A32Sfloat, 0 }, { vk::Format::eR32G32Sfloat, 16 } },
                                                                               vk::FrontFace::eClockwise,
                                                                               true,
                                                                               pipelineLayout,
@@ -117,7 +117,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::raii::Semaphore imageAcquiredSemaphore( device, vk::SemaphoreCreateInfo() );
     vk::Result          result;
     uint32_t            imageIndex;
-    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, *imageAcquiredSemaphore );
+    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, imageAcquiredSemaphore );
     assert( result == vk::Result::eSuccess );
     assert( imageIndex < swapChainData.images.size() );
 
@@ -126,13 +126,13 @@ int main( int /*argc*/, char ** /*argv*/ )
     std::array<vk::ClearValue, 2> clearValues;
     clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
-    vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
+    vk::RenderPassBeginInfo renderPassBeginInfo( renderPass, framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
 
     commandBuffer.beginRenderPass( renderPassBeginInfo, vk::SubpassContents::eInline );
-    commandBuffer.bindPipeline( vk::PipelineBindPoint::eGraphics, *graphicsPipeline );
-    commandBuffer.bindDescriptorSets( vk::PipelineBindPoint::eGraphics, *pipelineLayout, 0, { *descriptorSet }, nullptr );
+    commandBuffer.bindPipeline( vk::PipelineBindPoint::eGraphics, graphicsPipeline );
+    commandBuffer.bindDescriptorSets( vk::PipelineBindPoint::eGraphics, pipelineLayout, 0, { descriptorSet }, nullptr );
 
-    commandBuffer.bindVertexBuffers( 0, { *vertexBufferData.buffer }, { 0 } );
+    commandBuffer.bindVertexBuffers( 0, { vertexBufferData.buffer }, { 0 } );
     commandBuffer.setViewport(
       0, vk::Viewport( 0.0f, 0.0f, static_cast<float>( surfaceData.extent.width ), static_cast<float>( surfaceData.extent.height ), 0.0f, 1.0f ) );
     commandBuffer.setScissor( 0, vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ) );
@@ -147,7 +147,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::SubmitInfo         submitInfo( *imageAcquiredSemaphore, waitDestinationStageMask, *commandBuffer );
     graphicsQueue.submit( submitInfo, *drawFence );
 
-    while ( vk::Result::eTimeout == device.waitForFences( { *drawFence }, VK_TRUE, vk::su::FenceTimeout ) )
+    while ( vk::Result::eTimeout == device.waitForFences( { drawFence }, VK_TRUE, vk::su::FenceTimeout ) )
       ;
 
     vk::PresentInfoKHR presentInfoKHR( nullptr, *swapChainData.swapChain, imageIndex );

--- a/RAII_Samples/Events/Events.cpp
+++ b/RAII_Samples/Events/Events.cpp
@@ -51,14 +51,14 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::raii::Fence fence( device, vk::FenceCreateInfo() );
 
     vk::SubmitInfo submitInfo( {}, {}, *commandBuffer );
-    graphicsQueue.submit( submitInfo, *fence );
+    graphicsQueue.submit( submitInfo, fence );
 
     // Make sure timeout is long enough for a simple command buffer without waiting for an event
     vk::Result result;
     int        timeouts = -1;
     do
     {
-      result = device.waitForFences( { *fence }, true, vk::su::FenceTimeout );
+      result = device.waitForFences( { fence }, true, vk::su::FenceTimeout );
       timeouts++;
     } while ( result == vk::Result::eTimeout );
     assert( result == vk::Result::eSuccess );
@@ -75,16 +75,16 @@ int main( int /*argc*/, char ** /*argv*/ )
     commandPool.reset();
 
     commandBuffer.begin( vk::CommandBufferBeginInfo() );
-    commandBuffer.waitEvents( { *event }, vk::PipelineStageFlagBits::eHost, vk::PipelineStageFlagBits::eBottomOfPipe, nullptr, nullptr, nullptr );
+    commandBuffer.waitEvents( { event }, vk::PipelineStageFlagBits::eHost, vk::PipelineStageFlagBits::eBottomOfPipe, nullptr, nullptr, nullptr );
     commandBuffer.end();
-    device.resetFences( { *fence } );
+    device.resetFences( { fence } );
 
     // Note that stepping through this code in the debugger is a bad idea because the GPU can TDR waiting for the event.
     // Execute the code from vk::Queue::submit() through vk::Device::setEvent() without breakpoints
-    graphicsQueue.submit( submitInfo, *fence );
+    graphicsQueue.submit( submitInfo, fence );
 
     // We should timeout waiting for the fence because the GPU should be waiting on the event
-    result = device.waitForFences( { *fence }, true, vk::su::FenceTimeout );
+    result = device.waitForFences( { fence }, true, vk::su::FenceTimeout );
     if ( result != vk::Result::eTimeout )
     {
       std::cout << "Didn't get expected timeout in vk::Device::waitForFences, exiting\n";
@@ -96,11 +96,11 @@ int main( int /*argc*/, char ** /*argv*/ )
     event.set();
     do
     {
-      result = device.waitForFences( { *fence }, true, vk::su::FenceTimeout );
+      result = device.waitForFences( { fence }, true, vk::su::FenceTimeout );
     } while ( result == vk::Result::eTimeout );
     assert( result == vk::Result::eSuccess );
 
-    device.resetFences( { *fence } );
+    device.resetFences( { fence } );
     event.reset();
 
     // reset the command buffer by resetting the complete command pool
@@ -108,7 +108,7 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     // Now set the event from the GPU and wait on the CPU
     commandBuffer.begin( vk::CommandBufferBeginInfo() );
-    commandBuffer.setEvent( *event, vk::PipelineStageFlagBits::eBottomOfPipe );
+    commandBuffer.setEvent( event, vk::PipelineStageFlagBits::eBottomOfPipe );
     commandBuffer.end();
 
     // Look for the event on the CPU. It should be vk::Result::eEventReset since we haven't sent the command buffer yet.
@@ -116,7 +116,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     assert( result == vk::Result::eEventReset );
 
     // Send the command buffer and loop waiting for the event
-    graphicsQueue.submit( submitInfo, *fence );
+    graphicsQueue.submit( submitInfo, fence );
 
     int polls = 0;
     do
@@ -128,7 +128,7 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     do
     {
-      result = device.waitForFences( { *fence }, true, vk::su::FenceTimeout );
+      result = device.waitForFences( { fence }, true, vk::su::FenceTimeout );
     } while ( result == vk::Result::eTimeout );
     assert( result == vk::Result::eSuccess );
 

--- a/RAII_Samples/InitTexture/InitTexture.cpp
+++ b/RAII_Samples/InitTexture/InitTexture.cpp
@@ -95,7 +95,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     imageMemory = vk::raii::DeviceMemory( device, memoryAllocateInfo );
 
     // bind memory
-    image.bindMemory( *imageMemory, 0 );
+    image.bindMemory( imageMemory, 0 );
 
     vk::raii::Buffer       textureBuffer       = nullptr;
     vk::raii::DeviceMemory textureBufferMemory = nullptr;
@@ -115,7 +115,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       textureBufferMemory = vk::raii::DeviceMemory( device, memoryAllocateInfo );
 
       // bind memory
-      textureBuffer.bindMemory( *textureBufferMemory, 0 );
+      textureBuffer.bindMemory( textureBufferMemory, 0 );
     }
     else
     {
@@ -146,21 +146,21 @@ int main( int /*argc*/, char ** /*argv*/ )
     if ( needsStaging )
     {
       // Since we're going to blit to the texture image, set its layout to eTransferDstOptimal
-      vk::raii::su::setImageLayout( commandBuffer, *image, format, vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal );
+      vk::raii::su::setImageLayout( commandBuffer, image, format, vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal );
       vk::BufferImageCopy copyRegion( 0,
                                       surfaceData.extent.width,
                                       surfaceData.extent.height,
                                       vk::ImageSubresourceLayers( vk::ImageAspectFlagBits::eColor, 0, 0, 1 ),
                                       vk::Offset3D( 0, 0, 0 ),
                                       vk::Extent3D( surfaceData.extent, 1 ) );
-      commandBuffer.copyBufferToImage( *textureBuffer, *image, vk::ImageLayout::eTransferDstOptimal, copyRegion );
+      commandBuffer.copyBufferToImage( textureBuffer, image, vk::ImageLayout::eTransferDstOptimal, copyRegion );
       // Set the layout for the texture image from eTransferDstOptimal to SHADER_READ_ONLY
-      vk::raii::su::setImageLayout( commandBuffer, *image, format, vk::ImageLayout::eTransferDstOptimal, vk::ImageLayout::eShaderReadOnlyOptimal );
+      vk::raii::su::setImageLayout( commandBuffer, image, format, vk::ImageLayout::eTransferDstOptimal, vk::ImageLayout::eShaderReadOnlyOptimal );
     }
     else
     {
       // If we can use the linear tiled image as a texture, just do it
-      vk::raii::su::setImageLayout( commandBuffer, *image, format, vk::ImageLayout::ePreinitialized, vk::ImageLayout::eShaderReadOnlyOptimal );
+      vk::raii::su::setImageLayout( commandBuffer, image, format, vk::ImageLayout::ePreinitialized, vk::ImageLayout::eShaderReadOnlyOptimal );
     }
 
     commandBuffer.end();
@@ -183,7 +183,7 @@ int main( int /*argc*/, char ** /*argv*/ )
                                              vk::BorderColor::eFloatOpaqueWhite );
     vk::raii::Sampler     sampler( device, samplerCreateInfo );
 
-    vk::ImageViewCreateInfo imageViewCreateInfo( {}, *image, vk::ImageViewType::e2D, format, {}, { vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1 } );
+    vk::ImageViewCreateInfo imageViewCreateInfo( {}, image, vk::ImageViewType::e2D, format, {}, { vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1 } );
     vk::raii::ImageView     imageView( device, imageViewCreateInfo );
 
     /* VULKAN_KEY_END */

--- a/RAII_Samples/MultipleSets/MultipleSets.cpp
+++ b/RAII_Samples/MultipleSets/MultipleSets.cpp
@@ -113,7 +113,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       vk::raii::su::findGraphicsAndPresentQueueFamilyIndex( physicalDevice, surfaceData.surface );
     vk::raii::Device device = vk::raii::su::makeDevice( physicalDevice, graphicsAndPresentQueueFamilyIndex.first, vk::su::getDeviceExtensions() );
 
-    vk::raii::CommandPool commandPool = vk::raii::CommandPool( device, { {}, graphicsAndPresentQueueFamilyIndex.first } );
+    vk::raii::CommandPool   commandPool   = vk::raii::CommandPool( device, { {}, graphicsAndPresentQueueFamilyIndex.first } );
     vk::raii::CommandBuffer commandBuffer = vk::raii::su::makeCommandBuffer( device, commandPool );
 
     vk::raii::Queue graphicsQueue( device, graphicsAndPresentQueueFamilyIndex.first, 0 );
@@ -139,7 +139,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     glm::mat4x4              mvpcMatrix = vk::su::createModelViewProjectionClipMatrix( surfaceData.extent );
     vk::raii::su::copyToDevice( uniformBufferData.deviceMemory, mvpcMatrix );
 
-    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( *surfaceData.surface ) ).format;
+    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( surfaceData.surface ) ).format;
     vk::raii::RenderPass renderPass  = vk::raii::su::makeRenderPass( device, colorFormat, depthBufferData.format );
 
     glslang::InitializeProcess();
@@ -166,7 +166,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::raii::DescriptorSetLayout samplerLayout( device, descriptorSetLayoutCreateInfo );
 
     // Create pipeline layout with multiple descriptor sets
-    std::array<vk::DescriptorSetLayout, 2> descriptorSetLayouts = { *uniformLayout, *samplerLayout };
+    std::array<vk::DescriptorSetLayout, 2> descriptorSetLayouts = { uniformLayout, samplerLayout };
     vk::PipelineLayoutCreateInfo           pipelineLayoutCreateInfo( {}, descriptorSetLayouts );
     vk::raii::PipelineLayout               pipelineLayout( device, pipelineLayoutCreateInfo );
 
@@ -177,15 +177,15 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::raii::DescriptorPool              descriptorPool( device, descriptorPoolCreateInfo );
 
     // Populate descriptor sets
-    vk::DescriptorSetAllocateInfo descriptorSetAllocateInfo( *descriptorPool, descriptorSetLayouts );
+    vk::DescriptorSetAllocateInfo descriptorSetAllocateInfo( descriptorPool, descriptorSetLayouts );
     vk::raii::DescriptorSets      descriptorSets( device, descriptorSetAllocateInfo );
 
     // Populate with info about our uniform buffer
-    vk::DescriptorBufferInfo              uniformBufferInfo( *uniformBufferData.buffer, 0, sizeof( glm::mat4x4 ) );
-    vk::DescriptorImageInfo               textureImageInfo( *textureData.sampler, *textureData.imageData.imageView, vk::ImageLayout::eShaderReadOnlyOptimal );
+    vk::DescriptorBufferInfo              uniformBufferInfo( uniformBufferData.buffer, 0, sizeof( glm::mat4x4 ) );
+    vk::DescriptorImageInfo               textureImageInfo( textureData.sampler, textureData.imageData.imageView, vk::ImageLayout::eShaderReadOnlyOptimal );
     std::array<vk::WriteDescriptorSet, 2> writeDescriptorSets = {
-      { vk::WriteDescriptorSet( *descriptorSets[0], 0, 0, vk::DescriptorType::eUniformBuffer, {}, uniformBufferInfo ),
-        vk::WriteDescriptorSet( *descriptorSets[1], 0, 0, vk::DescriptorType::eCombinedImageSampler, textureImageInfo ) }
+      { vk::WriteDescriptorSet( descriptorSets[0], 0, 0, vk::DescriptorType::eUniformBuffer, {}, uniformBufferInfo ),
+        vk::WriteDescriptorSet( descriptorSets[1], 0, 0, vk::DescriptorType::eCombinedImageSampler, textureImageInfo ) }
     };
     device.updateDescriptorSets( writeDescriptorSets, nullptr );
 
@@ -199,7 +199,7 @@ int main( int /*argc*/, char ** /*argv*/ )
                                                                               fragmentShaderModule,
                                                                               nullptr,
                                                                               sizeof( texturedCubeData[0] ),
-                                                                              { { vk::Format::eR32G32B32A32Sfloat, 0 }, { vk::Format::eR32G32Sfloat, 16 } },
+                                                                                   { { vk::Format::eR32G32B32A32Sfloat, 0 }, { vk::Format::eR32G32Sfloat, 16 } },
                                                                               vk::FrontFace::eClockwise,
                                                                               true,
                                                                               pipelineLayout,
@@ -209,19 +209,19 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::raii::Semaphore imageAcquiredSemaphore( device, vk::SemaphoreCreateInfo() );
     vk::Result          result;
     uint32_t            imageIndex;
-    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, *imageAcquiredSemaphore );
+    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, imageAcquiredSemaphore );
     assert( result == vk::Result::eSuccess );
     assert( imageIndex < swapChainData.images.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
     clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
-    vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
+    vk::RenderPassBeginInfo renderPassBeginInfo( renderPass, framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
     commandBuffer.beginRenderPass( renderPassBeginInfo, vk::SubpassContents::eInline );
-    commandBuffer.bindPipeline( vk::PipelineBindPoint::eGraphics, *graphicsPipeline );
-    commandBuffer.bindDescriptorSets( vk::PipelineBindPoint::eGraphics, *pipelineLayout, 0, { *descriptorSets[0], *descriptorSets[1] }, nullptr );
+    commandBuffer.bindPipeline( vk::PipelineBindPoint::eGraphics, graphicsPipeline );
+    commandBuffer.bindDescriptorSets( vk::PipelineBindPoint::eGraphics, pipelineLayout, 0, { descriptorSets[0], descriptorSets[1] }, nullptr );
 
-    vk::Buffer buffer = *vertexBufferData.buffer;
+    vk::Buffer buffer = vertexBufferData.buffer;
     commandBuffer.bindVertexBuffers( 0, buffer, { 0 } );
     commandBuffer.setViewport(
       0, vk::Viewport( 0.0f, 0.0f, static_cast<float>( surfaceData.extent.width ), static_cast<float>( surfaceData.extent.height ), 0.0f, 1.0f ) );
@@ -237,7 +237,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::SubmitInfo         submitInfo( *imageAcquiredSemaphore, waitDestinationStageMask, *commandBuffer );
     graphicsQueue.submit( submitInfo, *drawFence );
 
-    while ( vk::Result::eTimeout == device.waitForFences( { *drawFence }, VK_TRUE, vk::su::FenceTimeout ) )
+    while ( vk::Result::eTimeout == device.waitForFences( { drawFence }, VK_TRUE, vk::su::FenceTimeout ) )
       ;
 
     vk::PresentInfoKHR presentInfoKHR( nullptr, *swapChainData.swapChain, imageIndex );

--- a/RAII_Samples/PipelineCache/PipelineCache.cpp
+++ b/RAII_Samples/PipelineCache/PipelineCache.cpp
@@ -42,7 +42,8 @@
 #endif
 
 typedef unsigned long long timestamp_t;
-timestamp_t                getMilliseconds()
+
+timestamp_t getMilliseconds()
 {
 #ifdef WIN32
   LARGE_INTEGER frequency;
@@ -85,7 +86,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       vk::raii::su::findGraphicsAndPresentQueueFamilyIndex( physicalDevice, surfaceData.surface );
     vk::raii::Device device = vk::raii::su::makeDevice( physicalDevice, graphicsAndPresentQueueFamilyIndex.first, vk::su::getDeviceExtensions() );
 
-    vk::raii::CommandPool commandPool = vk::raii::CommandPool( device, { {}, graphicsAndPresentQueueFamilyIndex.first } );
+    vk::raii::CommandPool   commandPool   = vk::raii::CommandPool( device, { {}, graphicsAndPresentQueueFamilyIndex.first } );
     vk::raii::CommandBuffer commandBuffer = vk::raii::su::makeCommandBuffer( device, commandPool );
 
     vk::raii::Queue graphicsQueue( device, graphicsAndPresentQueueFamilyIndex.first, 0 );
@@ -117,7 +118,7 @@ int main( int /*argc*/, char ** /*argv*/ )
                                                { vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment } } );
     vk::raii::PipelineLayout pipelineLayout( device, { {}, *descriptorSetLayout } );
 
-    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( *surfaceData.surface ) ).format;
+    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( surfaceData.surface ) ).format;
     vk::raii::RenderPass renderPass  = vk::raii::su::makeRenderPass( device, colorFormat, depthBufferData.format );
 
     glslang::InitializeProcess();
@@ -133,7 +134,7 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     vk::raii::DescriptorPool descriptorPool =
       vk::raii::su::makeDescriptorPool( device, { { vk::DescriptorType::eUniformBuffer, 1 }, { vk::DescriptorType::eCombinedImageSampler, 1 } } );
-    vk::raii::DescriptorSet descriptorSet = std::move( vk::raii::DescriptorSets( device, { *descriptorPool, *descriptorSetLayout } ).front() );
+    vk::raii::DescriptorSet descriptorSet = std::move( vk::raii::DescriptorSets( device, { descriptorPool, *descriptorSetLayout } ).front() );
 
     vk::raii::su::updateDescriptorSets(
       device, descriptorSet, { { vk::DescriptorType::eUniformBuffer, uniformBufferData.buffer, VK_WHOLE_SIZE, nullptr } }, { textureData } );
@@ -300,7 +301,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     // Get the index of the next available swapchain image:
     vk::Result result;
     uint32_t   imageIndex;
-    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, *imageAcquiredSemaphore );
+    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, imageAcquiredSemaphore );
     assert( result == vk::Result::eSuccess );
     assert( imageIndex < swapChainData.images.size() );
 
@@ -309,12 +310,12 @@ int main( int /*argc*/, char ** /*argv*/ )
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
 
     commandBuffer.beginRenderPass(
-      vk::RenderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D(), surfaceData.extent ), clearValues ),
+      vk::RenderPassBeginInfo( renderPass, framebuffers[imageIndex], vk::Rect2D( vk::Offset2D(), surfaceData.extent ), clearValues ),
       vk::SubpassContents::eInline );
-    commandBuffer.bindPipeline( vk::PipelineBindPoint::eGraphics, *graphicsPipeline );
-    commandBuffer.bindDescriptorSets( vk::PipelineBindPoint::eGraphics, *pipelineLayout, 0, { *descriptorSet }, {} );
+    commandBuffer.bindPipeline( vk::PipelineBindPoint::eGraphics, graphicsPipeline );
+    commandBuffer.bindDescriptorSets( vk::PipelineBindPoint::eGraphics, pipelineLayout, 0, { descriptorSet }, {} );
 
-    commandBuffer.bindVertexBuffers( 0, { *vertexBufferData.buffer }, { 0 } );
+    commandBuffer.bindVertexBuffers( 0, { vertexBufferData.buffer }, { 0 } );
     commandBuffer.setViewport(
       0, vk::Viewport( 0.0f, 0.0f, static_cast<float>( surfaceData.extent.width ), static_cast<float>( surfaceData.extent.height ), 0.0f, 1.0f ) );
     commandBuffer.setScissor( 0, vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ) );
@@ -329,7 +330,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::SubmitInfo         submitInfo( *imageAcquiredSemaphore, waitDestinationStageMask, *commandBuffer );
     graphicsQueue.submit( submitInfo, *drawFence );
 
-    while ( vk::Result::eTimeout == device.waitForFences( { *drawFence }, VK_TRUE, vk::su::FenceTimeout ) )
+    while ( vk::Result::eTimeout == device.waitForFences( { drawFence }, VK_TRUE, vk::su::FenceTimeout ) )
       ;
 
     vk::PresentInfoKHR presentInfoKHR( nullptr, *swapChainData.swapChain, imageIndex );

--- a/RAII_Samples/PipelineDerivative/PipelineDerivative.cpp
+++ b/RAII_Samples/PipelineDerivative/PipelineDerivative.cpp
@@ -52,7 +52,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       vk::raii::su::findGraphicsAndPresentQueueFamilyIndex( physicalDevice, surfaceData.surface );
     vk::raii::Device device = vk::raii::su::makeDevice( physicalDevice, graphicsAndPresentQueueFamilyIndex.first, vk::su::getDeviceExtensions() );
 
-    vk::raii::CommandPool commandPool = vk::raii::CommandPool( device, { {}, graphicsAndPresentQueueFamilyIndex.first } );
+    vk::raii::CommandPool   commandPool   = vk::raii::CommandPool( device, { {}, graphicsAndPresentQueueFamilyIndex.first } );
     vk::raii::CommandBuffer commandBuffer = vk::raii::su::makeCommandBuffer( device, commandPool );
 
     vk::raii::Queue graphicsQueue( device, graphicsAndPresentQueueFamilyIndex.first, 0 );
@@ -84,7 +84,7 @@ int main( int /*argc*/, char ** /*argv*/ )
                                                { vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment } } );
     vk::raii::PipelineLayout pipelineLayout( device, { {}, *descriptorSetLayout } );
 
-    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( *surfaceData.surface ) ).format;
+    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( surfaceData.surface ) ).format;
     vk::raii::RenderPass renderPass  = vk::raii::su::makeRenderPass( device, colorFormat, depthBufferData.format );
 
     glslang::InitializeProcess();
@@ -100,7 +100,7 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     vk::raii::DescriptorPool descriptorPool =
       vk::raii::su::makeDescriptorPool( device, { { vk::DescriptorType::eUniformBuffer, 1 }, { vk::DescriptorType::eCombinedImageSampler, 1 } } );
-    vk::raii::DescriptorSet descriptorSet = std::move( vk::raii::DescriptorSets( device, { *descriptorPool, *descriptorSetLayout } ).front() );
+    vk::raii::DescriptorSet descriptorSet = std::move( vk::raii::DescriptorSets( device, { descriptorPool, *descriptorSetLayout } ).front() );
 
     vk::raii::su::updateDescriptorSets(
       device, descriptorSet, { { vk::DescriptorType::eUniformBuffer, uniformBufferData.buffer, VK_WHOLE_SIZE, nullptr } }, { textureData } );
@@ -115,8 +115,8 @@ int main( int /*argc*/, char ** /*argv*/ )
     // Second pipeline has a modified fragment shader and sets the VK_PIPELINE_CREATE_DERIVATIVE_BIT flag.
 
     std::array<vk::PipelineShaderStageCreateInfo, 2> pipelineShaderStageCreateInfos = {
-      vk::PipelineShaderStageCreateInfo( {}, vk::ShaderStageFlagBits::eVertex, *vertexShaderModule, "main" ),
-      vk::PipelineShaderStageCreateInfo( {}, vk::ShaderStageFlagBits::eFragment, *fragmentShaderModule, "main" )
+      vk::PipelineShaderStageCreateInfo( {}, vk::ShaderStageFlagBits::eVertex, vertexShaderModule, "main" ),
+      vk::PipelineShaderStageCreateInfo( {}, vk::ShaderStageFlagBits::eFragment, fragmentShaderModule, "main" )
     };
 
     vk::VertexInputBindingDescription                  vertexInputBindingDescription( 0, sizeof( texturedCubeData[0] ) );
@@ -166,8 +166,8 @@ int main( int /*argc*/, char ** /*argv*/ )
                                                                &pipelineDepthStencilStateCreateInfo,
                                                                &pipelineColorBlendStateCreateInfo,
                                                                &pipelineDynamicStateCreateInfo,
-                                                               *pipelineLayout,
-                                                               *renderPass );
+                                                               pipelineLayout,
+                                                               renderPass );
 
     vk::raii::Pipeline basePipeline( device, pipelineCache, graphicsPipelineCreateInfo );
     switch ( basePipeline.getConstructorSuccessCode() )
@@ -200,9 +200,9 @@ void main()
     glslang::FinalizeProcess();
 
     // Modify pipeline info to reflect derivation
-    pipelineShaderStageCreateInfos[1]             = vk::PipelineShaderStageCreateInfo( {}, vk::ShaderStageFlagBits::eFragment, *fragmentShaderModule2, "main" );
+    pipelineShaderStageCreateInfos[1]             = vk::PipelineShaderStageCreateInfo( {}, vk::ShaderStageFlagBits::eFragment, fragmentShaderModule2, "main" );
     graphicsPipelineCreateInfo.flags              = vk::PipelineCreateFlagBits::eDerivative;
-    graphicsPipelineCreateInfo.basePipelineHandle = *basePipeline;
+    graphicsPipelineCreateInfo.basePipelineHandle = basePipeline;
     graphicsPipelineCreateInfo.basePipelineIndex  = -1;
 
     // And create the derived pipeline
@@ -223,7 +223,7 @@ void main()
     // Get the index of the next available swapchain image
     vk::Result result;
     uint32_t   imageIndex;
-    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, *imageAcquiredSemaphore );
+    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, imageAcquiredSemaphore );
     assert( result == vk::Result::eSuccess );
     assert( imageIndex < swapChainData.images.size() );
 
@@ -232,12 +232,12 @@ void main()
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
 
     commandBuffer.beginRenderPass(
-      vk::RenderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D(), surfaceData.extent ), clearValues ),
+      vk::RenderPassBeginInfo( renderPass, framebuffers[imageIndex], vk::Rect2D( vk::Offset2D(), surfaceData.extent ), clearValues ),
       vk::SubpassContents::eInline );
-    commandBuffer.bindPipeline( vk::PipelineBindPoint::eGraphics, *derivedPipeline );
-    commandBuffer.bindDescriptorSets( vk::PipelineBindPoint::eGraphics, *pipelineLayout, 0, { *descriptorSet }, {} );
+    commandBuffer.bindPipeline( vk::PipelineBindPoint::eGraphics, derivedPipeline );
+    commandBuffer.bindDescriptorSets( vk::PipelineBindPoint::eGraphics, pipelineLayout, 0, { descriptorSet }, {} );
 
-    commandBuffer.bindVertexBuffers( 0, { *vertexBufferData.buffer }, { 0 } );
+    commandBuffer.bindVertexBuffers( 0, { vertexBufferData.buffer }, { 0 } );
     commandBuffer.setViewport(
       0, vk::Viewport( 0.0f, 0.0f, static_cast<float>( surfaceData.extent.width ), static_cast<float>( surfaceData.extent.height ), 0.0f, 1.0f ) );
     commandBuffer.setScissor( 0, vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ) );
@@ -252,7 +252,7 @@ void main()
     vk::SubmitInfo         submitInfo( *imageAcquiredSemaphore, waitDestinationStageMask, *commandBuffer );
     graphicsQueue.submit( submitInfo, *drawFence );
 
-    while ( vk::Result::eTimeout == device.waitForFences( { *drawFence }, VK_TRUE, vk::su::FenceTimeout ) )
+    while ( vk::Result::eTimeout == device.waitForFences( { drawFence }, VK_TRUE, vk::su::FenceTimeout ) )
       ;
 
     vk::PresentInfoKHR presentInfoKHR( nullptr, *swapChainData.swapChain, imageIndex );

--- a/RAII_Samples/PushDescriptors/PushDescriptors.cpp
+++ b/RAII_Samples/PushDescriptors/PushDescriptors.cpp
@@ -77,7 +77,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       vk::raii::su::findGraphicsAndPresentQueueFamilyIndex( physicalDevice, surfaceData.surface );
     vk::raii::Device device = vk::raii::su::makeDevice( physicalDevice, graphicsAndPresentQueueFamilyIndex.first, deviceExtensions );
 
-    vk::raii::CommandPool commandPool = vk::raii::CommandPool( device, { {}, graphicsAndPresentQueueFamilyIndex.first } );
+    vk::raii::CommandPool   commandPool   = vk::raii::CommandPool( device, { {}, graphicsAndPresentQueueFamilyIndex.first } );
     vk::raii::CommandBuffer commandBuffer = vk::raii::su::makeCommandBuffer( device, commandPool );
 
     vk::raii::Queue graphicsQueue( device, graphicsAndPresentQueueFamilyIndex.first, 0 );
@@ -111,7 +111,7 @@ int main( int /*argc*/, char ** /*argv*/ )
                                              vk::DescriptorSetLayoutCreateFlagBits::ePushDescriptorKHR );
     vk::raii::PipelineLayout pipelineLayout( device, { {}, *descriptorSetLayout } );
 
-    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( *surfaceData.surface ) ).format;
+    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( surfaceData.surface ) ).format;
     vk::raii::RenderPass renderPass  = vk::raii::su::makeRenderPass( device, colorFormat, depthBufferData.format );
 
     glslang::InitializeProcess();
@@ -133,7 +133,7 @@ int main( int /*argc*/, char ** /*argv*/ )
                                                                               fragmentShaderModule,
                                                                               nullptr,
                                                                               sizeof( texturedCubeData[0] ),
-                                                                              { { vk::Format::eR32G32B32A32Sfloat, 0 }, { vk::Format::eR32G32Sfloat, 16 } },
+                                                                                   { { vk::Format::eR32G32B32A32Sfloat, 0 }, { vk::Format::eR32G32Sfloat, 16 } },
                                                                               vk::FrontFace::eClockwise,
                                                                               true,
                                                                               pipelineLayout,
@@ -143,26 +143,26 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::raii::Semaphore imageAcquiredSemaphore( device, vk::SemaphoreCreateInfo() );
     vk::Result          result;
     uint32_t            imageIndex;
-    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, *imageAcquiredSemaphore );
+    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, imageAcquiredSemaphore );
     assert( result == vk::Result::eSuccess );
     assert( imageIndex < swapChainData.images.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
     clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
-    vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
+    vk::RenderPassBeginInfo renderPassBeginInfo( renderPass, framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
     commandBuffer.beginRenderPass( renderPassBeginInfo, vk::SubpassContents::eInline );
-    commandBuffer.bindPipeline( vk::PipelineBindPoint::eGraphics, *graphicsPipeline );
+    commandBuffer.bindPipeline( vk::PipelineBindPoint::eGraphics, graphicsPipeline );
 
-    vk::DescriptorBufferInfo bufferInfo( *uniformBufferData.buffer, 0, sizeof( glm::mat4x4 ) );
-    vk::DescriptorImageInfo  imageInfo( *textureData.sampler, *textureData.imageData.imageView, vk::ImageLayout::eShaderReadOnlyOptimal );
+    vk::DescriptorBufferInfo bufferInfo( uniformBufferData.buffer, 0, sizeof( glm::mat4x4 ) );
+    vk::DescriptorImageInfo  imageInfo( textureData.sampler, textureData.imageData.imageView, vk::ImageLayout::eShaderReadOnlyOptimal );
     vk::WriteDescriptorSet   writeDescriptorSets[2] = { vk::WriteDescriptorSet( {}, 0, 0, vk::DescriptorType::eUniformBuffer, {}, bufferInfo ),
-                                                      vk::WriteDescriptorSet( {}, 1, 0, vk::DescriptorType::eCombinedImageSampler, imageInfo ) };
+                                                        vk::WriteDescriptorSet( {}, 1, 0, vk::DescriptorType::eCombinedImageSampler, imageInfo ) };
 
     // this call is from an extension and needs the dynamic dispatcher !!
-    commandBuffer.pushDescriptorSetKHR( vk::PipelineBindPoint::eGraphics, *pipelineLayout, 0, { 2, writeDescriptorSets } );
+    commandBuffer.pushDescriptorSetKHR( vk::PipelineBindPoint::eGraphics, pipelineLayout, 0, { 2, writeDescriptorSets } );
 
-    commandBuffer.bindVertexBuffers( 0, { *vertexBufferData.buffer }, { 0 } );
+    commandBuffer.bindVertexBuffers( 0, { vertexBufferData.buffer }, { 0 } );
     commandBuffer.setViewport(
       0, vk::Viewport( 0.0f, 0.0f, static_cast<float>( surfaceData.extent.width ), static_cast<float>( surfaceData.extent.height ), 0.0f, 1.0f ) );
     commandBuffer.setScissor( 0, vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ) );
@@ -177,7 +177,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::SubmitInfo         submitInfo( *imageAcquiredSemaphore, waitDestinationStageMask, *commandBuffer );
     graphicsQueue.submit( submitInfo, *drawFence );
 
-    while ( vk::Result::eTimeout == device.waitForFences( { *drawFence }, VK_TRUE, vk::su::FenceTimeout ) )
+    while ( vk::Result::eTimeout == device.waitForFences( { drawFence }, VK_TRUE, vk::su::FenceTimeout ) )
       ;
 
     vk::PresentInfoKHR presentInfoKHR( nullptr, *swapChainData.swapChain, imageIndex );

--- a/RAII_Samples/SecondaryCommandBuffer/SecondaryCommandBuffer.cpp
+++ b/RAII_Samples/SecondaryCommandBuffer/SecondaryCommandBuffer.cpp
@@ -81,7 +81,7 @@ int main( int /*argc*/, char ** /*argv*/ )
                                                { vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment } } );
     vk::raii::PipelineLayout pipelineLayout( device, { {}, *descriptorSetLayout } );
 
-    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( *surfaceData.surface ) ).format;
+    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( surfaceData.surface ) ).format;
     vk::raii::RenderPass renderPass =
       vk::raii::su::makeRenderPass( device, colorFormat, depthBufferData.format, vk::AttachmentLoadOp::eClear, vk::ImageLayout::eColorAttachmentOptimal );
 
@@ -122,8 +122,8 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::raii::DescriptorPool descriptorPool =
       vk::raii::su::makeDescriptorPool( device, { { vk::DescriptorType::eUniformBuffer, 2 }, { vk::DescriptorType::eCombinedImageSampler, 2 } } );
 
-    std::array<vk::DescriptorSetLayout, 2> layouts = { *descriptorSetLayout, *descriptorSetLayout };
-    vk::DescriptorSetAllocateInfo          descriptorSetAllocateInfo( *descriptorPool, layouts );
+    std::array<vk::DescriptorSetLayout, 2> layouts = { descriptorSetLayout, descriptorSetLayout };
+    vk::DescriptorSetAllocateInfo          descriptorSetAllocateInfo( descriptorPool, layouts );
     vk::raii::DescriptorSets               descriptorSets( device, descriptorSetAllocateInfo );
     assert( descriptorSets.size() == 2 );
 
@@ -135,14 +135,14 @@ int main( int /*argc*/, char ** /*argv*/ )
     /* VULKAN_KEY_START */
 
     // create four secondary command buffers, for each quadrant of the screen
-    vk::CommandBufferAllocateInfo commandBufferAllocateInfo( *commandPool, vk::CommandBufferLevel::eSecondary, 4 );
+    vk::CommandBufferAllocateInfo commandBufferAllocateInfo( commandPool, vk::CommandBufferLevel::eSecondary, 4 );
     vk::raii::CommandBuffers      secondaryCommandBuffers( device, commandBufferAllocateInfo );
 
     // Get the index of the next available swapchain image:
     vk::raii::Semaphore imageAcquiredSemaphore( device, vk::SemaphoreCreateInfo() );
     vk::Result          result;
     uint32_t            imageIndex;
-    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, *imageAcquiredSemaphore );
+    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, imageAcquiredSemaphore );
     assert( result == vk::Result::eSuccess );
     assert( imageIndex < swapChainData.images.size() );
 
@@ -157,7 +157,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::Rect2D           scissor( vk::Offset2D( 0, 0 ), vk::Extent2D( surfaceData.extent ) );
 
     // now we record four separate command buffers, one for each quadrant of the screen
-    vk::CommandBufferInheritanceInfo commandBufferInheritanceInfo( *renderPass, 0, *framebuffers[imageIndex] );
+    vk::CommandBufferInheritanceInfo commandBufferInheritanceInfo( renderPass, 0, framebuffers[imageIndex] );
     vk::CommandBufferBeginInfo       secondaryBeginInfo( vk::CommandBufferUsageFlagBits::eOneTimeSubmit | vk::CommandBufferUsageFlagBits::eRenderPassContinue,
                                                    &commandBufferInheritanceInfo );
 
@@ -168,21 +168,21 @@ int main( int /*argc*/, char ** /*argv*/ )
       viewport.y = 25.0f + 250.0f * ( i / 2 );
 
       secondaryCommandBuffers[i].begin( secondaryBeginInfo );
-      secondaryCommandBuffers[i].bindPipeline( vk::PipelineBindPoint::eGraphics, *graphicsPipeline );
-      secondaryCommandBuffers[i].bindDescriptorSets( vk::PipelineBindPoint::eGraphics, *pipelineLayout, 0, { *descriptorSets[i == 0 || i == 3] }, nullptr );
-      secondaryCommandBuffers[i].bindVertexBuffers( 0, { *vertexBufferData.buffer }, offset );
+      secondaryCommandBuffers[i].bindPipeline( vk::PipelineBindPoint::eGraphics, graphicsPipeline );
+      secondaryCommandBuffers[i].bindDescriptorSets( vk::PipelineBindPoint::eGraphics, pipelineLayout, 0, { descriptorSets[i == 0 || i == 3] }, nullptr );
+      secondaryCommandBuffers[i].bindVertexBuffers( 0, { vertexBufferData.buffer }, offset );
       secondaryCommandBuffers[i].setViewport( 0, viewport );
       secondaryCommandBuffers[i].setScissor( 0, scissor );
       secondaryCommandBuffers[i].draw( 12 * 3, 1, 0, 0 );
       secondaryCommandBuffers[i].end();
-      executeCommandBuffers[i] = *secondaryCommandBuffers[i];
+      executeCommandBuffers[i] = secondaryCommandBuffers[i];
     }
 
     std::array<vk::ClearValue, 2> clearValues;
     clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
 
-    vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
+    vk::RenderPassBeginInfo renderPassBeginInfo( renderPass, framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
 
     // specifying VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS means this render pass may ONLY call
     // vkCmdExecuteCommands
@@ -209,7 +209,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::SubmitInfo         submitInfo( *imageAcquiredSemaphore, waitDestinationStageMask, *commandBuffer );
     graphicsQueue.submit( submitInfo, *drawFence );
 
-    while ( vk::Result::eTimeout == device.waitForFences( { *drawFence }, VK_TRUE, vk::su::FenceTimeout ) )
+    while ( vk::Result::eTimeout == device.waitForFences( { drawFence }, VK_TRUE, vk::su::FenceTimeout ) )
       ;
 
     result = presentQueue.presentKHR( vk::PresentInfoKHR( {}, *swapChainData.swapChain, imageIndex, {} ) );

--- a/RAII_Samples/SeparateImageSampler/SeparateImageSampler.cpp
+++ b/RAII_Samples/SeparateImageSampler/SeparateImageSampler.cpp
@@ -82,7 +82,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       vk::raii::su::findGraphicsAndPresentQueueFamilyIndex( physicalDevice, surfaceData.surface );
     vk::raii::Device device = vk::raii::su::makeDevice( physicalDevice, graphicsAndPresentQueueFamilyIndex.first, vk::su::getDeviceExtensions() );
 
-    vk::raii::CommandPool commandPool = vk::raii::CommandPool( device, { {}, graphicsAndPresentQueueFamilyIndex.first } );
+    vk::raii::CommandPool   commandPool   = vk::raii::CommandPool( device, { {}, graphicsAndPresentQueueFamilyIndex.first } );
     vk::raii::CommandBuffer commandBuffer = vk::raii::su::makeCommandBuffer( device, commandPool );
 
     vk::raii::Queue graphicsQueue( device, graphicsAndPresentQueueFamilyIndex.first, 0 );
@@ -103,7 +103,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     glm::mat4x4              mvpcMatrix = vk::su::createModelViewProjectionClipMatrix( surfaceData.extent );
     vk::raii::su::copyToDevice( uniformBufferData.deviceMemory, mvpcMatrix );
 
-    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( *surfaceData.surface ) ).format;
+    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( surfaceData.surface ) ).format;
     vk::raii::RenderPass renderPass  = vk::raii::su::makeRenderPass( device, colorFormat, depthBufferData.format );
 
     glslang::InitializeProcess();
@@ -167,16 +167,16 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::raii::DescriptorPool              descriptorPool( device, descriptorPoolCreateInfo );
 
     // Populate descriptor sets
-    vk::DescriptorSetAllocateInfo descriptorSetAllocateInfo( *descriptorPool, *descriptorSetLayout );
+    vk::DescriptorSetAllocateInfo descriptorSetAllocateInfo( descriptorPool, *descriptorSetLayout );
     vk::raii::DescriptorSet       descriptorSet = std::move( vk::raii::DescriptorSets( device, descriptorSetAllocateInfo ).front() );
 
-    vk::DescriptorBufferInfo              bufferInfo( *uniformBufferData.buffer, 0, sizeof( glm::mat4x4 ) );
-    vk::DescriptorImageInfo               imageInfo( *textureData.sampler, *textureData.imageData.imageView, vk::ImageLayout::eShaderReadOnlyOptimal );
-    vk::DescriptorImageInfo               samplerInfo( *sampler, {}, {} );
+    vk::DescriptorBufferInfo              bufferInfo( uniformBufferData.buffer, 0, sizeof( glm::mat4x4 ) );
+    vk::DescriptorImageInfo               imageInfo( textureData.sampler, textureData.imageData.imageView, vk::ImageLayout::eShaderReadOnlyOptimal );
+    vk::DescriptorImageInfo               samplerInfo( sampler, {}, {} );
     std::array<vk::WriteDescriptorSet, 3> descriptorWrites = { { vk::WriteDescriptorSet(
-                                                                   *descriptorSet, 0, 0, vk::DescriptorType::eUniformBuffer, {}, bufferInfo ),
-                                                                 vk::WriteDescriptorSet( *descriptorSet, 1, 0, vk::DescriptorType::eSampledImage, imageInfo ),
-                                                                 vk::WriteDescriptorSet( *descriptorSet, 2, 0, vk::DescriptorType::eSampler, samplerInfo ) } };
+                                                                   descriptorSet, 0, 0, vk::DescriptorType::eUniformBuffer, {}, bufferInfo ),
+                                                                 vk::WriteDescriptorSet( descriptorSet, 1, 0, vk::DescriptorType::eSampledImage, imageInfo ),
+                                                                 vk::WriteDescriptorSet( descriptorSet, 2, 0, vk::DescriptorType::eSampler, samplerInfo ) } };
     device.updateDescriptorSets( descriptorWrites, nullptr );
 
     /* VULKAN_KEY_END */
@@ -189,7 +189,7 @@ int main( int /*argc*/, char ** /*argv*/ )
                                                                               fragmentShaderModule,
                                                                               nullptr,
                                                                               sizeof( texturedCubeData[0] ),
-                                                                              { { vk::Format::eR32G32B32A32Sfloat, 0 }, { vk::Format::eR32G32Sfloat, 16 } },
+                                                                                   { { vk::Format::eR32G32B32A32Sfloat, 0 }, { vk::Format::eR32G32Sfloat, 16 } },
                                                                               vk::FrontFace::eClockwise,
                                                                               true,
                                                                               pipelineLayout,
@@ -199,7 +199,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::raii::Semaphore imageAcquiredSemaphore( device, vk::SemaphoreCreateInfo() );
     vk::Result          result;
     uint32_t            imageIndex;
-    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, *imageAcquiredSemaphore );
+    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, imageAcquiredSemaphore );
     assert( result == vk::Result::eSuccess );
     assert( imageIndex < swapChainData.images.size() );
 
@@ -207,13 +207,13 @@ int main( int /*argc*/, char ** /*argv*/ )
     clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
 
-    vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
+    vk::RenderPassBeginInfo renderPassBeginInfo( renderPass, framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
     commandBuffer.beginRenderPass( renderPassBeginInfo, vk::SubpassContents::eInline );
 
-    commandBuffer.bindPipeline( vk::PipelineBindPoint::eGraphics, *graphicsPipeline );
-    commandBuffer.bindDescriptorSets( vk::PipelineBindPoint::eGraphics, *pipelineLayout, 0, { *descriptorSet }, nullptr );
+    commandBuffer.bindPipeline( vk::PipelineBindPoint::eGraphics, graphicsPipeline );
+    commandBuffer.bindDescriptorSets( vk::PipelineBindPoint::eGraphics, pipelineLayout, 0, { descriptorSet }, nullptr );
 
-    commandBuffer.bindVertexBuffers( 0, { *vertexBufferData.buffer }, { 0 } );
+    commandBuffer.bindVertexBuffers( 0, { vertexBufferData.buffer }, { 0 } );
     commandBuffer.setViewport(
       0, vk::Viewport( 0.0f, 0.0f, static_cast<float>( surfaceData.extent.width ), static_cast<float>( surfaceData.extent.height ), 0.0f, 1.0f ) );
     commandBuffer.setScissor( 0, vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ) );
@@ -228,7 +228,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::SubmitInfo         submitInfo( *imageAcquiredSemaphore, waitDestinationStageMask, *commandBuffer );
     graphicsQueue.submit( submitInfo, *drawFence );
 
-    while ( vk::Result::eTimeout == device.waitForFences( { *drawFence }, VK_TRUE, vk::su::FenceTimeout ) )
+    while ( vk::Result::eTimeout == device.waitForFences( { drawFence }, VK_TRUE, vk::su::FenceTimeout ) )
       ;
 
     vk::PresentInfoKHR presentInfoKHR( nullptr, *swapChainData.swapChain, imageIndex );

--- a/RAII_Samples/SurfaceCapabilities/SurfaceCapabilities.cpp
+++ b/RAII_Samples/SurfaceCapabilities/SurfaceCapabilities.cpp
@@ -84,11 +84,12 @@ int main( int /*argc*/, char ** /*argv*/ )
       std::cout << "PhysicalDevice " << i << "\n";
       if ( supportsGetSurfaceCapabilities2 )
       {
-        auto surfaceCapabilities2 = physicalDevices[i]
-                                      .getSurfaceCapabilities2KHR<vk::SurfaceCapabilities2KHR,
-                                                                  vk::DisplayNativeHdrSurfaceCapabilitiesAMD,
-                                                                  vk::SharedPresentSurfaceCapabilitiesKHR,
-                                                                  vk::SurfaceProtectedCapabilitiesKHR>( { *surfaceData.surface } );
+        auto surfaceCapabilities2 =
+          physicalDevices[i]
+            .getSurfaceCapabilities2KHR<vk::SurfaceCapabilities2KHR,
+                                        vk::DisplayNativeHdrSurfaceCapabilitiesAMD,
+                                        vk::SharedPresentSurfaceCapabilitiesKHR,
+                                        vk::SurfaceProtectedCapabilitiesKHR>( { static_cast<vk::SurfaceKHR>( surfaceData.surface ) } );
 
         vk::SurfaceCapabilitiesKHR const & surfaceCapabilities = surfaceCapabilities2.get<vk::SurfaceCapabilities2KHR>().surfaceCapabilities;
         cout( surfaceCapabilities );
@@ -121,7 +122,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       }
       else
       {
-        vk::SurfaceCapabilitiesKHR surfaceCapabilities = physicalDevices[i].getSurfaceCapabilitiesKHR( *surfaceData.surface );
+        vk::SurfaceCapabilitiesKHR surfaceCapabilities = physicalDevices[i].getSurfaceCapabilitiesKHR( surfaceData.surface );
         cout( surfaceCapabilities );
       }
     }

--- a/RAII_Samples/SurfaceFormats/SurfaceFormats.cpp
+++ b/RAII_Samples/SurfaceFormats/SurfaceFormats.cpp
@@ -46,7 +46,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     for ( size_t i = 0; i < physicalDevices.size(); i++ )
     {
       std::cout << "PhysicalDevice " << i << "\n";
-      std::vector<vk::SurfaceFormatKHR> surfaceFormats = physicalDevices[i].getSurfaceFormatsKHR( *surfaceData.surface );
+      std::vector<vk::SurfaceFormatKHR> surfaceFormats = physicalDevices[i].getSurfaceFormatsKHR( surfaceData.surface );
       for ( size_t j = 0; j < surfaceFormats.size(); j++ )
       {
         std::cout << std::string( "\t" ) << "Format " << j << "\n";

--- a/RAII_Samples/Template/Template.cpp
+++ b/RAII_Samples/Template/Template.cpp
@@ -44,7 +44,7 @@ int main( int /*argc*/, char ** /*argv*/ )
       vk::raii::su::findGraphicsAndPresentQueueFamilyIndex( physicalDevice, surfaceData.surface );
     vk::raii::Device device = vk::raii::su::makeDevice( physicalDevice, graphicsAndPresentQueueFamilyIndex.first, vk::su::getDeviceExtensions() );
 
-    vk::raii::CommandPool commandPool = vk::raii::CommandPool( device, { {}, graphicsAndPresentQueueFamilyIndex.first } );
+    vk::raii::CommandPool   commandPool   = vk::raii::CommandPool( device, { {}, graphicsAndPresentQueueFamilyIndex.first } );
     vk::raii::CommandBuffer commandBuffer = vk::raii::su::makeCommandBuffer( device, commandPool );
 
     vk::raii::Queue graphicsQueue( device, graphicsAndPresentQueueFamilyIndex.first, 0 );
@@ -76,7 +76,7 @@ int main( int /*argc*/, char ** /*argv*/ )
                                                { vk::DescriptorType::eCombinedImageSampler, 1, vk::ShaderStageFlagBits::eFragment } } );
     vk::raii::PipelineLayout pipelineLayout( device, { {}, *descriptorSetLayout } );
 
-    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( *surfaceData.surface ) ).format;
+    vk::Format           colorFormat = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( surfaceData.surface ) ).format;
     vk::raii::RenderPass renderPass  = vk::raii::su::makeRenderPass( device, colorFormat, depthBufferData.format );
 
     glslang::InitializeProcess();
@@ -92,9 +92,10 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     vk::raii::DescriptorPool descriptorPool =
       vk::raii::su::makeDescriptorPool( device, { { vk::DescriptorType::eUniformBuffer, 1 }, { vk::DescriptorType::eCombinedImageSampler, 1 } } );
-    vk::raii::DescriptorSet descriptorSet = std::move( vk::raii::DescriptorSets( device, { *descriptorPool, *descriptorSetLayout } ).front() );
+    vk::raii::DescriptorSet descriptorSet = std::move( vk::raii::DescriptorSets( device, { descriptorPool, *descriptorSetLayout } ).front() );
 
-    vk::raii::su::updateDescriptorSets( device, descriptorSet, { { vk::DescriptorType::eUniformBuffer, uniformBufferData.buffer, VK_WHOLE_SIZE, nullptr } }, { textureData } );
+    vk::raii::su::updateDescriptorSets(
+      device, descriptorSet, { { vk::DescriptorType::eUniformBuffer, uniformBufferData.buffer, VK_WHOLE_SIZE, nullptr } }, { textureData } );
 
     vk::raii::PipelineCache pipelineCache( device, vk::PipelineCacheCreateInfo() );
     vk::raii::Pipeline      graphicsPipeline = vk::raii::su::makeGraphicsPipeline( device,
@@ -104,7 +105,7 @@ int main( int /*argc*/, char ** /*argv*/ )
                                                                               fragmentShaderModule,
                                                                               nullptr,
                                                                               sizeof( texturedCubeData[0] ),
-                                                                              { { vk::Format::eR32G32B32A32Sfloat, 0 }, { vk::Format::eR32G32Sfloat, 16 } },
+                                                                                   { { vk::Format::eR32G32B32A32Sfloat, 0 }, { vk::Format::eR32G32Sfloat, 16 } },
                                                                               vk::FrontFace::eClockwise,
                                                                               true,
                                                                               pipelineLayout,
@@ -114,20 +115,20 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::raii::Semaphore imageAcquiredSemaphore( device, vk::SemaphoreCreateInfo() );
     vk::Result          result;
     uint32_t            imageIndex;
-    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, *imageAcquiredSemaphore );
+    std::tie( result, imageIndex ) = swapChainData.swapChain.acquireNextImage( vk::su::FenceTimeout, imageAcquiredSemaphore );
     assert( result == vk::Result::eSuccess );
     assert( imageIndex < swapChainData.images.size() );
 
     std::array<vk::ClearValue, 2> clearValues;
     clearValues[0].color        = vk::ClearColorValue( 0.2f, 0.2f, 0.2f, 0.2f );
     clearValues[1].depthStencil = vk::ClearDepthStencilValue( 1.0f, 0 );
-    vk::RenderPassBeginInfo renderPassBeginInfo( *renderPass, *framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
+    vk::RenderPassBeginInfo renderPassBeginInfo( renderPass, framebuffers[imageIndex], vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ), clearValues );
 
     commandBuffer.beginRenderPass( renderPassBeginInfo, vk::SubpassContents::eInline );
-    commandBuffer.bindPipeline( vk::PipelineBindPoint::eGraphics, *graphicsPipeline );
-    commandBuffer.bindDescriptorSets( vk::PipelineBindPoint::eGraphics, *pipelineLayout, 0, { *descriptorSet }, nullptr );
+    commandBuffer.bindPipeline( vk::PipelineBindPoint::eGraphics, graphicsPipeline );
+    commandBuffer.bindDescriptorSets( vk::PipelineBindPoint::eGraphics, pipelineLayout, 0, { descriptorSet }, nullptr );
 
-    commandBuffer.bindVertexBuffers( 0, { *vertexBufferData.buffer }, { 0 } );
+    commandBuffer.bindVertexBuffers( 0, { vertexBufferData.buffer }, { 0 } );
     commandBuffer.setViewport(
       0, vk::Viewport( 0.0f, 0.0f, static_cast<float>( surfaceData.extent.width ), static_cast<float>( surfaceData.extent.height ), 0.0f, 1.0f ) );
     commandBuffer.setScissor( 0, vk::Rect2D( vk::Offset2D( 0, 0 ), surfaceData.extent ) );
@@ -142,7 +143,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::SubmitInfo         submitInfo( *imageAcquiredSemaphore, waitDestinationStageMask, *commandBuffer );
     graphicsQueue.submit( submitInfo, *drawFence );
 
-    while ( vk::Result::eTimeout == device.waitForFences( { *drawFence }, VK_TRUE, vk::su::FenceTimeout ) )
+    while ( vk::Result::eTimeout == device.waitForFences( { drawFence }, VK_TRUE, vk::su::FenceTimeout ) )
       ;
 
     vk::PresentInfoKHR presentInfoKHR( nullptr, *swapChainData.swapChain, imageIndex );

--- a/README.md
+++ b/README.md
@@ -934,6 +934,10 @@ With this define, you can disable these declarations, but you will have to decla
 
 If both, VULKAN_HPP_NO_EXCEPTIONS and VULKAN_HPP_EXPECTED are defined, the vk::raii-classes don't throw exceptions. That is, the actual constructors are not available, but the creation-functions must be used. For more details have a look at the vk_raii_ProgrammingGuide.md.
 
+#### VULKAN_HPP_SMART_HANDLE_IMPLICIT_CAST
+
+Even though the ```vk::UniqueHandles``` and the ```vk::SharedHandles``` are semantically close to pointers, an implicit cast operator to the underlying ```vk::Handle``` might be handy. You can add that implicit cast operator by defining ```VULKAN_HPP_SMART_HANDLE_IMPLICIT_CAST```.
+
 #### VULKAN_HPP_STORAGE_API
 
 With this define you can specify whether the ```DispatchLoaderDynamic``` is imported or exported (see ```VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE```). If ```VULKAN_HPP_STORAGE_API``` is not defined externally, and ```VULKAN_HPP_STORAGE_SHARED``` is defined, depending on the ```VULKAN_HPP_STORAGE_SHARED_EXPORT``` being defined, ```VULKAN_HPP_STORAGE_API``` is either set to ```__declspec( dllexport )``` (for MSVC) / ```__attribute__( ( visibility( "default" ) ) )``` (for gcc or clang) or ```__declspec( dllimport )``` (for MSVC), respectively. For other compilers, you might specify the corresponding storage by defining ```VULKAN_HPP_STORAGE_API``` on your own.

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -8404,6 +8404,11 @@ ${moveAssignmentInstructions}
       return m_${handleName};
     }
 
+    operator VULKAN_HPP_NAMESPACE::${handleType}() const VULKAN_HPP_NOEXCEPT
+    {
+      return m_${handleName};
+    }
+
     void clear() VULKAN_HPP_NOEXCEPT
     {
 ${clearMembers}
@@ -9016,7 +9021,7 @@ std::string
     {
       if ( destructorParam.type.type == "Vk" + parentType )
       {
-        initializationList += "m_" + parentName + "( *" + parentName + " ), ";
+        initializationList += "m_" + parentName + "( " + parentName + " ), ";
       }
       else if ( destructorParam.type.type == handle.first )
       {

--- a/XMLHelper.hpp
+++ b/XMLHelper.hpp
@@ -274,7 +274,7 @@ inline std::vector<tinyxml2::XMLElement const *> getChildElements( ElementContai
   return childElements;
 }
 
-inline bool isHexNumber(std::string const& name)
+inline bool isHexNumber( std::string const & name )
 {
   return name.starts_with( "0x" ) && ( name.find_first_not_of( "0123456789ABCDEF", 2 ) == std::string::npos );
 }

--- a/samples/utils/utils.cpp
+++ b/samples/utils/utils.cpp
@@ -354,13 +354,13 @@ namespace vk
                                                                 void * /*pUserData*/ )
     {
 #if !defined( NDEBUG )
-      if ( static_cast<uint32_t>(pCallbackData->messageIdNumber) == 0x822806fa )
+      if ( static_cast<uint32_t>( pCallbackData->messageIdNumber ) == 0x822806fa )
       {
         // Validation Warning: vkCreateInstance(): to enable extension VK_EXT_debug_utils, but this extension is intended to support use by applications when
         // debugging and it is strongly recommended that it be otherwise avoided.
         return vk::False;
       }
-      else if ( static_cast<uint32_t>(pCallbackData->messageIdNumber) == 0xe8d1a9fe )
+      else if ( static_cast<uint32_t>( pCallbackData->messageIdNumber ) == 0xe8d1a9fe )
       {
         // Validation Performance Warning: Using debug builds of the validation layers *will* adversely affect performance.
         return vk::False;

--- a/snippets/SharedHandle.hpp
+++ b/snippets/SharedHandle.hpp
@@ -69,7 +69,10 @@ class ReferenceCounter
 {
 public:
   template <typename... Args>
-  ReferenceCounter( Args &&... control_args ) : m_header( std::forward<Args>( control_args )... ){}
+  ReferenceCounter( Args &&... control_args ) : m_header( std::forward<Args>( control_args )... )
+  {
+  }
+
   ReferenceCounter( const ReferenceCounter & )             = delete;
   ReferenceCounter & operator=( const ReferenceCounter & ) = delete;
 
@@ -162,6 +165,13 @@ public:
   {
     return bool( m_handle );
   }
+
+#if defined( VULKAN_HPP_SMART_HANDLE_IMPLICIT_CAST )
+  operator HandleType() const VULKAN_HPP_NOEXCEPT
+  {
+    return m_handle;
+  }
+#endif
 
   const HandleType * operator->() const VULKAN_HPP_NOEXCEPT
   {

--- a/snippets/UniqueHandle.hpp
+++ b/snippets/UniqueHandle.hpp
@@ -1,127 +1,131 @@
 #if !defined( VULKAN_HPP_NO_SMART_HANDLE )
-  template <typename Type, typename Dispatch>
-  class UniqueHandleTraits;
+template <typename Type, typename Dispatch>
+class UniqueHandleTraits;
 
-  template <typename Type, typename Dispatch>
-  class UniqueHandle : public UniqueHandleTraits<Type, Dispatch>::deleter
+template <typename Type, typename Dispatch>
+class UniqueHandle : public UniqueHandleTraits<Type, Dispatch>::deleter
+{
+private:
+  using Deleter = typename UniqueHandleTraits<Type, Dispatch>::deleter;
+
+public:
+  using element_type = Type;
+
+  UniqueHandle() : Deleter(), m_value() {}
+
+  explicit UniqueHandle( Type const & value, Deleter const & deleter = Deleter() ) VULKAN_HPP_NOEXCEPT
+    : Deleter( deleter )
+    , m_value( value )
   {
-  private:
-    using Deleter = typename UniqueHandleTraits<Type, Dispatch>::deleter;
+  }
 
-  public:
-    using element_type = Type;
+  UniqueHandle( UniqueHandle const & ) = delete;
 
-    UniqueHandle()
-      : Deleter()
-      , m_value()
-    {}
+  UniqueHandle( UniqueHandle && other ) VULKAN_HPP_NOEXCEPT
+    : Deleter( std::move( static_cast<Deleter &>( other ) ) )
+    , m_value( other.release() )
+  {
+  }
 
-    explicit UniqueHandle( Type const & value, Deleter const & deleter = Deleter() ) VULKAN_HPP_NOEXCEPT
-      : Deleter( deleter )
-      , m_value( value )
-    {}
+  ~UniqueHandle() VULKAN_HPP_NOEXCEPT
+  {
+    if ( m_value )
+    {
+      this->destroy( m_value );
+    }
+  }
 
-    UniqueHandle( UniqueHandle const & ) = delete;
+  UniqueHandle & operator=( UniqueHandle const & ) = delete;
 
-    UniqueHandle( UniqueHandle && other ) VULKAN_HPP_NOEXCEPT
-      : Deleter( std::move( static_cast<Deleter &>( other ) ) )
-      , m_value( other.release() )
-    {}
+  UniqueHandle & operator=( UniqueHandle && other ) VULKAN_HPP_NOEXCEPT
+  {
+    reset( other.release() );
+    *static_cast<Deleter *>( this ) = std::move( static_cast<Deleter &>( other ) );
+    return *this;
+  }
 
-    ~UniqueHandle() VULKAN_HPP_NOEXCEPT
+  explicit operator bool() const VULKAN_HPP_NOEXCEPT
+  {
+    return m_value.operator bool();
+  }
+
+#  if defined( VULKAN_HPP_SMART_HANDLE_IMPLICIT_CAST )
+  operator Type() const VULKAN_HPP_NOEXCEPT
+  {
+    return m_value;
+  }
+#  endif
+
+  Type const * operator->() const VULKAN_HPP_NOEXCEPT
+  {
+    return &m_value;
+  }
+
+  Type * operator->() VULKAN_HPP_NOEXCEPT
+  {
+    return &m_value;
+  }
+
+  Type const & operator*() const VULKAN_HPP_NOEXCEPT
+  {
+    return m_value;
+  }
+
+  Type & operator*() VULKAN_HPP_NOEXCEPT
+  {
+    return m_value;
+  }
+
+  const Type & get() const VULKAN_HPP_NOEXCEPT
+  {
+    return m_value;
+  }
+
+  Type & get() VULKAN_HPP_NOEXCEPT
+  {
+    return m_value;
+  }
+
+  void reset( Type const & value = Type() ) VULKAN_HPP_NOEXCEPT
+  {
+    if ( m_value != value )
     {
       if ( m_value )
       {
         this->destroy( m_value );
       }
+      m_value = value;
     }
-
-    UniqueHandle & operator=( UniqueHandle const & ) = delete;
-
-    UniqueHandle & operator=( UniqueHandle && other ) VULKAN_HPP_NOEXCEPT
-    {
-      reset( other.release() );
-      *static_cast<Deleter *>( this ) = std::move( static_cast<Deleter &>( other ) );
-      return *this;
-    }
-
-    explicit operator bool() const VULKAN_HPP_NOEXCEPT
-    {
-      return m_value.operator bool();
-    }
-
-    Type const * operator->() const VULKAN_HPP_NOEXCEPT
-    {
-      return &m_value;
-    }
-
-    Type * operator->() VULKAN_HPP_NOEXCEPT
-    {
-      return &m_value;
-    }
-
-    Type const & operator*() const VULKAN_HPP_NOEXCEPT
-    {
-      return m_value;
-    }
-
-    Type & operator*() VULKAN_HPP_NOEXCEPT
-    {
-      return m_value;
-    }
-
-    const Type & get() const VULKAN_HPP_NOEXCEPT
-    {
-      return m_value;
-    }
-
-    Type & get() VULKAN_HPP_NOEXCEPT
-    {
-      return m_value;
-    }
-
-    void reset( Type const & value = Type() ) VULKAN_HPP_NOEXCEPT
-    {
-      if ( m_value != value )
-      {
-        if ( m_value )
-        {
-          this->destroy( m_value );
-        }
-        m_value = value;
-      }
-    }
-
-    Type release() VULKAN_HPP_NOEXCEPT
-    {
-      Type value = m_value;
-      m_value    = nullptr;
-      return value;
-    }
-
-    void swap( UniqueHandle<Type, Dispatch> & rhs ) VULKAN_HPP_NOEXCEPT
-    {
-      std::swap( m_value, rhs.m_value );
-      std::swap( static_cast<Deleter &>( *this ), static_cast<Deleter &>( rhs ) );
-    }
-
-  private:
-    Type m_value;
-  };
-
-  template <typename UniqueType>
-  VULKAN_HPP_INLINE std::vector<typename UniqueType::element_type>
-                    uniqueToRaw( std::vector<UniqueType> const & handles )
-  {
-    std::vector<typename UniqueType::element_type> newBuffer( handles.size() );
-    std::transform( handles.begin(), handles.end(), newBuffer.begin(), []( UniqueType const & handle ) { return handle.get(); } );
-    return newBuffer;
   }
 
-  template <typename Type, typename Dispatch>
-  VULKAN_HPP_INLINE void swap( UniqueHandle<Type, Dispatch> & lhs,
-                               UniqueHandle<Type, Dispatch> & rhs ) VULKAN_HPP_NOEXCEPT
+  Type release() VULKAN_HPP_NOEXCEPT
   {
-    lhs.swap( rhs );
+    Type value = m_value;
+    m_value    = nullptr;
+    return value;
   }
+
+  void swap( UniqueHandle<Type, Dispatch> & rhs ) VULKAN_HPP_NOEXCEPT
+  {
+    std::swap( m_value, rhs.m_value );
+    std::swap( static_cast<Deleter &>( *this ), static_cast<Deleter &>( rhs ) );
+  }
+
+private:
+  Type m_value;
+};
+
+template <typename UniqueType>
+VULKAN_HPP_INLINE std::vector<typename UniqueType::element_type> uniqueToRaw( std::vector<UniqueType> const & handles )
+{
+  std::vector<typename UniqueType::element_type> newBuffer( handles.size() );
+  std::transform( handles.begin(), handles.end(), newBuffer.begin(), []( UniqueType const & handle ) { return handle.get(); } );
+  return newBuffer;
+}
+
+template <typename Type, typename Dispatch>
+VULKAN_HPP_INLINE void swap( UniqueHandle<Type, Dispatch> & lhs, UniqueHandle<Type, Dispatch> & rhs ) VULKAN_HPP_NOEXCEPT
+{
+  lhs.swap( rhs );
+}
 #endif

--- a/tests/NoExceptionsRAII/NoExceptionsRAII.cpp
+++ b/tests/NoExceptionsRAII/NoExceptionsRAII.cpp
@@ -23,7 +23,7 @@
 
 // only if VULKAN_HPP_RAII_NO_EXCEPTIONS really is defined, this test is meaningfull and needs to compile and run.
 #if defined( VULKAN_HPP_RAII_NO_EXCEPTIONS )
-#include <vulkan/vulkan_raii.hpp>
+#  include <vulkan/vulkan_raii.hpp>
 
 static char const * AppName    = "NoExceptions";
 static char const * EngineName = "Vulkan.hpp";
@@ -56,16 +56,15 @@ int main( int /*argc*/, char ** /*argv*/ )
   // create a Device
   float                     queuePriority = 0.0f;
   vk::DeviceQueueCreateInfo deviceQueueCreateInfo( vk::DeviceQueueCreateFlags(), static_cast<uint32_t>( graphicsQueueFamilyIndex ), 1, &queuePriority );
-  auto device = physicalDevice.createDevice( vk::DeviceCreateInfo( vk::DeviceCreateFlags(), deviceQueueCreateInfo ) );
+  auto                      device = physicalDevice.createDevice( vk::DeviceCreateInfo( vk::DeviceCreateFlags(), deviceQueueCreateInfo ) );
   assert( device.has_value() );
 
   // create a CommandPool to allocate a CommandBuffer from
-  auto commandPool =
-    device->createCommandPool( vk::CommandPoolCreateInfo( vk::CommandPoolCreateFlags(), deviceQueueCreateInfo.queueFamilyIndex ) );
+  auto commandPool = device->createCommandPool( vk::CommandPoolCreateInfo( vk::CommandPoolCreateFlags(), deviceQueueCreateInfo.queueFamilyIndex ) );
   assert( commandPool.has_value() );
 
   // allocate a CommandBuffer from the CommandPool
-  auto commandBuffers = device->allocateCommandBuffers( vk::CommandBufferAllocateInfo( **commandPool, vk::CommandBufferLevel::ePrimary, 1 ) );
+  auto commandBuffers = device->allocateCommandBuffers( vk::CommandBufferAllocateInfo( *commandPool, vk::CommandBufferLevel::ePrimary, 1 ) );
   assert( commandBuffers.has_value() );
 
   auto commandBuffer = std::move( commandBuffers->front() );

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -919,6 +919,13 @@ namespace VULKAN_HPP_NAMESPACE
       return m_value.operator bool();
     }
 
+#    if defined( VULKAN_HPP_SMART_HANDLE_IMPLICIT_CAST )
+    operator Type() const VULKAN_HPP_NOEXCEPT
+    {
+      return m_value;
+    }
+#    endif
+
     Type const * operator->() const VULKAN_HPP_NOEXCEPT
     {
       return &m_value;

--- a/vulkan/vulkan_raii.hpp
+++ b/vulkan/vulkan_raii.hpp
@@ -2833,6 +2833,11 @@ namespace VULKAN_HPP_NAMESPACE
         return m_instance;
       }
 
+      operator VULKAN_HPP_NAMESPACE::Instance() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_instance;
+      }
+
       void clear() VULKAN_HPP_NOEXCEPT
       {
         if ( m_instance )
@@ -3096,6 +3101,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::PhysicalDevice const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_physicalDevice;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::PhysicalDevice() const VULKAN_HPP_NOEXCEPT
       {
         return m_physicalDevice;
       }
@@ -3557,6 +3567,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::Device const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_device;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::Device() const VULKAN_HPP_NOEXCEPT
       {
         return m_device;
       }
@@ -4584,7 +4599,7 @@ namespace VULKAN_HPP_NAMESPACE
       AccelerationStructureKHR( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                                 VkAccelerationStructureKHR                                                      accelerationStructure,
                                 VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_accelerationStructure( accelerationStructure )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -4624,6 +4639,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::AccelerationStructureKHR const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_accelerationStructure;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::AccelerationStructureKHR() const VULKAN_HPP_NOEXCEPT
       {
         return m_accelerationStructure;
       }
@@ -4699,7 +4719,7 @@ namespace VULKAN_HPP_NAMESPACE
       AccelerationStructureNV( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                                VkAccelerationStructureNV                                                       accelerationStructure,
                                VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_accelerationStructure( accelerationStructure )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -4739,6 +4759,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::AccelerationStructureNV const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_accelerationStructure;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::AccelerationStructureNV() const VULKAN_HPP_NOEXCEPT
       {
         return m_accelerationStructure;
       }
@@ -4822,7 +4847,7 @@ namespace VULKAN_HPP_NAMESPACE
       Buffer( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
               VkBuffer                                                                        buffer,
               VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_buffer( buffer )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -4862,6 +4887,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::Buffer const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_buffer;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::Buffer() const VULKAN_HPP_NOEXCEPT
       {
         return m_buffer;
       }
@@ -4943,7 +4973,7 @@ namespace VULKAN_HPP_NAMESPACE
       BufferCollectionFUCHSIA( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                                VkBufferCollectionFUCHSIA                                                       collection,
                                VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_collection( collection )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -4983,6 +5013,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::BufferCollectionFUCHSIA const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_collection;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::BufferCollectionFUCHSIA() const VULKAN_HPP_NOEXCEPT
       {
         return m_collection;
       }
@@ -5067,7 +5102,7 @@ namespace VULKAN_HPP_NAMESPACE
       BufferView( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                   VkBufferView                                                                    bufferView,
                   VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_bufferView( bufferView )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -5107,6 +5142,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::BufferView const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_bufferView;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::BufferView() const VULKAN_HPP_NOEXCEPT
       {
         return m_bufferView;
       }
@@ -5181,7 +5221,7 @@ namespace VULKAN_HPP_NAMESPACE
       CommandPool( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                    VkCommandPool                                                                   commandPool,
                    VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_commandPool( commandPool )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -5221,6 +5261,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::CommandPool const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_commandPool;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::CommandPool() const VULKAN_HPP_NOEXCEPT
       {
         return m_commandPool;
       }
@@ -5296,7 +5341,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     public:
       CommandBuffer( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const & device, VkCommandBuffer commandBuffer, VkCommandPool commandPool )
-        : m_device( *device ), m_commandPool( commandPool ), m_commandBuffer( commandBuffer ), m_dispatcher( device.getDispatcher() )
+        : m_device( device ), m_commandPool( commandPool ), m_commandBuffer( commandBuffer ), m_dispatcher( device.getDispatcher() )
       {
       }
 
@@ -5333,6 +5378,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::CommandBuffer const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_commandBuffer;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::CommandBuffer() const VULKAN_HPP_NOEXCEPT
       {
         return m_commandBuffer;
       }
@@ -6362,7 +6412,7 @@ namespace VULKAN_HPP_NAMESPACE
       CuFunctionNVX( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                      VkCuFunctionNVX                                                                 function,
                      VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_function( function )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -6402,6 +6452,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::CuFunctionNVX const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_function;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::CuFunctionNVX() const VULKAN_HPP_NOEXCEPT
       {
         return m_function;
       }
@@ -6476,7 +6531,7 @@ namespace VULKAN_HPP_NAMESPACE
       CuModuleNVX( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                    VkCuModuleNVX                                                                   module,
                    VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_module( module )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -6516,6 +6571,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::CuModuleNVX const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_module;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::CuModuleNVX() const VULKAN_HPP_NOEXCEPT
       {
         return m_module;
       }
@@ -6591,7 +6651,7 @@ namespace VULKAN_HPP_NAMESPACE
       CudaFunctionNV( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                       VkCudaFunctionNV                                                                function,
                       VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_function( function )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -6631,6 +6691,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::CudaFunctionNV const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_function;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::CudaFunctionNV() const VULKAN_HPP_NOEXCEPT
       {
         return m_function;
       }
@@ -6707,7 +6772,7 @@ namespace VULKAN_HPP_NAMESPACE
       CudaModuleNV( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                     VkCudaModuleNV                                                                  module,
                     VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_module( module )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -6747,6 +6812,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::CudaModuleNV const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_module;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::CudaModuleNV() const VULKAN_HPP_NOEXCEPT
       {
         return m_module;
       }
@@ -6826,7 +6896,7 @@ namespace VULKAN_HPP_NAMESPACE
       DebugReportCallbackEXT( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Instance const &               instance,
                               VkDebugReportCallbackEXT                                                        callback,
                               VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_instance( *instance )
+        : m_instance( instance )
         , m_callback( callback )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( instance.getDispatcher() )
@@ -6866,6 +6936,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::DebugReportCallbackEXT const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_callback;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::DebugReportCallbackEXT() const VULKAN_HPP_NOEXCEPT
       {
         return m_callback;
       }
@@ -6941,7 +7016,7 @@ namespace VULKAN_HPP_NAMESPACE
       DebugUtilsMessengerEXT( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Instance const &               instance,
                               VkDebugUtilsMessengerEXT                                                        messenger,
                               VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_instance( *instance )
+        : m_instance( instance )
         , m_messenger( messenger )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( instance.getDispatcher() )
@@ -6981,6 +7056,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::DebugUtilsMessengerEXT const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_messenger;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::DebugUtilsMessengerEXT() const VULKAN_HPP_NOEXCEPT
       {
         return m_messenger;
       }
@@ -7055,7 +7135,7 @@ namespace VULKAN_HPP_NAMESPACE
       DeferredOperationKHR( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                             VkDeferredOperationKHR                                                          operation,
                             VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_operation( operation )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -7095,6 +7175,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::DeferredOperationKHR const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_operation;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::DeferredOperationKHR() const VULKAN_HPP_NOEXCEPT
       {
         return m_operation;
       }
@@ -7178,7 +7263,7 @@ namespace VULKAN_HPP_NAMESPACE
       DescriptorPool( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                       VkDescriptorPool                                                                descriptorPool,
                       VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_descriptorPool( descriptorPool )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -7218,6 +7303,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::DescriptorPool const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_descriptorPool;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::DescriptorPool() const VULKAN_HPP_NOEXCEPT
       {
         return m_descriptorPool;
       }
@@ -7286,7 +7376,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     public:
       DescriptorSet( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const & device, VkDescriptorSet descriptorSet, VkDescriptorPool descriptorPool )
-        : m_device( *device ), m_descriptorPool( descriptorPool ), m_descriptorSet( descriptorSet ), m_dispatcher( device.getDispatcher() )
+        : m_device( device ), m_descriptorPool( descriptorPool ), m_descriptorSet( descriptorSet ), m_dispatcher( device.getDispatcher() )
       {
       }
 
@@ -7323,6 +7413,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::DescriptorSet const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_descriptorSet;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::DescriptorSet() const VULKAN_HPP_NOEXCEPT
       {
         return m_descriptorSet;
       }
@@ -7439,7 +7534,7 @@ namespace VULKAN_HPP_NAMESPACE
       DescriptorSetLayout( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                            VkDescriptorSetLayout                                                           descriptorSetLayout,
                            VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_descriptorSetLayout( descriptorSetLayout )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -7479,6 +7574,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::DescriptorSetLayout const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_descriptorSetLayout;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::DescriptorSetLayout() const VULKAN_HPP_NOEXCEPT
       {
         return m_descriptorSetLayout;
       }
@@ -7560,7 +7660,7 @@ namespace VULKAN_HPP_NAMESPACE
       DescriptorUpdateTemplate( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                                 VkDescriptorUpdateTemplate                                                      descriptorUpdateTemplate,
                                 VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_descriptorUpdateTemplate( descriptorUpdateTemplate )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -7600,6 +7700,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::DescriptorUpdateTemplate const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_descriptorUpdateTemplate;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::DescriptorUpdateTemplate() const VULKAN_HPP_NOEXCEPT
       {
         return m_descriptorUpdateTemplate;
       }
@@ -7675,7 +7780,7 @@ namespace VULKAN_HPP_NAMESPACE
       DeviceMemory( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                     VkDeviceMemory                                                                  memory,
                     VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_memory( memory )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -7715,6 +7820,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::DeviceMemory const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_memory;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::DeviceMemory() const VULKAN_HPP_NOEXCEPT
       {
         return m_memory;
       }
@@ -7823,7 +7933,7 @@ namespace VULKAN_HPP_NAMESPACE
 #  endif
 
       DisplayKHR( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::PhysicalDevice const & physicalDevice, VkDisplayKHR display )
-        : m_physicalDevice( *physicalDevice ), m_display( display ), m_dispatcher( physicalDevice.getDispatcher() )
+        : m_physicalDevice( physicalDevice ), m_display( display ), m_dispatcher( physicalDevice.getDispatcher() )
       {
       }
 
@@ -7858,6 +7968,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::DisplayKHR const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_display;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::DisplayKHR() const VULKAN_HPP_NOEXCEPT
       {
         return m_display;
       }
@@ -8014,6 +8129,11 @@ namespace VULKAN_HPP_NAMESPACE
         return m_displayModeKHR;
       }
 
+      operator VULKAN_HPP_NAMESPACE::DisplayModeKHR() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_displayModeKHR;
+      }
+
       void clear() VULKAN_HPP_NOEXCEPT
       {
         m_physicalDevice = nullptr;
@@ -8074,7 +8194,7 @@ namespace VULKAN_HPP_NAMESPACE
       Event( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
              VkEvent                                                                         event,
              VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_event( event )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -8114,6 +8234,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::Event const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_event;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::Event() const VULKAN_HPP_NOEXCEPT
       {
         return m_event;
       }
@@ -8215,7 +8340,7 @@ namespace VULKAN_HPP_NAMESPACE
       Fence( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
              VkFence                                                                         fence,
              VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_fence( fence )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -8255,6 +8380,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::Fence const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_fence;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::Fence() const VULKAN_HPP_NOEXCEPT
       {
         return m_fence;
       }
@@ -8333,7 +8463,7 @@ namespace VULKAN_HPP_NAMESPACE
       Framebuffer( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                    VkFramebuffer                                                                   framebuffer,
                    VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_framebuffer( framebuffer )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -8373,6 +8503,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::Framebuffer const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_framebuffer;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::Framebuffer() const VULKAN_HPP_NOEXCEPT
       {
         return m_framebuffer;
       }
@@ -8451,7 +8586,7 @@ namespace VULKAN_HPP_NAMESPACE
       Image( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
              VkImage                                                                         image,
              VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_image( image )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -8491,6 +8626,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::Image const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_image;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::Image() const VULKAN_HPP_NOEXCEPT
       {
         return m_image;
       }
@@ -8598,7 +8738,7 @@ namespace VULKAN_HPP_NAMESPACE
       ImageView( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                  VkImageView                                                                     imageView,
                  VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_imageView( imageView )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -8638,6 +8778,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::ImageView const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_imageView;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::ImageView() const VULKAN_HPP_NOEXCEPT
       {
         return m_imageView;
       }
@@ -8716,7 +8861,7 @@ namespace VULKAN_HPP_NAMESPACE
       IndirectCommandsLayoutNV( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                                 VkIndirectCommandsLayoutNV                                                      indirectCommandsLayout,
                                 VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_indirectCommandsLayout( indirectCommandsLayout )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -8756,6 +8901,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::IndirectCommandsLayoutNV const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_indirectCommandsLayout;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::IndirectCommandsLayoutNV() const VULKAN_HPP_NOEXCEPT
       {
         return m_indirectCommandsLayout;
       }
@@ -8831,7 +8981,7 @@ namespace VULKAN_HPP_NAMESPACE
       MicromapEXT( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                    VkMicromapEXT                                                                   micromap,
                    VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_micromap( micromap )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -8871,6 +9021,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::MicromapEXT const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_micromap;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::MicromapEXT() const VULKAN_HPP_NOEXCEPT
       {
         return m_micromap;
       }
@@ -8945,7 +9100,7 @@ namespace VULKAN_HPP_NAMESPACE
       OpticalFlowSessionNV( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                             VkOpticalFlowSessionNV                                                          session,
                             VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_session( session )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -8985,6 +9140,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::OpticalFlowSessionNV const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_session;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::OpticalFlowSessionNV() const VULKAN_HPP_NOEXCEPT
       {
         return m_session;
       }
@@ -9063,7 +9223,7 @@ namespace VULKAN_HPP_NAMESPACE
 #  endif
 
       PerformanceConfigurationINTEL( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const & device, VkPerformanceConfigurationINTEL configuration )
-        : m_device( *device ), m_configuration( configuration ), m_dispatcher( device.getDispatcher() )
+        : m_device( device ), m_configuration( configuration ), m_dispatcher( device.getDispatcher() )
       {
       }
 
@@ -9098,6 +9258,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::PerformanceConfigurationINTEL const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_configuration;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::PerformanceConfigurationINTEL() const VULKAN_HPP_NOEXCEPT
       {
         return m_configuration;
       }
@@ -9168,7 +9333,7 @@ namespace VULKAN_HPP_NAMESPACE
       PipelineCache( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                      VkPipelineCache                                                                 pipelineCache,
                      VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_pipelineCache( pipelineCache )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -9208,6 +9373,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::PipelineCache const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_pipelineCache;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::PipelineCache() const VULKAN_HPP_NOEXCEPT
       {
         return m_pipelineCache;
       }
@@ -9334,7 +9504,7 @@ namespace VULKAN_HPP_NAMESPACE
                 VkPipeline                                                                      pipeline,
                 VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator   = nullptr,
                 VULKAN_HPP_NAMESPACE::Result                                                    successCode = VULKAN_HPP_NAMESPACE::Result::eSuccess )
-        : m_device( *device )
+        : m_device( device )
         , m_pipeline( pipeline )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_constructorSuccessCode( successCode )
@@ -9377,6 +9547,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::Pipeline const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_pipeline;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::Pipeline() const VULKAN_HPP_NOEXCEPT
       {
         return m_pipeline;
       }
@@ -9572,7 +9747,7 @@ namespace VULKAN_HPP_NAMESPACE
       PipelineLayout( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                       VkPipelineLayout                                                                pipelineLayout,
                       VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_pipelineLayout( pipelineLayout )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -9612,6 +9787,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::PipelineLayout const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_pipelineLayout;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::PipelineLayout() const VULKAN_HPP_NOEXCEPT
       {
         return m_pipelineLayout;
       }
@@ -9687,7 +9867,7 @@ namespace VULKAN_HPP_NAMESPACE
       PrivateDataSlot( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                        VkPrivateDataSlot                                                               privateDataSlot,
                        VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_privateDataSlot( privateDataSlot )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -9727,6 +9907,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::PrivateDataSlot const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_privateDataSlot;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::PrivateDataSlot() const VULKAN_HPP_NOEXCEPT
       {
         return m_privateDataSlot;
       }
@@ -9802,7 +9987,7 @@ namespace VULKAN_HPP_NAMESPACE
       QueryPool( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                  VkQueryPool                                                                     queryPool,
                  VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_queryPool( queryPool )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -9842,6 +10027,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::QueryPool const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_queryPool;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::QueryPool() const VULKAN_HPP_NOEXCEPT
       {
         return m_queryPool;
       }
@@ -9986,6 +10176,11 @@ namespace VULKAN_HPP_NAMESPACE
         return m_queue;
       }
 
+      operator VULKAN_HPP_NAMESPACE::Queue() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_queue;
+      }
+
       void clear() VULKAN_HPP_NOEXCEPT
       {
         m_queue      = nullptr;
@@ -10093,7 +10288,7 @@ namespace VULKAN_HPP_NAMESPACE
       RenderPass( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                   VkRenderPass                                                                    renderPass,
                   VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_renderPass( renderPass )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -10133,6 +10328,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::RenderPass const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_renderPass;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::RenderPass() const VULKAN_HPP_NOEXCEPT
       {
         return m_renderPass;
       }
@@ -10215,7 +10415,7 @@ namespace VULKAN_HPP_NAMESPACE
       Sampler( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                VkSampler                                                                       sampler,
                VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_sampler( sampler )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -10255,6 +10455,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::Sampler const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_sampler;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::Sampler() const VULKAN_HPP_NOEXCEPT
       {
         return m_sampler;
       }
@@ -10329,7 +10534,7 @@ namespace VULKAN_HPP_NAMESPACE
       SamplerYcbcrConversion( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                               VkSamplerYcbcrConversion                                                        ycbcrConversion,
                               VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_ycbcrConversion( ycbcrConversion )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -10369,6 +10574,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::SamplerYcbcrConversion const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_ycbcrConversion;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::SamplerYcbcrConversion() const VULKAN_HPP_NOEXCEPT
       {
         return m_ycbcrConversion;
       }
@@ -10444,7 +10654,7 @@ namespace VULKAN_HPP_NAMESPACE
       Semaphore( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                  VkSemaphore                                                                     semaphore,
                  VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_semaphore( semaphore )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -10484,6 +10694,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::Semaphore const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_semaphore;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::Semaphore() const VULKAN_HPP_NOEXCEPT
       {
         return m_semaphore;
       }
@@ -10566,7 +10781,7 @@ namespace VULKAN_HPP_NAMESPACE
       ShaderEXT( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                  VkShaderEXT                                                                     shader,
                  VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_shader( shader )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -10606,6 +10821,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::ShaderEXT const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_shader;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::ShaderEXT() const VULKAN_HPP_NOEXCEPT
       {
         return m_shader;
       }
@@ -10711,7 +10931,7 @@ namespace VULKAN_HPP_NAMESPACE
       ShaderModule( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                     VkShaderModule                                                                  shaderModule,
                     VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_shaderModule( shaderModule )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -10751,6 +10971,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::ShaderModule const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_shaderModule;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::ShaderModule() const VULKAN_HPP_NOEXCEPT
       {
         return m_shaderModule;
       }
@@ -10981,7 +11206,7 @@ namespace VULKAN_HPP_NAMESPACE
       SurfaceKHR( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Instance const &               instance,
                   VkSurfaceKHR                                                                    surface,
                   VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_instance( *instance )
+        : m_instance( instance )
         , m_surface( surface )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( instance.getDispatcher() )
@@ -11021,6 +11246,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::SurfaceKHR const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_surface;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::SurfaceKHR() const VULKAN_HPP_NOEXCEPT
       {
         return m_surface;
       }
@@ -11095,7 +11325,7 @@ namespace VULKAN_HPP_NAMESPACE
       SwapchainKHR( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                     VkSwapchainKHR                                                                  swapchain,
                     VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_swapchain( swapchain )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -11135,6 +11365,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::SwapchainKHR const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_swapchain;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::SwapchainKHR() const VULKAN_HPP_NOEXCEPT
       {
         return m_swapchain;
       }
@@ -11285,7 +11520,7 @@ namespace VULKAN_HPP_NAMESPACE
       ValidationCacheEXT( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                           VkValidationCacheEXT                                                            validationCache,
                           VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_validationCache( validationCache )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -11325,6 +11560,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::ValidationCacheEXT const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_validationCache;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::ValidationCacheEXT() const VULKAN_HPP_NOEXCEPT
       {
         return m_validationCache;
       }
@@ -11406,7 +11646,7 @@ namespace VULKAN_HPP_NAMESPACE
       VideoSessionKHR( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                        VkVideoSessionKHR                                                               videoSession,
                        VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_videoSession( videoSession )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -11446,6 +11686,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::VideoSessionKHR const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_videoSession;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::VideoSessionKHR() const VULKAN_HPP_NOEXCEPT
       {
         return m_videoSession;
       }
@@ -11527,7 +11772,7 @@ namespace VULKAN_HPP_NAMESPACE
       VideoSessionParametersKHR( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                                  VkVideoSessionParametersKHR                                                     videoSessionParameters,
                                  VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_videoSessionParameters( videoSessionParameters )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -11567,6 +11812,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::VideoSessionParametersKHR const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_videoSessionParameters;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::VideoSessionParametersKHR() const VULKAN_HPP_NOEXCEPT
       {
         return m_videoSessionParameters;
       }

--- a/vulkan/vulkan_shared.hpp
+++ b/vulkan/vulkan_shared.hpp
@@ -182,6 +182,13 @@ namespace VULKAN_HPP_NAMESPACE
       return bool( m_handle );
     }
 
+#  if defined( VULKAN_HPP_SMART_HANDLE_IMPLICIT_CAST )
+    operator HandleType() const VULKAN_HPP_NOEXCEPT
+    {
+      return m_handle;
+    }
+#  endif
+
     const HandleType * operator->() const VULKAN_HPP_NOEXCEPT
     {
       return &m_handle;

--- a/vulkan/vulkansc.hpp
+++ b/vulkan/vulkansc.hpp
@@ -919,6 +919,13 @@ namespace VULKAN_HPP_NAMESPACE
       return m_value.operator bool();
     }
 
+#    if defined( VULKAN_HPP_SMART_HANDLE_IMPLICIT_CAST )
+    operator Type() const VULKAN_HPP_NOEXCEPT
+    {
+      return m_value;
+    }
+#    endif
+
     Type const * operator->() const VULKAN_HPP_NOEXCEPT
     {
       return &m_value;

--- a/vulkan/vulkansc_raii.hpp
+++ b/vulkan/vulkansc_raii.hpp
@@ -1256,6 +1256,11 @@ namespace VULKAN_HPP_NAMESPACE
         return m_instance;
       }
 
+      operator VULKAN_HPP_NAMESPACE::Instance() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_instance;
+      }
+
       void clear() VULKAN_HPP_NOEXCEPT
       {
         if ( m_instance )
@@ -1382,6 +1387,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::PhysicalDevice const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_physicalDevice;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::PhysicalDevice() const VULKAN_HPP_NOEXCEPT
       {
         return m_physicalDevice;
       }
@@ -1672,6 +1682,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::Device const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_device;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::Device() const VULKAN_HPP_NOEXCEPT
       {
         return m_device;
       }
@@ -2091,7 +2106,7 @@ namespace VULKAN_HPP_NAMESPACE
       Buffer( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
               VkBuffer                                                                        buffer,
               VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_buffer( buffer )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -2131,6 +2146,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::Buffer const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_buffer;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::Buffer() const VULKAN_HPP_NOEXCEPT
       {
         return m_buffer;
       }
@@ -2211,7 +2231,7 @@ namespace VULKAN_HPP_NAMESPACE
       BufferView( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                   VkBufferView                                                                    bufferView,
                   VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_bufferView( bufferView )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -2251,6 +2271,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::BufferView const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_bufferView;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::BufferView() const VULKAN_HPP_NOEXCEPT
       {
         return m_bufferView;
       }
@@ -2325,7 +2350,7 @@ namespace VULKAN_HPP_NAMESPACE
       CommandPool( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                    VkCommandPool                                                                   commandPool,
                    VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_commandPool( commandPool )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -2365,6 +2390,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::CommandPool const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_commandPool;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::CommandPool() const VULKAN_HPP_NOEXCEPT
       {
         return m_commandPool;
       }
@@ -2437,7 +2467,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     public:
       CommandBuffer( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const & device, VkCommandBuffer commandBuffer, VkCommandPool commandPool )
-        : m_device( *device ), m_commandPool( commandPool ), m_commandBuffer( commandBuffer ), m_dispatcher( device.getDispatcher() )
+        : m_device( device ), m_commandPool( commandPool ), m_commandBuffer( commandBuffer ), m_dispatcher( device.getDispatcher() )
       {
       }
 
@@ -2474,6 +2504,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::CommandBuffer const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_commandBuffer;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::CommandBuffer() const VULKAN_HPP_NOEXCEPT
       {
         return m_commandBuffer;
       }
@@ -2976,7 +3011,7 @@ namespace VULKAN_HPP_NAMESPACE
       DebugUtilsMessengerEXT( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Instance const &               instance,
                               VkDebugUtilsMessengerEXT                                                        messenger,
                               VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_instance( *instance )
+        : m_instance( instance )
         , m_messenger( messenger )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( instance.getDispatcher() )
@@ -3016,6 +3051,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::DebugUtilsMessengerEXT const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_messenger;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::DebugUtilsMessengerEXT() const VULKAN_HPP_NOEXCEPT
       {
         return m_messenger;
       }
@@ -3091,7 +3131,7 @@ namespace VULKAN_HPP_NAMESPACE
       DescriptorPool( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                       VkDescriptorPool                                                                descriptorPool,
                       VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_descriptorPool( descriptorPool )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -3131,6 +3171,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::DescriptorPool const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_descriptorPool;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::DescriptorPool() const VULKAN_HPP_NOEXCEPT
       {
         return m_descriptorPool;
       }
@@ -3199,7 +3244,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     public:
       DescriptorSet( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const & device, VkDescriptorSet descriptorSet, VkDescriptorPool descriptorPool )
-        : m_device( *device ), m_descriptorPool( descriptorPool ), m_descriptorSet( descriptorSet ), m_dispatcher( device.getDispatcher() )
+        : m_device( device ), m_descriptorPool( descriptorPool ), m_descriptorSet( descriptorSet ), m_dispatcher( device.getDispatcher() )
       {
       }
 
@@ -3236,6 +3281,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::DescriptorSet const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_descriptorSet;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::DescriptorSet() const VULKAN_HPP_NOEXCEPT
       {
         return m_descriptorSet;
       }
@@ -3338,7 +3388,7 @@ namespace VULKAN_HPP_NAMESPACE
       DescriptorSetLayout( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                            VkDescriptorSetLayout                                                           descriptorSetLayout,
                            VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_descriptorSetLayout( descriptorSetLayout )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -3378,6 +3428,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::DescriptorSetLayout const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_descriptorSetLayout;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::DescriptorSetLayout() const VULKAN_HPP_NOEXCEPT
       {
         return m_descriptorSetLayout;
       }
@@ -3453,7 +3508,7 @@ namespace VULKAN_HPP_NAMESPACE
       DeviceMemory( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                     VkDeviceMemory                                                                  memory,
                     VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_memory( memory )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -3493,6 +3548,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::DeviceMemory const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_memory;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::DeviceMemory() const VULKAN_HPP_NOEXCEPT
       {
         return m_memory;
       }
@@ -3566,7 +3626,7 @@ namespace VULKAN_HPP_NAMESPACE
 
     public:
       DisplayKHR( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::PhysicalDevice const & physicalDevice, VkDisplayKHR display )
-        : m_physicalDevice( *physicalDevice ), m_display( display ), m_dispatcher( physicalDevice.getDispatcher() )
+        : m_physicalDevice( physicalDevice ), m_display( display ), m_dispatcher( physicalDevice.getDispatcher() )
       {
       }
 
@@ -3601,6 +3661,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::DisplayKHR const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_display;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::DisplayKHR() const VULKAN_HPP_NOEXCEPT
       {
         return m_display;
       }
@@ -3751,6 +3816,11 @@ namespace VULKAN_HPP_NAMESPACE
         return m_displayModeKHR;
       }
 
+      operator VULKAN_HPP_NAMESPACE::DisplayModeKHR() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_displayModeKHR;
+      }
+
       void clear() VULKAN_HPP_NOEXCEPT
       {
         m_physicalDevice = nullptr;
@@ -3811,7 +3881,7 @@ namespace VULKAN_HPP_NAMESPACE
       Event( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
              VkEvent                                                                         event,
              VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_event( event )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -3851,6 +3921,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::Event const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_event;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::Event() const VULKAN_HPP_NOEXCEPT
       {
         return m_event;
       }
@@ -3952,7 +4027,7 @@ namespace VULKAN_HPP_NAMESPACE
       Fence( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
              VkFence                                                                         fence,
              VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_fence( fence )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -3992,6 +4067,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::Fence const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_fence;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::Fence() const VULKAN_HPP_NOEXCEPT
       {
         return m_fence;
       }
@@ -4070,7 +4150,7 @@ namespace VULKAN_HPP_NAMESPACE
       Framebuffer( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                    VkFramebuffer                                                                   framebuffer,
                    VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_framebuffer( framebuffer )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -4110,6 +4190,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::Framebuffer const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_framebuffer;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::Framebuffer() const VULKAN_HPP_NOEXCEPT
       {
         return m_framebuffer;
       }
@@ -4184,7 +4269,7 @@ namespace VULKAN_HPP_NAMESPACE
       Image( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
              VkImage                                                                         image,
              VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_image( image )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -4224,6 +4309,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::Image const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_image;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::Image() const VULKAN_HPP_NOEXCEPT
       {
         return m_image;
       }
@@ -4311,7 +4401,7 @@ namespace VULKAN_HPP_NAMESPACE
       ImageView( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                  VkImageView                                                                     imageView,
                  VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_imageView( imageView )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -4351,6 +4441,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::ImageView const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_imageView;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::ImageView() const VULKAN_HPP_NOEXCEPT
       {
         return m_imageView;
       }
@@ -4425,7 +4520,7 @@ namespace VULKAN_HPP_NAMESPACE
       PipelineCache( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                      VkPipelineCache                                                                 pipelineCache,
                      VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_pipelineCache( pipelineCache )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -4465,6 +4560,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::PipelineCache const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_pipelineCache;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::PipelineCache() const VULKAN_HPP_NOEXCEPT
       {
         return m_pipelineCache;
       }
@@ -4574,7 +4674,7 @@ namespace VULKAN_HPP_NAMESPACE
                 VkPipeline                                                                      pipeline,
                 VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator   = nullptr,
                 VULKAN_HPP_NAMESPACE::Result                                                    successCode = VULKAN_HPP_NAMESPACE::Result::eSuccess )
-        : m_device( *device )
+        : m_device( device )
         , m_pipeline( pipeline )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_constructorSuccessCode( successCode )
@@ -4617,6 +4717,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::Pipeline const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_pipeline;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::Pipeline() const VULKAN_HPP_NOEXCEPT
       {
         return m_pipeline;
       }
@@ -4738,7 +4843,7 @@ namespace VULKAN_HPP_NAMESPACE
       PipelineLayout( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                       VkPipelineLayout                                                                pipelineLayout,
                       VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_pipelineLayout( pipelineLayout )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -4778,6 +4883,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::PipelineLayout const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_pipelineLayout;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::PipelineLayout() const VULKAN_HPP_NOEXCEPT
       {
         return m_pipelineLayout;
       }
@@ -4853,7 +4963,7 @@ namespace VULKAN_HPP_NAMESPACE
       PrivateDataSlot( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                        VkPrivateDataSlot                                                               privateDataSlot,
                        VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_privateDataSlot( privateDataSlot )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -4893,6 +5003,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::PrivateDataSlot const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_privateDataSlot;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::PrivateDataSlot() const VULKAN_HPP_NOEXCEPT
       {
         return m_privateDataSlot;
       }
@@ -4968,7 +5083,7 @@ namespace VULKAN_HPP_NAMESPACE
       QueryPool( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                  VkQueryPool                                                                     queryPool,
                  VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_queryPool( queryPool )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -5008,6 +5123,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::QueryPool const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_queryPool;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::QueryPool() const VULKAN_HPP_NOEXCEPT
       {
         return m_queryPool;
       }
@@ -5148,6 +5268,11 @@ namespace VULKAN_HPP_NAMESPACE
         return m_queue;
       }
 
+      operator VULKAN_HPP_NAMESPACE::Queue() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_queue;
+      }
+
       void clear() VULKAN_HPP_NOEXCEPT
       {
         m_queue      = nullptr;
@@ -5240,7 +5365,7 @@ namespace VULKAN_HPP_NAMESPACE
       RenderPass( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                   VkRenderPass                                                                    renderPass,
                   VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_renderPass( renderPass )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -5280,6 +5405,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::RenderPass const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_renderPass;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::RenderPass() const VULKAN_HPP_NOEXCEPT
       {
         return m_renderPass;
       }
@@ -5358,7 +5488,7 @@ namespace VULKAN_HPP_NAMESPACE
       Sampler( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                VkSampler                                                                       sampler,
                VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_sampler( sampler )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -5398,6 +5528,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::Sampler const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_sampler;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::Sampler() const VULKAN_HPP_NOEXCEPT
       {
         return m_sampler;
       }
@@ -5472,7 +5607,7 @@ namespace VULKAN_HPP_NAMESPACE
       SamplerYcbcrConversion( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                               VkSamplerYcbcrConversion                                                        ycbcrConversion,
                               VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_ycbcrConversion( ycbcrConversion )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -5512,6 +5647,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::SamplerYcbcrConversion const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_ycbcrConversion;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::SamplerYcbcrConversion() const VULKAN_HPP_NOEXCEPT
       {
         return m_ycbcrConversion;
       }
@@ -5587,7 +5727,7 @@ namespace VULKAN_HPP_NAMESPACE
       Semaphore( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                  VkSemaphore                                                                     semaphore,
                  VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_semaphore( semaphore )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -5627,6 +5767,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::Semaphore const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_semaphore;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::Semaphore() const VULKAN_HPP_NOEXCEPT
       {
         return m_semaphore;
       }
@@ -5706,7 +5851,7 @@ namespace VULKAN_HPP_NAMESPACE
       SemaphoreSciSyncPoolNV( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                               VkSemaphoreSciSyncPoolNV                                                        semaphorePool,
                               VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_semaphorePool( semaphorePool )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -5746,6 +5891,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::SemaphoreSciSyncPoolNV const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_semaphorePool;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::SemaphoreSciSyncPoolNV() const VULKAN_HPP_NOEXCEPT
       {
         return m_semaphorePool;
       }
@@ -5822,7 +5972,7 @@ namespace VULKAN_HPP_NAMESPACE
       ShaderModule( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                     VkShaderModule                                                                  shaderModule,
                     VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_shaderModule( shaderModule )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -5862,6 +6012,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::ShaderModule const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_shaderModule;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::ShaderModule() const VULKAN_HPP_NOEXCEPT
       {
         return m_shaderModule;
       }
@@ -5945,7 +6100,7 @@ namespace VULKAN_HPP_NAMESPACE
       SurfaceKHR( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Instance const &               instance,
                   VkSurfaceKHR                                                                    surface,
                   VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_instance( *instance )
+        : m_instance( instance )
         , m_surface( surface )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( instance.getDispatcher() )
@@ -5985,6 +6140,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::SurfaceKHR const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_surface;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::SurfaceKHR() const VULKAN_HPP_NOEXCEPT
       {
         return m_surface;
       }
@@ -6059,7 +6219,7 @@ namespace VULKAN_HPP_NAMESPACE
       SwapchainKHR( VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device const &                 device,
                     VkSwapchainKHR                                                                  swapchain,
                     VULKAN_HPP_NAMESPACE::Optional<const VULKAN_HPP_NAMESPACE::AllocationCallbacks> allocator = nullptr )
-        : m_device( *device )
+        : m_device( device )
         , m_swapchain( swapchain )
         , m_allocator( static_cast<const VULKAN_HPP_NAMESPACE::AllocationCallbacks *>( allocator ) )
         , m_dispatcher( device.getDispatcher() )
@@ -6099,6 +6259,11 @@ namespace VULKAN_HPP_NAMESPACE
       }
 
       VULKAN_HPP_NAMESPACE::SwapchainKHR const & operator*() const VULKAN_HPP_NOEXCEPT
+      {
+        return m_swapchain;
+      }
+
+      operator VULKAN_HPP_NAMESPACE::SwapchainKHR() const VULKAN_HPP_NOEXCEPT
       {
         return m_swapchain;
       }

--- a/vulkan/vulkansc_shared.hpp
+++ b/vulkan/vulkansc_shared.hpp
@@ -182,6 +182,13 @@ namespace VULKAN_HPP_NAMESPACE
       return bool( m_handle );
     }
 
+#  if defined( VULKAN_HPP_SMART_HANDLE_IMPLICIT_CAST )
+    operator HandleType() const VULKAN_HPP_NOEXCEPT
+    {
+      return m_handle;
+    }
+#  endif
+
     const HandleType * operator->() const VULKAN_HPP_NOEXCEPT
     {
       return &m_handle;


### PR DESCRIPTION
Add an implicit cast for the vk::UniqueHandles and the vk::SharedHandles, "hidden" by the define `VULKAN_HPP_SMART_HANDLE_IMPLICIT_CAST`. Those two handle wrapper are semantically very close to the corresponding pointer types and thus the implicit cast is not a perfect fit. Making it available by an opt-in seems to be reasonable.
The vk::raii::Handles, on the other hand, are more a non-pointer wrapper, and thus get the implicit-cast unconditionally.

Resolves #1731.