### PR TITLE
Make generated headers resistant to missing definition of NOMINMAX for windows builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ function( vulkan_hpp__setup_platform )
 	cmake_parse_arguments( TARGET "{options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
 	if( WIN32 )
-		target_compile_definitions( ${TARGET_NAME} PUBLIC NOMINMAX VK_USE_PLATFORM_WIN32_KHR )
+		target_compile_definitions( ${TARGET_NAME} PUBLIC VK_USE_PLATFORM_WIN32_KHR )
 	elseif( APPLE )
 		target_compile_definitions( ${TARGET_NAME} PUBLIC VK_USE_PLATFORM_MACOS_MVK )
 	elseif( UNIX )

--- a/RAII_Samples/05_InitSwapchain/05_InitSwapchain.cpp
+++ b/RAII_Samples/05_InitSwapchain/05_InitSwapchain.cpp
@@ -93,7 +93,7 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     vk::SurfaceCapabilitiesKHR surfaceCapabilities = physicalDevice.getSurfaceCapabilitiesKHR( surface );
     vk::Extent2D               swapchainExtent;
-    if ( surfaceCapabilities.currentExtent.width == std::numeric_limits<uint32_t>::max() )
+    if ( surfaceCapabilities.currentExtent.width == (std::numeric_limits<uint32_t>::max)() )
     {
       // If the surface size is undefined, the size is set to the size of the images requested.
       swapchainExtent.width  = vk::su::clamp( width, surfaceCapabilities.minImageExtent.width, surfaceCapabilities.maxImageExtent.width );

--- a/RAII_Samples/utils/utils.hpp
+++ b/RAII_Samples/utils/utils.hpp
@@ -342,7 +342,7 @@ namespace vk
 
           vk::SurfaceCapabilitiesKHR surfaceCapabilities = physicalDevice.getSurfaceCapabilitiesKHR( surface );
           vk::Extent2D               swapchainExtent;
-          if ( surfaceCapabilities.currentExtent.width == std::numeric_limits<uint32_t>::max() )
+          if ( surfaceCapabilities.currentExtent.width == (std::numeric_limits<uint32_t>::max)() )
           {
             // If the surface size is undefined, the size is set to the size of the images requested.
             swapchainExtent.width  = vk::su::clamp( extent.width, surfaceCapabilities.minImageExtent.width, surfaceCapabilities.maxImageExtent.width );
@@ -509,7 +509,7 @@ namespace vk
                                                                             vk::raii::SurfaceKHR const &     surface )
       {
         std::vector<vk::QueueFamilyProperties> queueFamilyProperties = physicalDevice.getQueueFamilyProperties();
-        assert( queueFamilyProperties.size() < std::numeric_limits<uint32_t>::max() );
+        assert( queueFamilyProperties.size() < (std::numeric_limits<uint32_t>::max)() );
 
         uint32_t graphicsQueueFamilyIndex = vk::su::findGraphicsQueueFamilyIndex( queueFamilyProperties );
         if ( physicalDevice.getSurfaceSupportKHR( graphicsQueueFamilyIndex, surface ) )

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -8219,7 +8219,7 @@ std::string VulkanHppGenerator::generateLenInitializer(
   if ( !litit->second.front()->arraySizes.empty() )
   {
     assert( litit->second.front()->arraySizes.size() == 1 );
-    initializer = "std::min( " + initializer + ", " + litit->second.front()->arraySizes[0] + " )";
+    initializer = "(std::min)( " + initializer + ", " + litit->second.front()->arraySizes[0] + " )";
   }
   return initializer;
 }
@@ -11719,7 +11719,7 @@ std::string VulkanHppGenerator::generateStructSetter( std::string const & struct
         if ( !member.arraySizes.empty() )
         {
           assert( member.arraySizes.size() == 1 );
-          lenValue = "std::min( " + lenValue + ", " + member.arraySizes[0] + " )";
+          lenValue = "(std::min)( " + lenValue + ", " + member.arraySizes[0] + " )";
         }
 
         if ( member.type.isPointer() )

--- a/samples/05_InitSwapchain/05_InitSwapchain.cpp
+++ b/samples/05_InitSwapchain/05_InitSwapchain.cpp
@@ -96,7 +96,7 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     vk::SurfaceCapabilitiesKHR surfaceCapabilities = physicalDevice.getSurfaceCapabilitiesKHR( surface );
     vk::Extent2D               swapchainExtent;
-    if ( surfaceCapabilities.currentExtent.width == std::numeric_limits<uint32_t>::max() )
+    if ( surfaceCapabilities.currentExtent.width == (std::numeric_limits<uint32_t>::max)() )
     {
       // If the surface size is undefined, the size is set to the size of the images requested.
       swapchainExtent.width  = vk::su::clamp( width, surfaceCapabilities.minImageExtent.width, surfaceCapabilities.maxImageExtent.width );

--- a/samples/utils/utils.cpp
+++ b/samples/utils/utils.cpp
@@ -422,7 +422,7 @@ namespace vk
     std::pair<uint32_t, uint32_t> findGraphicsAndPresentQueueFamilyIndex( vk::PhysicalDevice physicalDevice, vk::SurfaceKHR const & surface )
     {
       std::vector<vk::QueueFamilyProperties> queueFamilyProperties = physicalDevice.getQueueFamilyProperties();
-      assert( queueFamilyProperties.size() < std::numeric_limits<uint32_t>::max() );
+      assert( queueFamilyProperties.size() < (std::numeric_limits<uint32_t>::max)() );
 
       uint32_t graphicsQueueFamilyIndex = findGraphicsQueueFamilyIndex( queueFamilyProperties );
       if ( physicalDevice.getSurfaceSupportKHR( graphicsQueueFamilyIndex, surface ) )
@@ -806,7 +806,7 @@ namespace vk
 
       vk::SurfaceCapabilitiesKHR surfaceCapabilities = physicalDevice.getSurfaceCapabilitiesKHR( surface );
       vk::Extent2D               swapchainExtent;
-      if ( surfaceCapabilities.currentExtent.width == std::numeric_limits<uint32_t>::max() )
+      if ( surfaceCapabilities.currentExtent.width == (std::numeric_limits<uint32_t>::max)() )
       {
         // If the surface size is undefined, the size is set to the size of the images requested.
         swapchainExtent.width  = clamp( extent.width, surfaceCapabilities.minImageExtent.width, surfaceCapabilities.maxImageExtent.width );

--- a/samples/utils/utils.hpp
+++ b/samples/utils/utils.hpp
@@ -76,10 +76,10 @@ namespace vk
 
     VULKAN_HPP_INLINE uint32_t clampSurfaceImageCount( const uint32_t desiredImageCount, const uint32_t minImageCount, const uint32_t maxImageCount )
     {
-      uint32_t imageCount = std::max( desiredImageCount, minImageCount );
+      uint32_t imageCount = (std::max)( desiredImageCount, minImageCount );
       if ( maxImageCount > 0 )
       {
-        imageCount = std::min( imageCount, maxImageCount );
+        imageCount = (std::min)( imageCount, maxImageCount );
       }
       return imageCount;
     }
@@ -355,7 +355,7 @@ namespace vk
       static_assert( !std::numeric_limits<SourceType>::is_signed, "Only unsigned types supported!" );
       static_assert( std::numeric_limits<TargetType>::is_integer, "Only integer types supported!" );
       static_assert( !std::numeric_limits<TargetType>::is_signed, "Only unsigned types supported!" );
-      assert( value <= std::numeric_limits<TargetType>::max() );
+      assert( value <= (std::numeric_limits<TargetType>::max)() );
       return static_cast<TargetType>( value );
     }
 

--- a/snippets/ArrayWrapper1D.hpp
+++ b/snippets/ArrayWrapper1D.hpp
@@ -60,7 +60,7 @@ public:
 private:
   VULKAN_HPP_CONSTEXPR_14 void copy( char const * data, size_t len ) VULKAN_HPP_NOEXCEPT
   {
-    size_t n = std::min( N - 1, len );
+    size_t n = (std::min)( N - 1, len );
     for ( size_t i = 0; i < n; ++i )
     {
       ( *this )[i] = data[i];

--- a/tests/UniqueHandle/UniqueHandle.cpp
+++ b/tests/UniqueHandle/UniqueHandle.cpp
@@ -174,7 +174,7 @@ vk::UniqueSwapchainKHR createSwapchainKHRUnique( vk::PhysicalDevice physicalDevi
   vk::SurfaceCapabilitiesKHR surfaceCapabilities = physicalDevice.getSurfaceCapabilitiesKHR( surface );
   vk::SurfaceFormatKHR       surfaceFormat       = vk::su::pickSurfaceFormat( physicalDevice.getSurfaceFormatsKHR( surface ) );
   vk::Extent2D               swapchainExtent;
-  if ( surfaceCapabilities.currentExtent.width == std::numeric_limits<uint32_t>::max() )
+  if ( surfaceCapabilities.currentExtent.width == (std::numeric_limits<uint32_t>::max)() )
   {
     // If the surface size is undefined, the size is set to the size of the images requested.
     swapchainExtent.width  = vk::su::clamp<uint32_t>( 64, surfaceCapabilities.minImageExtent.width, surfaceCapabilities.maxImageExtent.width );

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -149,7 +149,7 @@ namespace VULKAN_HPP_NAMESPACE
   private:
     VULKAN_HPP_CONSTEXPR_14 void copy( char const * data, size_t len ) VULKAN_HPP_NOEXCEPT
     {
-      size_t n = std::min( N - 1, len );
+      size_t n = ( std::min )( N - 1, len );
       for ( size_t i = 0; i < n; ++i )
       {
         ( *this )[i] = data[i];
@@ -16830,7 +16830,7 @@ namespace VULKAN_HPP_NAMESPACE
           m_library = dlopen( "libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL );
         }
 #  elif defined( _WIN32 )
-        m_library = ::LoadLibraryA( "vulkan-1.dll" );
+          m_library = ::LoadLibraryA( "vulkan-1.dll" );
 #  else
 #    error unsupported platform
 #  endif

--- a/vulkan/vulkansc.hpp
+++ b/vulkan/vulkansc.hpp
@@ -149,7 +149,7 @@ namespace VULKAN_HPP_NAMESPACE
   private:
     VULKAN_HPP_CONSTEXPR_14 void copy( char const * data, size_t len ) VULKAN_HPP_NOEXCEPT
     {
-      size_t n = std::min( N - 1, len );
+      size_t n = ( std::min )( N - 1, len );
       for ( size_t i = 0; i < n; ++i )
       {
         ( *this )[i] = data[i];
@@ -6985,7 +6985,7 @@ namespace VULKAN_HPP_NAMESPACE
           m_library = dlopen( "libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL );
         }
 #  elif defined( _WIN32 )
-        m_library = ::LoadLibraryA( "vulkan-1.dll" );
+          m_library = ::LoadLibraryA( "vulkan-1.dll" );
 #  else
 #    error unsupported platform
 #  endif

--- a/vulkan/vulkansc_structs.hpp
+++ b/vulkan/vulkansc_structs.hpp
@@ -32923,7 +32923,7 @@ namespace VULKAN_HPP_NAMESPACE
                                    VULKAN_HPP_NAMESPACE::Bool32                                                   subsetAllocation_ = {},
                                    void *                                                                         pNext_            = nullptr )
       : pNext( pNext_ )
-      , physicalDeviceCount( std::min( static_cast<uint32_t>( physicalDevices_.size() ), VK_MAX_DEVICE_GROUP_SIZE ) )
+      , physicalDeviceCount( ( std::min )( static_cast<uint32_t>( physicalDevices_.size() ), VK_MAX_DEVICE_GROUP_SIZE ) )
       , subsetAllocation( subsetAllocation_ )
     {
       VULKAN_HPP_ASSERT( physicalDevices_.size() < VK_MAX_DEVICE_GROUP_SIZE );
@@ -35080,8 +35080,8 @@ namespace VULKAN_HPP_NAMESPACE
 #  if !defined( VULKAN_HPP_DISABLE_ENHANCED_MODE )
     PhysicalDeviceMemoryProperties( VULKAN_HPP_NAMESPACE::ArrayProxy<VULKAN_HPP_NAMESPACE::MemoryType> const & memoryTypes_,
                                     VULKAN_HPP_NAMESPACE::ArrayProxy<VULKAN_HPP_NAMESPACE::MemoryHeap> const & memoryHeaps_ = {} )
-      : memoryTypeCount( std::min( static_cast<uint32_t>( memoryTypes_.size() ), VK_MAX_MEMORY_TYPES ) )
-      , memoryHeapCount( std::min( static_cast<uint32_t>( memoryHeaps_.size() ), VK_MAX_MEMORY_HEAPS ) )
+      : memoryTypeCount( ( std::min )( static_cast<uint32_t>( memoryTypes_.size() ), VK_MAX_MEMORY_TYPES ) )
+      , memoryHeapCount( ( std::min )( static_cast<uint32_t>( memoryHeaps_.size() ), VK_MAX_MEMORY_HEAPS ) )
     {
       VULKAN_HPP_ASSERT( memoryTypes_.size() < VK_MAX_MEMORY_TYPES );
       memcpy( memoryTypes, memoryTypes_.data(), memoryTypeCount * sizeof( VULKAN_HPP_NAMESPACE::MemoryType ) );


### PR DESCRIPTION
Resolves #1893.