### PR TITLE
Fixed Validation Error From Zero MaxImageCount in VkSurfaceCapabilitiesKHR

### DIFF
--- a/RAII_Samples/05_InitSwapchain/05_InitSwapchain.cpp
+++ b/RAII_Samples/05_InitSwapchain/05_InitSwapchain.cpp
@@ -120,7 +120,7 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     vk::SwapchainCreateInfoKHR swapChainCreateInfo( vk::SwapchainCreateFlagsKHR(),
                                                     surface,
-                                                    vk::su::clamp( 3u, surfaceCapabilities.minImageCount, surfaceCapabilities.maxImageCount ),
+                                                    vk::su::clampSurfaceImageCount( 3u, surfaceCapabilities.minImageCount, surfaceCapabilities.maxImageCount ),
                                                     format,
                                                     vk::ColorSpaceKHR::eSrgbNonlinear,
                                                     swapchainExtent,

--- a/samples/05_InitSwapchain/05_InitSwapchain.cpp
+++ b/samples/05_InitSwapchain/05_InitSwapchain.cpp
@@ -123,7 +123,7 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     vk::SwapchainCreateInfoKHR swapChainCreateInfo( vk::SwapchainCreateFlagsKHR(),
                                                     surface,
-                                                    vk::su::clamp( 3u, surfaceCapabilities.minImageCount, surfaceCapabilities.maxImageCount ),
+                                                    vk::su::clampSurfaceImageCount( 3u, surfaceCapabilities.minImageCount, surfaceCapabilities.maxImageCount ),
                                                     format,
                                                     vk::ColorSpaceKHR::eSrgbNonlinear,
                                                     swapchainExtent,

--- a/samples/utils/utils.cpp
+++ b/samples/utils/utils.cpp
@@ -826,7 +826,7 @@ namespace vk
       vk::PresentModeKHR         presentMode = vk::su::pickPresentMode( physicalDevice.getSurfacePresentModesKHR( surface ) );
       vk::SwapchainCreateInfoKHR swapChainCreateInfo( {},
                                                       surface,
-                                                      vk::su::clamp( 3u, surfaceCapabilities.minImageCount, surfaceCapabilities.maxImageCount ),
+                                                      vk::su::clampSurfaceImageCount( 3u, surfaceCapabilities.minImageCount, surfaceCapabilities.maxImageCount ),
                                                       colorFormat,
                                                       surfaceFormat.colorSpace,
                                                       swapchainExtent,

--- a/samples/utils/utils.hpp
+++ b/samples/utils/utils.hpp
@@ -74,6 +74,16 @@ namespace vk
       return v < lo ? lo : hi < v ? hi : v;
     }
 
+    VULKAN_HPP_INLINE uint32_t clampSurfaceImageCount( const uint32_t desiredImageCount, const uint32_t minImageCount, const uint32_t maxImageCount )
+    {
+      uint32_t imageCount = std::max( desiredImageCount, minImageCount );
+      if( maxImageCount > 0 )
+      {
+        imageCount = std::min( imageCount, maxImageCount );
+      }
+      return imageCount;
+    }
+
     void setImageLayout(
       vk::CommandBuffer const & commandBuffer, vk::Image image, vk::Format format, vk::ImageLayout oldImageLayout, vk::ImageLayout newImageLayout );
 

--- a/tests/UniqueHandle/UniqueHandle.cpp
+++ b/tests/UniqueHandle/UniqueHandle.cpp
@@ -195,7 +195,7 @@ vk::UniqueSwapchainKHR createSwapchainKHRUnique( vk::PhysicalDevice physicalDevi
                                                                                                          : vk::CompositeAlphaFlagBitsKHR::eOpaque;
   vk::SwapchainCreateInfoKHR swapChainCreateInfo( {},
                                                   surface,
-                                                  vk::su::clamp( 3u, surfaceCapabilities.minImageCount, surfaceCapabilities.maxImageCount ),
+                                                  vk::su::clampSurfaceImageCount( 3u, surfaceCapabilities.minImageCount, surfaceCapabilities.maxImageCount ),
                                                   surfaceFormat.format,
                                                   surfaceFormat.colorSpace,
                                                   swapchainExtent,


### PR DESCRIPTION
Correctly handle a zero max image count in VkSurfaceCapabilitiesKHR which indicates no upper limit to the number of images in a swapchain.
_"maxImageCount is the maximum number of images the specified device supports for a swapchain created for the surface, and will be either 0, or greater than or equal to minImageCount. A value of 0 means that there is no limit on the number of images, though there may be limits related to the total amount of memory used by presentable images."_
https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSurfaceCapabilitiesKHR.html

Fixes validation error VUID-VkSwapchainCreateInfoKHR-minImageCount-01271