### PR TITLE
Change default for template non-type parameter value of struct CppType from 0 to Type{}.

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,7 +870,7 @@ When this is defined before including `vulkan.hpp`, you essentially disable all 
 * the helper class `vk::StructureChain` for compile-time construction of structure chains.
 
 If this is not defined, you additionally get:
-* enhanced versions of the commands (consuming `vk::ArrayProxy<>`, simplifying handling of array data; returning requested data; throwing exceptions on errors (as long as `VULKAN_HPP_NO_EXCEPTIONS` is not defined);
+* enhanced versions of the commands (consuming `vk::ArrayProxy<>`), simplifying handling of array data; returning requested data; throwing exceptions on errors (as long as `VULKAN_HPP_NO_EXCEPTIONS` is not defined);
 * enhanced structure constructors (as long as `VULKAN_HPP_NO_STRUCT_CONSTRUCTORS` is not defined) (consuming `vk::ArrayProxyNoTemporaries<>`);
 * enhanced setter functions on some members of structs (consuming `vk::ArrayProxyNoTemporaries<>`);
 * the helper classes `vk::ArrayProxy<>` and `vk::ArrayProxyNoTemporaries<>`

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -466,7 +466,7 @@ ${PoolFree}
 #endif // !VULKAN_HPP_NO_SMART_HANDLE
 ${baseTypes}
 
-  template <typename Type, Type value = 0>
+  template <typename Type, Type value = Type{}>
   struct CppType
   {};
 } // namespace VULKAN_HPP_NAMESPACE

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -6144,7 +6144,7 @@ namespace VULKAN_HPP_NAMESPACE
   using RemoteAddressNV = void *;
   using SampleMask      = uint32_t;
 
-  template <typename Type, Type value = 0>
+  template <typename Type, Type value = Type{}>
   struct CppType
   {
   };

--- a/vulkan/vulkansc.hpp
+++ b/vulkan/vulkansc.hpp
@@ -3392,7 +3392,7 @@ namespace VULKAN_HPP_NAMESPACE
   using RemoteAddressNV = void *;
   using SampleMask      = uint32_t;
 
-  template <typename Type, Type value = 0>
+  template <typename Type, Type value = Type{}>
   struct CppType
   {
   };


### PR DESCRIPTION
Resolves #1860.

Plus a minor fix in Readme.md, Resolves #1854.