### PR TITLE
Fix issue with vk::StructureChain::assign

### DIFF
--- a/snippets/StructureChain.hpp
+++ b/snippets/StructureChain.hpp
@@ -121,10 +121,10 @@
     template <typename T = typename std::tuple_element<0, std::tuple<ChainElements...>>::type, size_t Which = 0>
     StructureChain & assign( const T & rhs ) VULKAN_HPP_NOEXCEPT
     {
-      T &    lhs   = get<T, Which>();
-      void * pNext = lhs.pNext;
-      lhs          = rhs;
-      lhs.pNext    = pNext;
+      T &  lhs   	= get<T, Which>();
+      auto pNext = lhs.pNext;
+      lhs        = rhs;
+      lhs.pNext  = pNext;
       return *this;
     }
 

--- a/tests/StructureChain/StructureChain.cpp
+++ b/tests/StructureChain/StructureChain.cpp
@@ -77,6 +77,9 @@ int main( int /*argc*/, char ** /*argv*/ )
     sc7.assign<vk::PhysicalDeviceIDProperties>( {} );
     assert( pNext == sc7.get<vk::PhysicalDeviceIDProperties>().pNext );
 
+    vk::StructureChain<vk::DeviceQueueCreateInfo, vk::DeviceQueueGlobalPriorityCreateInfoKHR> sc8;
+    sc8.assign<vk::DeviceQueueGlobalPriorityCreateInfoKHR>( {} );
+
 #if !defined( NDEBUG )
     void * pNext1 = sc7.get<vk::PhysicalDeviceMaintenance3Properties>().pNext;
 #endif

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -723,10 +723,10 @@ namespace VULKAN_HPP_NAMESPACE
     template <typename T = typename std::tuple_element<0, std::tuple<ChainElements...>>::type, size_t Which = 0>
     StructureChain & assign( const T & rhs ) VULKAN_HPP_NOEXCEPT
     {
-      T &    lhs   = get<T, Which>();
-      void * pNext = lhs.pNext;
-      lhs          = rhs;
-      lhs.pNext    = pNext;
+      T &  lhs   = get<T, Which>();
+      auto pNext = lhs.pNext;
+      lhs        = rhs;
+      lhs.pNext  = pNext;
       return *this;
     }
 
@@ -16589,7 +16589,7 @@ namespace VULKAN_HPP_NAMESPACE
           m_library = dlopen( "libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL );
         }
 #  elif defined( _WIN32 )
-        m_library = ::LoadLibraryA( "vulkan-1.dll" );
+          m_library = ::LoadLibraryA( "vulkan-1.dll" );
 #  else
 #    error unsupported platform
 #  endif

--- a/vulkan/vulkansc.hpp
+++ b/vulkan/vulkansc.hpp
@@ -723,10 +723,10 @@ namespace VULKAN_HPP_NAMESPACE
     template <typename T = typename std::tuple_element<0, std::tuple<ChainElements...>>::type, size_t Which = 0>
     StructureChain & assign( const T & rhs ) VULKAN_HPP_NOEXCEPT
     {
-      T &    lhs   = get<T, Which>();
-      void * pNext = lhs.pNext;
-      lhs          = rhs;
-      lhs.pNext    = pNext;
+      T &  lhs   = get<T, Which>();
+      auto pNext = lhs.pNext;
+      lhs        = rhs;
+      lhs.pNext  = pNext;
       return *this;
     }
 
@@ -6950,7 +6950,7 @@ namespace VULKAN_HPP_NAMESPACE
           m_library = dlopen( "libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL );
         }
 #  elif defined( _WIN32 )
-        m_library = ::LoadLibraryA( "vulkan-1.dll" );
+          m_library = ::LoadLibraryA( "vulkan-1.dll" );
 #  else
 #    error unsupported platform
 #  endif


### PR DESCRIPTION
Use `auto`, instead of `void *`, to also support structures with `const void *` as type for `pNext`.

Resolves #1797.