### PR TITLE
allow len="1" from param in parsing vk.xml

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -12813,7 +12813,7 @@ std::pair<bool, VulkanHppGenerator::ParamData> VulkanHppGenerator::readCommandPa
         }
         else
         {
-          checkForError( ( attribute.second == "null-terminated" ) || isLenByStructMember( attribute.second, params ),
+          checkForError( ( attribute.second == "null-terminated" ) || ( attribute.second == "1" ) || isLenByStructMember( attribute.second, params ),
                          line,
                          "attribute <len> holds an unknown value <" + attribute.second + ">" );
         }


### PR DESCRIPTION
In registry.rnc, the description of len in <param> allows special values such as "null-terminated" or "1". But somehow the value "1" is missed.

```
#   <param> are function parameters, in order
#     len - if the member is an array, len may be one or more of the following
#           things, separated by commas (one for each array indirection):
#           another member of that struct, 'null-terminated' for a string,
#           '1' to indicate it is just a pointer (used for nested pointers),
#           or a latex equation (prefixed with 'latexmath:')
```

@oddhack added:

Fixes #1787