### PR TITLE
Disabled `vk::raii::exchange()` implementation for C++14 or newer

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -578,17 +578,17 @@ namespace VULKAN_HPP_NAMESPACE
 {
   namespace VULKAN_HPP_RAII_NAMESPACE
   {
+#  if ( 14 <= VULKAN_HPP_CPP_VERSION )
+    using std::exchange;
+#  else
     template <class T, class U = T>
     VULKAN_HPP_CONSTEXPR_14 VULKAN_HPP_INLINE T exchange( T & obj, U && newValue )
     {
-#  if ( 14 <= VULKAN_HPP_CPP_VERSION )
-      return std::exchange<T>( obj, std::forward<U>( newValue ) );
-#  else
       T oldValue = std::move( obj );
       obj        = std::forward<U>( newValue );
       return oldValue;
-#  endif
     }
+#  endif
 
     template <class T>
     class CreateReturnType

--- a/vulkan/vulkan_raii.hpp
+++ b/vulkan/vulkan_raii.hpp
@@ -17,17 +17,17 @@ namespace VULKAN_HPP_NAMESPACE
 {
   namespace VULKAN_HPP_RAII_NAMESPACE
   {
+#  if ( 14 <= VULKAN_HPP_CPP_VERSION )
+    using std::exchange;
+#  else
     template <class T, class U = T>
     VULKAN_HPP_CONSTEXPR_14 VULKAN_HPP_INLINE T exchange( T & obj, U && newValue )
     {
-#  if ( 14 <= VULKAN_HPP_CPP_VERSION )
-      return std::exchange<T>( obj, std::forward<U>( newValue ) );
-#  else
       T oldValue = std::move( obj );
       obj        = std::forward<U>( newValue );
       return oldValue;
-#  endif
     }
+#  endif
 
     template <class T>
     class CreateReturnType

--- a/vulkan/vulkansc_raii.hpp
+++ b/vulkan/vulkansc_raii.hpp
@@ -17,17 +17,17 @@ namespace VULKAN_HPP_NAMESPACE
 {
   namespace VULKAN_HPP_RAII_NAMESPACE
   {
+#  if ( 14 <= VULKAN_HPP_CPP_VERSION )
+    using std::exchange;
+#  else
     template <class T, class U = T>
     VULKAN_HPP_CONSTEXPR_14 VULKAN_HPP_INLINE T exchange( T & obj, U && newValue )
     {
-#  if ( 14 <= VULKAN_HPP_CPP_VERSION )
-      return std::exchange<T>( obj, std::forward<U>( newValue ) );
-#  else
       T oldValue = std::move( obj );
       obj        = std::forward<U>( newValue );
       return oldValue;
-#  endif
     }
+#  endif
 
     template <class T>
     class CreateReturnType


### PR DESCRIPTION
Replaced with `using std::exchange`

```
namespace sample
{
    using std::exchange;

    void func()
    {
        std::vector<vk::raii::CommandBuffer> bufs = ...;
        exchange(bufs, {}); //< that line causes 'ambiguous call' compiler error
    }
}

```