### PR TITLE
Add specializations of std::hash for all the structs and handles in the vk-namespace.

### DIFF
--- a/VulkanHppGenerator.hpp
+++ b/VulkanHppGenerator.hpp
@@ -753,6 +753,9 @@ private:
   std::string generateCppModuleUsings() const;
   std::string generateCppModuleRaiiUsings() const;
   std::string generateCppModuleSharedHandleUsings() const;
+  std::string generateCppModuleHandleHashSpecializations() const;
+  std::string generateCppModuleHashSpecializations() const;
+  std::string generateCppModuleStructHashSpecializations() const;
   std::string generateDataDeclarations( CommandData const &                       commandData,
                                         std::vector<size_t> const &               returnParams,
                                         std::map<size_t, VectorParamData> const & vectorParams,

--- a/tests/Cpp20Modules/Cpp20Modules.cpp
+++ b/tests/Cpp20Modules/Cpp20Modules.cpp
@@ -1,6 +1,22 @@
+// Copyright(c) 2024, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// VulkanHpp Test : Cpp20Module
+//                  Compile test on using c++20 modules
+
 import vulkan_hpp;
 
-#include <iostream>
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 static std::string AppName    = "Cpp20Modules";
@@ -12,6 +28,8 @@ VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 
 int main( int /*argc*/, char ** /*argv*/ )
 {
+  std::cout << "test Cpp20Module" << std::endl;
+
   /* VULKAN_HPP_KEY_START */
   try
   {

--- a/tests/CppStdModule/CppStdModule.cpp
+++ b/tests/CppStdModule/CppStdModule.cpp
@@ -1,59 +1,101 @@
+// Copyright(c) 2024, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// VulkanHpp Test : CppStdModule
+//                  Compile test on using c++20 modules
+
 import std;
 import vulkan_hpp;
 
+#if defined( _MSC_VER )
+#  pragma warning( disable : 4189 )  // local variable is initialized but not referenced
+#elif defined( __GNUC__ )
+#  pragma GCC diagnostic ignored "-Wunused-variable"
+#else
+// unknow compiler... just ignore the warnings for yourselves ;)
+#endif
+
+#include <assert.h>
 #include <vulkan/vulkan_hpp_macros.hpp>
 
-static std::string AppName = "CppStdModule";
+static std::string AppName    = "CppStdModule";
 static std::string EngineName = "Vulkan.cppm";
 
 #if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
 VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 #endif
 
-int main(int /*argc*/, char** /*argv*/)
+int main( int /*argc*/, char ** /*argv*/ )
 {
-    /* VULKAN_HPP_KEY_START */
-    try
-    {
+  std::cout << "test CppStdModule" << std::endl;
+
+  /* VULKAN_HPP_KEY_START */
+  try
+  {
 #if ( VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1 )
-        // initialize minimal set of function pointers
-        VULKAN_HPP_DEFAULT_DISPATCHER.init();
+    // initialize minimal set of function pointers
+    VULKAN_HPP_DEFAULT_DISPATCHER.init();
 #endif
 
-        // initialize the vk::ApplicationInfo structure
-        vk::ApplicationInfo applicationInfo(AppName.c_str(), 1, EngineName.c_str(), 1, vk::makeApiVersion(1, 0, 0, 0));
+    // initialize the vk::ApplicationInfo structure
+    vk::ApplicationInfo applicationInfo( AppName.c_str(), 1, EngineName.c_str(), 1, vk::makeApiVersion( 1, 0, 0, 0 ) );
 
-        // initialize the vk::InstanceCreateInfo
-        vk::InstanceCreateInfo instanceCreateInfo({}, &applicationInfo);
+    // initialize the vk::InstanceCreateInfo
+    vk::InstanceCreateInfo instanceCreateInfo( {}, &applicationInfo );
 
-        // create an Instance
-        vk::Instance instance = vk::createInstance(instanceCreateInfo);
+    // create an Instance
+    vk::Instance instance = vk::createInstance( instanceCreateInfo );
 
 #if ( VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1 )
-        // initialize function pointers for instance
-        VULKAN_HPP_DEFAULT_DISPATCHER.init(instance);
+    // initialize function pointers for instance
+    VULKAN_HPP_DEFAULT_DISPATCHER.init( instance );
 #endif
 
-        // destroy it again
-        instance.destroy();
-    }
-    catch (vk::SystemError& err)
-    {
-        std::cout << "vk::SystemError: " << err.what() << std::endl;
-        exit(-1);
-    }
-    catch (std::exception& err)
-    {
-        std::cout << "std::exception: " << err.what() << std::endl;
-        exit(-1);
-    }
-    catch (...)
-    {
-        std::cout << "unknown error\n";
-        exit(-1);
-    }
+    // some minimal check for std::hash on a vk-type
+    auto h1 = std::hash<vk::Instance>{}( instance );
+    auto h2 = std::hash<VkInstance>{}( static_cast<VkInstance>( instance ) );
+    assert( h1 == h2 );
 
-    /* VULKAN_HPP_KEY_END */
+    std::unordered_set<vk::Instance> uset;
+    uset.insert( instance );
 
-    return 0;
+    std::unordered_map<vk::Instance, size_t> umap;
+    umap[instance] = 1;
+
+    vk::FormatFeatureFlags fff;
+    auto                   hf = std::hash<vk::FormatFeatureFlags>{}( fff );
+
+    // destroy it again
+    instance.destroy();
+  }
+  catch ( vk::SystemError & err )
+  {
+    std::cout << "vk::SystemError: " << err.what() << std::endl;
+    exit( -1 );
+  }
+  catch ( std::exception & err )
+  {
+    std::cout << "std::exception: " << err.what() << std::endl;
+    exit( -1 );
+  }
+  catch ( ... )
+  {
+    std::cout << "unknown error\n";
+    exit( -1 );
+  }
+
+  /* VULKAN_HPP_KEY_END */
+
+  return 0;
 }

--- a/vulkan/vulkan.cppm
+++ b/vulkan/vulkan.cppm
@@ -12,7 +12,7 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
-#if defined( __cpp_lib_modules )
+#if defined( __cpp_lib_modules ) && !defined( VULKAN_HPP_ENABLE_STD_MODULE )
 #  define VULKAN_HPP_ENABLE_STD_MODULE
 #endif
 
@@ -5077,3 +5077,3009 @@ export namespace VULKAN_HPP_NAMESPACE
   }  // namespace VULKAN_HPP_RAII_NAMESPACE
 #endif
 }  // namespace VULKAN_HPP_NAMESPACE
+
+export namespace std
+{
+
+  //=======================================
+  //=== HASH specialization for Flags types ===
+  //=======================================
+
+  template <typename BitType>
+  struct hash<VULKAN_HPP_NAMESPACE::Flags<BitType>>;
+
+  //========================================
+  //=== HASH specializations for handles ===
+  //========================================
+
+  //=== VK_VERSION_1_0 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Instance>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevice>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Device>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Queue>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceMemory>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Fence>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Semaphore>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Event>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueryPool>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Buffer>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferView>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Image>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageView>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ShaderModule>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCache>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Pipeline>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineLayout>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Sampler>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorPool>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSet>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSetLayout>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Framebuffer>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPass>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandPool>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandBuffer>;
+
+  //=== VK_VERSION_1_1 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerYcbcrConversion>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorUpdateTemplate>;
+
+  //=== VK_VERSION_1_3 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PrivateDataSlot>;
+
+  //=== VK_KHR_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfaceKHR>;
+
+  //=== VK_KHR_swapchain ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SwapchainKHR>;
+
+  //=== VK_KHR_display ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayModeKHR>;
+
+  //=== VK_EXT_debug_report ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DebugReportCallbackEXT>;
+
+  //=== VK_KHR_video_queue ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoSessionKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoSessionParametersKHR>;
+
+  //=== VK_NVX_binary_import ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CuModuleNVX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CuFunctionNVX>;
+
+  //=== VK_EXT_debug_utils ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DebugUtilsMessengerEXT>;
+
+  //=== VK_KHR_acceleration_structure ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureKHR>;
+
+  //=== VK_EXT_validation_cache ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ValidationCacheEXT>;
+
+  //=== VK_NV_ray_tracing ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureNV>;
+
+  //=== VK_INTEL_performance_query ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PerformanceConfigurationINTEL>;
+
+  //=== VK_KHR_deferred_host_operations ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeferredOperationKHR>;
+
+  //=== VK_NV_device_generated_commands ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IndirectCommandsLayoutNV>;
+
+#if defined( VK_ENABLE_BETA_EXTENSIONS )
+  //=== VK_NV_cuda_kernel_launch ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CudaModuleNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CudaFunctionNV>;
+#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+
+#if defined( VK_USE_PLATFORM_FUCHSIA )
+  //=== VK_FUCHSIA_buffer_collection ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferCollectionFUCHSIA>;
+#endif /*VK_USE_PLATFORM_FUCHSIA*/
+
+  //=== VK_EXT_opacity_micromap ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MicromapEXT>;
+
+  //=== VK_NV_optical_flow ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::OpticalFlowSessionNV>;
+
+  //=== VK_EXT_shader_object ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ShaderEXT>;
+
+  //=== VK_KHR_pipeline_binary ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineBinaryKHR>;
+
+  //=== VK_EXT_device_generated_commands ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IndirectCommandsLayoutEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IndirectExecutionSetEXT>;
+
+  //========================================
+  //=== HASH specializations for structs ===
+  //========================================
+
+  //=== VK_VERSION_1_0 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Extent2D>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Extent3D>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Offset2D>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Offset3D>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Rect2D>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BaseInStructure>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BaseOutStructure>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferMemoryBarrier>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DispatchIndirectCommand>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DrawIndexedIndirectCommand>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DrawIndirectCommand>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageMemoryBarrier>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryBarrier>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCacheHeaderVersionOne>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AllocationCallbacks>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ApplicationInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FormatProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageFormatProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::InstanceCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryHeap>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryType>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceLimits>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMemoryProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSparseProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueueFamilyProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceQueueCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExtensionProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::LayerProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubmitInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MappedMemoryRange>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryAllocateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryRequirements>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindSparseInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageSubresource>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SparseBufferMemoryBindInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SparseImageFormatProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SparseImageMemoryBind>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SparseImageMemoryBindInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SparseImageMemoryRequirements>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SparseImageOpaqueMemoryBindInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SparseMemoryBind>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FenceCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SemaphoreCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::EventCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueryPoolCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferViewCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubresourceLayout>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ComponentMapping>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageSubresourceRange>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageViewCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ShaderModuleCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCacheCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ComputePipelineCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::GraphicsPipelineCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineColorBlendAttachmentState>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineColorBlendStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineDepthStencilStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineDynamicStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineInputAssemblyStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineMultisampleStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineRasterizationStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineShaderStageCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineTessellationStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineVertexInputStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineViewportStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SpecializationInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SpecializationMapEntry>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::StencilOpState>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VertexInputAttributeDescription>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VertexInputBindingDescription>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Viewport>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineLayoutCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PushConstantRange>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyDescriptorSet>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorBufferInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorImageInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorPoolCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorPoolSize>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSetAllocateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSetLayoutBinding>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSetLayoutCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::WriteDescriptorSet>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AttachmentDescription>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AttachmentReference>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FramebufferCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassDependency>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassDescription>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandPoolCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandBufferAllocateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandBufferBeginInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandBufferInheritanceInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferCopy>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferImageCopy>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ClearAttachment>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ClearColorValue>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ClearDepthStencilValue>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ClearRect>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ClearValue>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageBlit>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageCopy>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageResolve>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageSubresourceLayers>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassBeginInfo>;
+
+  //=== VK_VERSION_1_1 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSubgroupProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindBufferMemoryInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindImageMemoryInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevice16BitStorageFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryDedicatedRequirements>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryDedicatedAllocateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryAllocateFlagsInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceGroupRenderPassBeginInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceGroupCommandBufferBeginInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceGroupSubmitInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceGroupBindSparseInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindBufferMemoryDeviceGroupInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindImageMemoryDeviceGroupInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceGroupProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceGroupDeviceCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferMemoryRequirementsInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageMemoryRequirementsInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageSparseMemoryRequirementsInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryRequirements2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SparseImageMemoryRequirements2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFeatures2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceProperties2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FormatProperties2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageFormatProperties2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImageFormatInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueueFamilyProperties2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMemoryProperties2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SparseImageFormatProperties2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSparseImageFormatInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePointClippingProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassInputAttachmentAspectCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::InputAttachmentAspectReference>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageViewUsageCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineTessellationDomainOriginStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassMultiviewCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMultiviewFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMultiviewProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVariablePointersFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceProtectedMemoryFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceProtectedMemoryProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceQueueInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ProtectedSubmitInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerYcbcrConversionCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerYcbcrConversionInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindImagePlaneMemoryInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImagePlaneMemoryRequirementsInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSamplerYcbcrConversionFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerYcbcrConversionImageFormatProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorUpdateTemplateEntry>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorUpdateTemplateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalMemoryProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExternalImageFormatInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalImageFormatProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExternalBufferInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalBufferProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceIDProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalMemoryImageCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalMemoryBufferCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportMemoryAllocateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExternalFenceInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalFenceProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportFenceCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportSemaphoreCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExternalSemaphoreInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalSemaphoreProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMaintenance3Properties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSetLayoutSupport>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderDrawParametersFeatures>;
+
+  //=== VK_VERSION_1_2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVulkan11Features>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVulkan11Properties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVulkan12Features>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVulkan12Properties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageFormatListCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassCreateInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AttachmentDescription2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AttachmentReference2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassDescription2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassDependency2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassBeginInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassEndInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevice8BitStorageFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ConformanceVersion>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDriverProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderAtomicInt64Features>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderFloat16Int8Features>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFloatControlsProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSetLayoutBindingFlagsCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDescriptorIndexingFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDescriptorIndexingProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSetVariableDescriptorCountAllocateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSetVariableDescriptorCountLayoutSupport>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassDescriptionDepthStencilResolve>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDepthStencilResolveProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceScalarBlockLayoutFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageStencilUsageCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerReductionModeCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSamplerFilterMinmaxProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVulkanMemoryModelFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImagelessFramebufferFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FramebufferAttachmentsCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FramebufferAttachmentImageInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassAttachmentBeginInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceUniformBufferStandardLayoutFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderSubgroupExtendedTypesFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSeparateDepthStencilLayoutsFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AttachmentReferenceStencilLayout>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AttachmentDescriptionStencilLayout>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceHostQueryResetFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceTimelineSemaphoreFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceTimelineSemaphoreProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SemaphoreTypeCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::TimelineSemaphoreSubmitInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SemaphoreWaitInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SemaphoreSignalInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceBufferDeviceAddressFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferDeviceAddressInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferOpaqueCaptureAddressCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryOpaqueCaptureAddressAllocateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceMemoryOpaqueCaptureAddressInfo>;
+
+  //=== VK_VERSION_1_3 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVulkan13Features>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVulkan13Properties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCreationFeedbackCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCreationFeedback>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderTerminateInvocationFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceToolProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderDemoteToHelperInvocationFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePrivateDataFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DevicePrivateDataCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PrivateDataSlotCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePipelineCreationCacheControlFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryBarrier2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferMemoryBarrier2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageMemoryBarrier2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DependencyInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubmitInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SemaphoreSubmitInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandBufferSubmitInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSynchronization2Features>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceZeroInitializeWorkgroupMemoryFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImageRobustnessFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyBufferInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyImageInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyBufferToImageInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyImageToBufferInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BlitImageInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ResolveImageInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferCopy2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageCopy2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageBlit2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferImageCopy2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageResolve2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSubgroupSizeControlFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSubgroupSizeControlProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineShaderStageRequiredSubgroupSizeCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceInlineUniformBlockFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceInlineUniformBlockProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::WriteDescriptorSetInlineUniformBlock>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorPoolInlineUniformBlockCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceTextureCompressionASTCHDRFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderingInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderingAttachmentInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineRenderingCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDynamicRenderingFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandBufferInheritanceRenderingInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderIntegerDotProductFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderIntegerDotProductProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceTexelBufferAlignmentProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FormatProperties3>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMaintenance4Features>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMaintenance4Properties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceBufferMemoryRequirements>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceImageMemoryRequirements>;
+
+  //=== VK_KHR_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfaceCapabilitiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfaceFormatKHR>;
+
+  //=== VK_KHR_swapchain ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SwapchainCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PresentInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageSwapchainCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindImageMemorySwapchainInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AcquireNextImageInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceGroupPresentCapabilitiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceGroupPresentInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceGroupSwapchainCreateInfoKHR>;
+
+  //=== VK_KHR_display ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayModeCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayModeParametersKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayModePropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayPlaneCapabilitiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayPlanePropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplaySurfaceCreateInfoKHR>;
+
+  //=== VK_KHR_display_swapchain ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayPresentInfoKHR>;
+
+#if defined( VK_USE_PLATFORM_XLIB_KHR )
+  //=== VK_KHR_xlib_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::XlibSurfaceCreateInfoKHR>;
+#endif /*VK_USE_PLATFORM_XLIB_KHR*/
+
+#if defined( VK_USE_PLATFORM_XCB_KHR )
+  //=== VK_KHR_xcb_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::XcbSurfaceCreateInfoKHR>;
+#endif /*VK_USE_PLATFORM_XCB_KHR*/
+
+#if defined( VK_USE_PLATFORM_WAYLAND_KHR )
+  //=== VK_KHR_wayland_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::WaylandSurfaceCreateInfoKHR>;
+#endif /*VK_USE_PLATFORM_WAYLAND_KHR*/
+
+#if defined( VK_USE_PLATFORM_ANDROID_KHR )
+  //=== VK_KHR_android_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AndroidSurfaceCreateInfoKHR>;
+#endif /*VK_USE_PLATFORM_ANDROID_KHR*/
+
+#if defined( VK_USE_PLATFORM_WIN32_KHR )
+  //=== VK_KHR_win32_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Win32SurfaceCreateInfoKHR>;
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
+  //=== VK_EXT_debug_report ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DebugReportCallbackCreateInfoEXT>;
+
+  //=== VK_AMD_rasterization_order ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineRasterizationStateRasterizationOrderAMD>;
+
+  //=== VK_EXT_debug_marker ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DebugMarkerObjectNameInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DebugMarkerObjectTagInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DebugMarkerMarkerInfoEXT>;
+
+  //=== VK_KHR_video_queue ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueueFamilyQueryResultStatusPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueueFamilyVideoPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoProfileInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoProfileListInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoCapabilitiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVideoFormatInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoFormatPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoPictureResourceInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoReferenceSlotInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoSessionMemoryRequirementsKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindVideoSessionMemoryInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoSessionCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoSessionParametersCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoSessionParametersUpdateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoBeginCodingInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEndCodingInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoCodingControlInfoKHR>;
+
+  //=== VK_KHR_video_decode_queue ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeCapabilitiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeUsageInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeInfoKHR>;
+
+  //=== VK_NV_dedicated_allocation ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DedicatedAllocationImageCreateInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DedicatedAllocationBufferCreateInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DedicatedAllocationMemoryAllocateInfoNV>;
+
+  //=== VK_EXT_transform_feedback ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceTransformFeedbackFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceTransformFeedbackPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineRasterizationStateStreamCreateInfoEXT>;
+
+  //=== VK_NVX_binary_import ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CuModuleCreateInfoNVX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CuFunctionCreateInfoNVX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CuLaunchInfoNVX>;
+
+  //=== VK_NVX_image_view_handle ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageViewHandleInfoNVX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageViewAddressPropertiesNVX>;
+
+  //=== VK_KHR_video_encode_h264 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH264CapabilitiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH264QualityLevelPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH264SessionCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH264SessionParametersCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH264SessionParametersAddInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH264SessionParametersGetInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH264SessionParametersFeedbackInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH264PictureInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH264DpbSlotInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH264NaluSliceInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH264ProfileInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH264RateControlInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH264RateControlLayerInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH264QpKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH264FrameSizeKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH264GopRemainingFrameInfoKHR>;
+
+  //=== VK_KHR_video_encode_h265 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH265CapabilitiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH265SessionCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH265QualityLevelPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH265SessionParametersCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH265SessionParametersAddInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH265SessionParametersGetInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH265SessionParametersFeedbackInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH265PictureInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH265DpbSlotInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH265NaluSliceSegmentInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH265ProfileInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH265RateControlInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH265RateControlLayerInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH265QpKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH265FrameSizeKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeH265GopRemainingFrameInfoKHR>;
+
+  //=== VK_KHR_video_decode_h264 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeH264ProfileInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeH264CapabilitiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeH264SessionParametersCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeH264SessionParametersAddInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeH264PictureInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeH264DpbSlotInfoKHR>;
+
+  //=== VK_AMD_texture_gather_bias_lod ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::TextureLODGatherFormatPropertiesAMD>;
+
+  //=== VK_AMD_shader_info ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ShaderResourceUsageAMD>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ShaderStatisticsInfoAMD>;
+
+#if defined( VK_USE_PLATFORM_GGP )
+  //=== VK_GGP_stream_descriptor_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::StreamDescriptorSurfaceCreateInfoGGP>;
+#endif /*VK_USE_PLATFORM_GGP*/
+
+  //=== VK_NV_corner_sampled_image ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCornerSampledImageFeaturesNV>;
+
+  //=== VK_NV_external_memory_capabilities ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalImageFormatPropertiesNV>;
+
+  //=== VK_NV_external_memory ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalMemoryImageCreateInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportMemoryAllocateInfoNV>;
+
+#if defined( VK_USE_PLATFORM_WIN32_KHR )
+  //=== VK_NV_external_memory_win32 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportMemoryWin32HandleInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportMemoryWin32HandleInfoNV>;
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
+#if defined( VK_USE_PLATFORM_WIN32_KHR )
+  //=== VK_NV_win32_keyed_mutex ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Win32KeyedMutexAcquireReleaseInfoNV>;
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
+  //=== VK_KHR_device_group ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceGroupPresentCapabilitiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageSwapchainCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindImageMemorySwapchainInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AcquireNextImageInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceGroupPresentInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceGroupSwapchainCreateInfoKHR>;
+
+  //=== VK_EXT_validation_flags ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ValidationFlagsEXT>;
+
+#if defined( VK_USE_PLATFORM_VI_NN )
+  //=== VK_NN_vi_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ViSurfaceCreateInfoNN>;
+#endif /*VK_USE_PLATFORM_VI_NN*/
+
+  //=== VK_EXT_astc_decode_mode ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageViewASTCDecodeModeEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceASTCDecodeFeaturesEXT>;
+
+  //=== VK_EXT_pipeline_robustness ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePipelineRobustnessFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePipelineRobustnessPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineRobustnessCreateInfoEXT>;
+
+#if defined( VK_USE_PLATFORM_WIN32_KHR )
+  //=== VK_KHR_external_memory_win32 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportMemoryWin32HandleInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportMemoryWin32HandleInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryWin32HandlePropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryGetWin32HandleInfoKHR>;
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
+  //=== VK_KHR_external_memory_fd ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportMemoryFdInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryFdPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryGetFdInfoKHR>;
+
+#if defined( VK_USE_PLATFORM_WIN32_KHR )
+  //=== VK_KHR_win32_keyed_mutex ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Win32KeyedMutexAcquireReleaseInfoKHR>;
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
+#if defined( VK_USE_PLATFORM_WIN32_KHR )
+  //=== VK_KHR_external_semaphore_win32 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportSemaphoreWin32HandleInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportSemaphoreWin32HandleInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::D3D12FenceSubmitInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SemaphoreGetWin32HandleInfoKHR>;
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
+  //=== VK_KHR_external_semaphore_fd ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportSemaphoreFdInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SemaphoreGetFdInfoKHR>;
+
+  //=== VK_KHR_push_descriptor ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePushDescriptorPropertiesKHR>;
+
+  //=== VK_EXT_conditional_rendering ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ConditionalRenderingBeginInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceConditionalRenderingFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandBufferInheritanceConditionalRenderingInfoEXT>;
+
+  //=== VK_KHR_incremental_present ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PresentRegionsKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PresentRegionKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RectLayerKHR>;
+
+  //=== VK_NV_clip_space_w_scaling ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ViewportWScalingNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineViewportWScalingStateCreateInfoNV>;
+
+  //=== VK_EXT_display_surface_counter ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfaceCapabilities2EXT>;
+
+  //=== VK_EXT_display_control ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayPowerInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceEventInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayEventInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SwapchainCounterCreateInfoEXT>;
+
+  //=== VK_GOOGLE_display_timing ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RefreshCycleDurationGOOGLE>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PastPresentationTimingGOOGLE>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PresentTimesInfoGOOGLE>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PresentTimeGOOGLE>;
+
+  //=== VK_NVX_multiview_per_view_attributes ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMultiviewPerViewAttributesPropertiesNVX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MultiviewPerViewAttributesInfoNVX>;
+
+  //=== VK_NV_viewport_swizzle ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ViewportSwizzleNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineViewportSwizzleStateCreateInfoNV>;
+
+  //=== VK_EXT_discard_rectangles ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDiscardRectanglePropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineDiscardRectangleStateCreateInfoEXT>;
+
+  //=== VK_EXT_conservative_rasterization ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceConservativeRasterizationPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineRasterizationConservativeStateCreateInfoEXT>;
+
+  //=== VK_EXT_depth_clip_enable ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDepthClipEnableFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineRasterizationDepthClipStateCreateInfoEXT>;
+
+  //=== VK_EXT_hdr_metadata ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::HdrMetadataEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::XYColorEXT>;
+
+  //=== VK_IMG_relaxed_line_rasterization ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRelaxedLineRasterizationFeaturesIMG>;
+
+  //=== VK_KHR_shared_presentable_image ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SharedPresentSurfaceCapabilitiesKHR>;
+
+#if defined( VK_USE_PLATFORM_WIN32_KHR )
+  //=== VK_KHR_external_fence_win32 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportFenceWin32HandleInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportFenceWin32HandleInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FenceGetWin32HandleInfoKHR>;
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
+  //=== VK_KHR_external_fence_fd ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportFenceFdInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FenceGetFdInfoKHR>;
+
+  //=== VK_KHR_performance_query ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePerformanceQueryFeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePerformanceQueryPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PerformanceCounterKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PerformanceCounterDescriptionKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueryPoolPerformanceCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PerformanceCounterResultKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AcquireProfilingLockInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PerformanceQuerySubmitInfoKHR>;
+
+  //=== VK_KHR_get_surface_capabilities2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSurfaceInfo2KHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfaceCapabilities2KHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfaceFormat2KHR>;
+
+  //=== VK_KHR_get_display_properties2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayProperties2KHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayPlaneProperties2KHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayModeProperties2KHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayPlaneInfo2KHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayPlaneCapabilities2KHR>;
+
+#if defined( VK_USE_PLATFORM_IOS_MVK )
+  //=== VK_MVK_ios_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IOSSurfaceCreateInfoMVK>;
+#endif /*VK_USE_PLATFORM_IOS_MVK*/
+
+#if defined( VK_USE_PLATFORM_MACOS_MVK )
+  //=== VK_MVK_macos_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MacOSSurfaceCreateInfoMVK>;
+#endif /*VK_USE_PLATFORM_MACOS_MVK*/
+
+  //=== VK_EXT_debug_utils ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DebugUtilsLabelEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DebugUtilsMessengerCallbackDataEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DebugUtilsMessengerCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DebugUtilsObjectNameInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DebugUtilsObjectTagInfoEXT>;
+
+#if defined( VK_USE_PLATFORM_ANDROID_KHR )
+  //=== VK_ANDROID_external_memory_android_hardware_buffer ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AndroidHardwareBufferUsageANDROID>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AndroidHardwareBufferPropertiesANDROID>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AndroidHardwareBufferFormatPropertiesANDROID>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportAndroidHardwareBufferInfoANDROID>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryGetAndroidHardwareBufferInfoANDROID>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalFormatANDROID>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AndroidHardwareBufferFormatProperties2ANDROID>;
+#endif /*VK_USE_PLATFORM_ANDROID_KHR*/
+
+#if defined( VK_ENABLE_BETA_EXTENSIONS )
+  //=== VK_AMDX_shader_enqueue ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderEnqueueFeaturesAMDX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderEnqueuePropertiesAMDX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExecutionGraphPipelineScratchSizeAMDX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExecutionGraphPipelineCreateInfoAMDX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DispatchGraphInfoAMDX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DispatchGraphCountInfoAMDX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineShaderStageNodeCreateInfoAMDX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceOrHostAddressConstAMDX>;
+#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+
+  //=== VK_AMD_mixed_attachment_samples ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AttachmentSampleCountInfoAMD>;
+
+  //=== VK_EXT_sample_locations ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SampleLocationEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SampleLocationsInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AttachmentSampleLocationsEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassSampleLocationsEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassSampleLocationsBeginInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineSampleLocationsStateCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSampleLocationsPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MultisamplePropertiesEXT>;
+
+  //=== VK_EXT_blend_operation_advanced ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceBlendOperationAdvancedFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceBlendOperationAdvancedPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineColorBlendAdvancedStateCreateInfoEXT>;
+
+  //=== VK_NV_fragment_coverage_to_color ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCoverageToColorStateCreateInfoNV>;
+
+  //=== VK_KHR_acceleration_structure ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceOrHostAddressKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceOrHostAddressConstKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureBuildRangeInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AabbPositionsKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureGeometryTrianglesDataKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::TransformMatrixKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureBuildGeometryInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureGeometryAabbsDataKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureInstanceKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureGeometryInstancesDataKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureGeometryDataKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureGeometryKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::WriteDescriptorSetAccelerationStructureKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceAccelerationStructureFeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceAccelerationStructurePropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureDeviceAddressInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureVersionInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyAccelerationStructureToMemoryInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyMemoryToAccelerationStructureInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyAccelerationStructureInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureBuildSizesInfoKHR>;
+
+  //=== VK_KHR_ray_tracing_pipeline ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RayTracingShaderGroupCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RayTracingPipelineCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRayTracingPipelineFeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRayTracingPipelinePropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::StridedDeviceAddressRegionKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::TraceRaysIndirectCommandKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RayTracingPipelineInterfaceCreateInfoKHR>;
+
+  //=== VK_KHR_ray_query ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRayQueryFeaturesKHR>;
+
+  //=== VK_NV_framebuffer_mixed_samples ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCoverageModulationStateCreateInfoNV>;
+
+  //=== VK_NV_shader_sm_builtins ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderSMBuiltinsPropertiesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderSMBuiltinsFeaturesNV>;
+
+  //=== VK_EXT_image_drm_format_modifier ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DrmFormatModifierPropertiesListEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DrmFormatModifierPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImageDrmFormatModifierInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageDrmFormatModifierListCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageDrmFormatModifierExplicitCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageDrmFormatModifierPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DrmFormatModifierPropertiesList2EXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DrmFormatModifierProperties2EXT>;
+
+  //=== VK_EXT_validation_cache ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ValidationCacheCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ShaderModuleValidationCacheCreateInfoEXT>;
+
+#if defined( VK_ENABLE_BETA_EXTENSIONS )
+  //=== VK_KHR_portability_subset ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePortabilitySubsetFeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePortabilitySubsetPropertiesKHR>;
+#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+
+  //=== VK_NV_shading_rate_image ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ShadingRatePaletteNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineViewportShadingRateImageStateCreateInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShadingRateImageFeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShadingRateImagePropertiesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CoarseSampleLocationNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CoarseSampleOrderCustomNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineViewportCoarseSampleOrderStateCreateInfoNV>;
+
+  //=== VK_NV_ray_tracing ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RayTracingShaderGroupCreateInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RayTracingPipelineCreateInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::GeometryTrianglesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::GeometryAABBNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::GeometryDataNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::GeometryNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureCreateInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindAccelerationStructureMemoryInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::WriteDescriptorSetAccelerationStructureNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureMemoryRequirementsInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRayTracingPropertiesNV>;
+
+  //=== VK_NV_representative_fragment_test ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRepresentativeFragmentTestFeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineRepresentativeFragmentTestStateCreateInfoNV>;
+
+  //=== VK_EXT_filter_cubic ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImageViewImageFormatInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FilterCubicImageViewImageFormatPropertiesEXT>;
+
+  //=== VK_EXT_external_memory_host ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportMemoryHostPointerInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryHostPointerPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExternalMemoryHostPropertiesEXT>;
+
+  //=== VK_KHR_shader_clock ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderClockFeaturesKHR>;
+
+  //=== VK_AMD_pipeline_compiler_control ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCompilerControlCreateInfoAMD>;
+
+  //=== VK_AMD_shader_core_properties ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderCorePropertiesAMD>;
+
+  //=== VK_KHR_video_decode_h265 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeH265ProfileInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeH265CapabilitiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeH265SessionParametersCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeH265SessionParametersAddInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeH265PictureInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeH265DpbSlotInfoKHR>;
+
+  //=== VK_KHR_global_priority ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceQueueGlobalPriorityCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceGlobalPriorityQueryFeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueueFamilyGlobalPriorityPropertiesKHR>;
+
+  //=== VK_AMD_memory_overallocation_behavior ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceMemoryOverallocationCreateInfoAMD>;
+
+  //=== VK_EXT_vertex_attribute_divisor ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVertexAttributeDivisorPropertiesEXT>;
+
+#if defined( VK_USE_PLATFORM_GGP )
+  //=== VK_GGP_frame_token ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PresentFrameTokenGGP>;
+#endif /*VK_USE_PLATFORM_GGP*/
+
+  //=== VK_NV_mesh_shader ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMeshShaderFeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMeshShaderPropertiesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DrawMeshTasksIndirectCommandNV>;
+
+  //=== VK_NV_shader_image_footprint ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderImageFootprintFeaturesNV>;
+
+  //=== VK_NV_scissor_exclusive ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineViewportExclusiveScissorStateCreateInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExclusiveScissorFeaturesNV>;
+
+  //=== VK_NV_device_diagnostic_checkpoints ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueueFamilyCheckpointPropertiesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CheckpointDataNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueueFamilyCheckpointProperties2NV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CheckpointData2NV>;
+
+  //=== VK_INTEL_shader_integer_functions2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderIntegerFunctions2FeaturesINTEL>;
+
+  //=== VK_INTEL_performance_query ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PerformanceValueDataINTEL>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PerformanceValueINTEL>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::InitializePerformanceApiInfoINTEL>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueryPoolPerformanceQueryCreateInfoINTEL>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PerformanceMarkerInfoINTEL>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PerformanceStreamMarkerInfoINTEL>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PerformanceOverrideInfoINTEL>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PerformanceConfigurationAcquireInfoINTEL>;
+
+  //=== VK_EXT_pci_bus_info ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePCIBusInfoPropertiesEXT>;
+
+  //=== VK_AMD_display_native_hdr ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayNativeHdrSurfaceCapabilitiesAMD>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SwapchainDisplayNativeHdrCreateInfoAMD>;
+
+#if defined( VK_USE_PLATFORM_FUCHSIA )
+  //=== VK_FUCHSIA_imagepipe_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImagePipeSurfaceCreateInfoFUCHSIA>;
+#endif /*VK_USE_PLATFORM_FUCHSIA*/
+
+#if defined( VK_USE_PLATFORM_METAL_EXT )
+  //=== VK_EXT_metal_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MetalSurfaceCreateInfoEXT>;
+#endif /*VK_USE_PLATFORM_METAL_EXT*/
+
+  //=== VK_EXT_fragment_density_map ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFragmentDensityMapFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFragmentDensityMapPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassFragmentDensityMapCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderingFragmentDensityMapAttachmentInfoEXT>;
+
+  //=== VK_KHR_fragment_shading_rate ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FragmentShadingRateAttachmentInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineFragmentShadingRateStateCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFragmentShadingRateFeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFragmentShadingRatePropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFragmentShadingRateKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderingFragmentShadingRateAttachmentInfoKHR>;
+
+  //=== VK_AMD_shader_core_properties2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderCoreProperties2AMD>;
+
+  //=== VK_AMD_device_coherent_memory ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCoherentMemoryFeaturesAMD>;
+
+  //=== VK_KHR_dynamic_rendering_local_read ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDynamicRenderingLocalReadFeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderingAttachmentLocationInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderingInputAttachmentIndexInfoKHR>;
+
+  //=== VK_EXT_shader_image_atomic_int64 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderImageAtomicInt64FeaturesEXT>;
+
+  //=== VK_KHR_shader_quad_control ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderQuadControlFeaturesKHR>;
+
+  //=== VK_EXT_memory_budget ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMemoryBudgetPropertiesEXT>;
+
+  //=== VK_EXT_memory_priority ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMemoryPriorityFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryPriorityAllocateInfoEXT>;
+
+  //=== VK_KHR_surface_protected_capabilities ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfaceProtectedCapabilitiesKHR>;
+
+  //=== VK_NV_dedicated_allocation_image_aliasing ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV>;
+
+  //=== VK_EXT_buffer_device_address ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceBufferDeviceAddressFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferDeviceAddressCreateInfoEXT>;
+
+  //=== VK_EXT_validation_features ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ValidationFeaturesEXT>;
+
+  //=== VK_KHR_present_wait ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePresentWaitFeaturesKHR>;
+
+  //=== VK_NV_cooperative_matrix ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CooperativeMatrixPropertiesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCooperativeMatrixFeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCooperativeMatrixPropertiesNV>;
+
+  //=== VK_NV_coverage_reduction_mode ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCoverageReductionModeFeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCoverageReductionStateCreateInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FramebufferMixedSamplesCombinationNV>;
+
+  //=== VK_EXT_fragment_shader_interlock ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFragmentShaderInterlockFeaturesEXT>;
+
+  //=== VK_EXT_ycbcr_image_arrays ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceYcbcrImageArraysFeaturesEXT>;
+
+  //=== VK_EXT_provoking_vertex ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceProvokingVertexFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceProvokingVertexPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineRasterizationProvokingVertexStateCreateInfoEXT>;
+
+#if defined( VK_USE_PLATFORM_WIN32_KHR )
+  //=== VK_EXT_full_screen_exclusive ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfaceFullScreenExclusiveInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfaceCapabilitiesFullScreenExclusiveEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfaceFullScreenExclusiveWin32InfoEXT>;
+#endif /*VK_USE_PLATFORM_WIN32_KHR*/
+
+  //=== VK_EXT_headless_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::HeadlessSurfaceCreateInfoEXT>;
+
+  //=== VK_EXT_shader_atomic_float ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderAtomicFloatFeaturesEXT>;
+
+  //=== VK_EXT_extended_dynamic_state ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExtendedDynamicStateFeaturesEXT>;
+
+  //=== VK_KHR_pipeline_executable_properties ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePipelineExecutablePropertiesFeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineExecutablePropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineExecutableInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineExecutableStatisticValueKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineExecutableStatisticKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineExecutableInternalRepresentationKHR>;
+
+  //=== VK_EXT_host_image_copy ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceHostImageCopyFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceHostImageCopyPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryToImageCopyEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageToMemoryCopyEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyMemoryToImageInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyImageToMemoryInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyImageToImageInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::HostImageLayoutTransitionInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubresourceHostMemcpySizeEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::HostImageCopyDevicePerformanceQueryEXT>;
+
+  //=== VK_KHR_map_memory2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryMapInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryUnmapInfoKHR>;
+
+  //=== VK_EXT_map_memory_placed ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMapMemoryPlacedFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMapMemoryPlacedPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryMapPlacedInfoEXT>;
+
+  //=== VK_EXT_shader_atomic_float2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderAtomicFloat2FeaturesEXT>;
+
+  //=== VK_EXT_surface_maintenance1 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfacePresentModeEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfacePresentScalingCapabilitiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfacePresentModeCompatibilityEXT>;
+
+  //=== VK_EXT_swapchain_maintenance1 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSwapchainMaintenance1FeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SwapchainPresentFenceInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SwapchainPresentModesCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SwapchainPresentModeInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SwapchainPresentScalingCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ReleaseSwapchainImagesInfoEXT>;
+
+  //=== VK_NV_device_generated_commands ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDeviceGeneratedCommandsPropertiesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDeviceGeneratedCommandsFeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::GraphicsShaderGroupCreateInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::GraphicsPipelineShaderGroupsCreateInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindShaderGroupIndirectCommandNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindIndexBufferIndirectCommandNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindVertexBufferIndirectCommandNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SetStateFlagsIndirectCommandNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IndirectCommandsStreamNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IndirectCommandsLayoutTokenNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IndirectCommandsLayoutCreateInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::GeneratedCommandsInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::GeneratedCommandsMemoryRequirementsInfoNV>;
+
+  //=== VK_NV_inherited_viewport_scissor ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceInheritedViewportScissorFeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandBufferInheritanceViewportScissorInfoNV>;
+
+  //=== VK_EXT_texel_buffer_alignment ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceTexelBufferAlignmentFeaturesEXT>;
+
+  //=== VK_QCOM_render_pass_transform ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassTransformBeginInfoQCOM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandBufferInheritanceRenderPassTransformInfoQCOM>;
+
+  //=== VK_EXT_depth_bias_control ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDepthBiasControlFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DepthBiasInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DepthBiasRepresentationInfoEXT>;
+
+  //=== VK_EXT_device_memory_report ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDeviceMemoryReportFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceDeviceMemoryReportCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceMemoryReportCallbackDataEXT>;
+
+  //=== VK_EXT_robustness2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRobustness2FeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRobustness2PropertiesEXT>;
+
+  //=== VK_EXT_custom_border_color ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerCustomBorderColorCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCustomBorderColorPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCustomBorderColorFeaturesEXT>;
+
+  //=== VK_KHR_pipeline_library ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineLibraryCreateInfoKHR>;
+
+  //=== VK_NV_present_barrier ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePresentBarrierFeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfaceCapabilitiesPresentBarrierNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SwapchainPresentBarrierCreateInfoNV>;
+
+  //=== VK_KHR_present_id ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PresentIdKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePresentIdFeaturesKHR>;
+
+  //=== VK_KHR_video_encode_queue ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeCapabilitiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueryPoolVideoEncodeFeedbackCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeUsageInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeRateControlInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeRateControlLayerInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVideoEncodeQualityLevelInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeQualityLevelPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeQualityLevelInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeSessionParametersGetInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoEncodeSessionParametersFeedbackInfoKHR>;
+
+  //=== VK_NV_device_diagnostics_config ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDiagnosticsConfigFeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceDiagnosticsConfigCreateInfoNV>;
+
+#if defined( VK_ENABLE_BETA_EXTENSIONS )
+  //=== VK_NV_cuda_kernel_launch ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CudaModuleCreateInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CudaFunctionCreateInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CudaLaunchInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCudaKernelLaunchFeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCudaKernelLaunchPropertiesNV>;
+#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+
+  //=== VK_NV_low_latency ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueryLowLatencySupportNV>;
+
+#if defined( VK_USE_PLATFORM_METAL_EXT )
+  //=== VK_EXT_metal_objects ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportMetalObjectCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportMetalObjectsInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportMetalDeviceInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportMetalCommandQueueInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportMetalBufferInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportMetalBufferInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportMetalTextureInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportMetalTextureInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportMetalIOSurfaceInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportMetalIOSurfaceInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportMetalSharedEventInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportMetalSharedEventInfoEXT>;
+#endif /*VK_USE_PLATFORM_METAL_EXT*/
+
+  //=== VK_EXT_descriptor_buffer ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDescriptorBufferPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDescriptorBufferDensityMapPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDescriptorBufferFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorAddressInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorBufferBindingInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorBufferBindingPushDescriptorBufferHandleEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorDataEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorGetInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferCaptureDescriptorDataInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageCaptureDescriptorDataInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageViewCaptureDescriptorDataInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerCaptureDescriptorDataInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::OpaqueCaptureDescriptorDataCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureCaptureDescriptorDataInfoEXT>;
+
+  //=== VK_EXT_graphics_pipeline_library ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceGraphicsPipelineLibraryPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::GraphicsPipelineLibraryCreateInfoEXT>;
+
+  //=== VK_AMD_shader_early_and_late_fragment_tests ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD>;
+
+  //=== VK_KHR_fragment_shader_barycentric ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFragmentShaderBarycentricFeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFragmentShaderBarycentricPropertiesKHR>;
+
+  //=== VK_KHR_shader_subgroup_uniform_control_flow ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR>;
+
+  //=== VK_NV_fragment_shading_rate_enums ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFragmentShadingRateEnumsFeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFragmentShadingRateEnumsPropertiesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineFragmentShadingRateEnumStateCreateInfoNV>;
+
+  //=== VK_NV_ray_tracing_motion_blur ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureGeometryMotionTrianglesDataNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureMotionInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureMotionInstanceNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureMotionInstanceDataNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureMatrixMotionInstanceNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureSRTMotionInstanceNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SRTDataNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRayTracingMotionBlurFeaturesNV>;
+
+  //=== VK_EXT_mesh_shader ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMeshShaderFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMeshShaderPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DrawMeshTasksIndirectCommandEXT>;
+
+  //=== VK_EXT_ycbcr_2plane_444_formats ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT>;
+
+  //=== VK_EXT_fragment_density_map2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFragmentDensityMap2FeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFragmentDensityMap2PropertiesEXT>;
+
+  //=== VK_QCOM_rotated_copy_commands ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyCommandTransformInfoQCOM>;
+
+  //=== VK_KHR_workgroup_memory_explicit_layout ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>;
+
+  //=== VK_EXT_image_compression_control ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImageCompressionControlFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageCompressionControlEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageCompressionPropertiesEXT>;
+
+  //=== VK_EXT_attachment_feedback_loop_layout ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT>;
+
+  //=== VK_EXT_4444_formats ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevice4444FormatsFeaturesEXT>;
+
+  //=== VK_EXT_device_fault ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFaultFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceFaultCountsEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceFaultInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceFaultAddressInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceFaultVendorInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceFaultVendorBinaryHeaderVersionOneEXT>;
+
+  //=== VK_EXT_rgba10x6_formats ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRGBA10X6FormatsFeaturesEXT>;
+
+#if defined( VK_USE_PLATFORM_DIRECTFB_EXT )
+  //=== VK_EXT_directfb_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DirectFBSurfaceCreateInfoEXT>;
+#endif /*VK_USE_PLATFORM_DIRECTFB_EXT*/
+
+  //=== VK_EXT_vertex_input_dynamic_state ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVertexInputDynamicStateFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VertexInputBindingDescription2EXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VertexInputAttributeDescription2EXT>;
+
+  //=== VK_EXT_physical_device_drm ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDrmPropertiesEXT>;
+
+  //=== VK_EXT_device_address_binding_report ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceAddressBindingReportFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceAddressBindingCallbackDataEXT>;
+
+  //=== VK_EXT_depth_clip_control ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDepthClipControlFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineViewportDepthClipControlCreateInfoEXT>;
+
+  //=== VK_EXT_primitive_topology_list_restart ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePrimitiveTopologyListRestartFeaturesEXT>;
+
+  //=== VK_EXT_present_mode_fifo_latest_ready ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePresentModeFifoLatestReadyFeaturesEXT>;
+
+#if defined( VK_USE_PLATFORM_FUCHSIA )
+  //=== VK_FUCHSIA_external_memory ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportMemoryZirconHandleInfoFUCHSIA>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryZirconHandlePropertiesFUCHSIA>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryGetZirconHandleInfoFUCHSIA>;
+#endif /*VK_USE_PLATFORM_FUCHSIA*/
+
+#if defined( VK_USE_PLATFORM_FUCHSIA )
+  //=== VK_FUCHSIA_external_semaphore ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportSemaphoreZirconHandleInfoFUCHSIA>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SemaphoreGetZirconHandleInfoFUCHSIA>;
+#endif /*VK_USE_PLATFORM_FUCHSIA*/
+
+#if defined( VK_USE_PLATFORM_FUCHSIA )
+  //=== VK_FUCHSIA_buffer_collection ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferCollectionCreateInfoFUCHSIA>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportMemoryBufferCollectionFUCHSIA>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferCollectionImageCreateInfoFUCHSIA>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferConstraintsInfoFUCHSIA>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferCollectionBufferCreateInfoFUCHSIA>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferCollectionPropertiesFUCHSIA>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SysmemColorSpaceFUCHSIA>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageConstraintsInfoFUCHSIA>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageFormatConstraintsInfoFUCHSIA>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferCollectionConstraintsInfoFUCHSIA>;
+#endif /*VK_USE_PLATFORM_FUCHSIA*/
+
+  //=== VK_HUAWEI_subpass_shading ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassShadingPipelineCreateInfoHUAWEI>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSubpassShadingFeaturesHUAWEI>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSubpassShadingPropertiesHUAWEI>;
+
+  //=== VK_HUAWEI_invocation_mask ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceInvocationMaskFeaturesHUAWEI>;
+
+  //=== VK_NV_external_memory_rdma ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryGetRemoteAddressInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExternalMemoryRDMAFeaturesNV>;
+
+  //=== VK_EXT_pipeline_properties ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelinePropertiesIdentifierEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePipelinePropertiesFeaturesEXT>;
+
+  //=== VK_EXT_frame_boundary ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFrameBoundaryFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FrameBoundaryEXT>;
+
+  //=== VK_EXT_multisampled_render_to_single_sampled ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassResolvePerformanceQueryEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MultisampledRenderToSingleSampledInfoEXT>;
+
+  //=== VK_EXT_extended_dynamic_state2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExtendedDynamicState2FeaturesEXT>;
+
+#if defined( VK_USE_PLATFORM_SCREEN_QNX )
+  //=== VK_QNX_screen_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ScreenSurfaceCreateInfoQNX>;
+#endif /*VK_USE_PLATFORM_SCREEN_QNX*/
+
+  //=== VK_EXT_color_write_enable ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceColorWriteEnableFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineColorWriteCreateInfoEXT>;
+
+  //=== VK_EXT_primitives_generated_query ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePrimitivesGeneratedQueryFeaturesEXT>;
+
+  //=== VK_KHR_ray_tracing_maintenance1 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRayTracingMaintenance1FeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::TraceRaysIndirectCommand2KHR>;
+
+  //=== VK_EXT_image_view_min_lod ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImageViewMinLodFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageViewMinLodCreateInfoEXT>;
+
+  //=== VK_EXT_multi_draw ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMultiDrawFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMultiDrawPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MultiDrawInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MultiDrawIndexedInfoEXT>;
+
+  //=== VK_EXT_image_2d_view_of_3d ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImage2DViewOf3DFeaturesEXT>;
+
+  //=== VK_EXT_shader_tile_image ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderTileImageFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderTileImagePropertiesEXT>;
+
+  //=== VK_EXT_opacity_micromap ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MicromapBuildInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MicromapUsageEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MicromapCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceOpacityMicromapFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceOpacityMicromapPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MicromapVersionInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyMicromapToMemoryInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyMemoryToMicromapInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyMicromapInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MicromapBuildSizesInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureTrianglesOpacityMicromapEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MicromapTriangleEXT>;
+
+#if defined( VK_ENABLE_BETA_EXTENSIONS )
+  //=== VK_NV_displacement_micromap ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDisplacementMicromapFeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDisplacementMicromapPropertiesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AccelerationStructureTrianglesDisplacementMicromapNV>;
+#endif /*VK_ENABLE_BETA_EXTENSIONS*/
+
+  //=== VK_HUAWEI_cluster_culling_shader ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceClusterCullingShaderFeaturesHUAWEI>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceClusterCullingShaderPropertiesHUAWEI>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI>;
+
+  //=== VK_EXT_border_color_swizzle ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceBorderColorSwizzleFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerBorderColorComponentMappingCreateInfoEXT>;
+
+  //=== VK_EXT_pageable_device_local_memory ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePageableDeviceLocalMemoryFeaturesEXT>;
+
+  //=== VK_ARM_shader_core_properties ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderCorePropertiesARM>;
+
+  //=== VK_KHR_shader_subgroup_rotate ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderSubgroupRotateFeaturesKHR>;
+
+  //=== VK_ARM_scheduling_controls ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceQueueShaderCoreControlCreateInfoARM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSchedulingControlsFeaturesARM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSchedulingControlsPropertiesARM>;
+
+  //=== VK_EXT_image_sliced_view_of_3d ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImageSlicedViewOf3DFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageViewSlicedCreateInfoEXT>;
+
+  //=== VK_VALVE_descriptor_set_host_mapping ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDescriptorSetHostMappingFeaturesVALVE>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSetBindingReferenceVALVE>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSetLayoutHostMappingInfoVALVE>;
+
+  //=== VK_EXT_depth_clamp_zero_one ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDepthClampZeroOneFeaturesEXT>;
+
+  //=== VK_EXT_non_seamless_cube_map ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceNonSeamlessCubeMapFeaturesEXT>;
+
+  //=== VK_ARM_render_pass_striped ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRenderPassStripedFeaturesARM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRenderPassStripedPropertiesARM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassStripeBeginInfoARM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassStripeInfoARM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassStripeSubmitInfoARM>;
+
+  //=== VK_QCOM_fragment_density_map_offset ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassFragmentDensityMapOffsetEndInfoQCOM>;
+
+  //=== VK_NV_copy_memory_indirect ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyMemoryIndirectCommandNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyMemoryToImageIndirectCommandNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCopyMemoryIndirectFeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCopyMemoryIndirectPropertiesNV>;
+
+  //=== VK_NV_memory_decompression ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DecompressMemoryRegionNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMemoryDecompressionFeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMemoryDecompressionPropertiesNV>;
+
+  //=== VK_NV_device_generated_commands_compute ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ComputePipelineIndirectBufferInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineIndirectDeviceAddressInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindPipelineIndirectCommandNV>;
+
+  //=== VK_NV_linear_color_attachment ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceLinearColorAttachmentFeaturesNV>;
+
+  //=== VK_KHR_shader_maximal_reconvergence ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderMaximalReconvergenceFeaturesKHR>;
+
+  //=== VK_EXT_image_compression_control_swapchain ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImageCompressionControlSwapchainFeaturesEXT>;
+
+  //=== VK_QCOM_image_processing ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageViewSampleWeightCreateInfoQCOM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImageProcessingFeaturesQCOM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImageProcessingPropertiesQCOM>;
+
+  //=== VK_EXT_nested_command_buffer ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceNestedCommandBufferFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceNestedCommandBufferPropertiesEXT>;
+
+  //=== VK_EXT_external_memory_acquire_unmodified ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalMemoryAcquireUnmodifiedEXT>;
+
+  //=== VK_EXT_extended_dynamic_state3 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExtendedDynamicState3FeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExtendedDynamicState3PropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ColorBlendEquationEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ColorBlendAdvancedEXT>;
+
+  //=== VK_EXT_subpass_merge_feedback ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSubpassMergeFeedbackFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassCreationControlEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassCreationFeedbackInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassCreationFeedbackCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassSubpassFeedbackInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassSubpassFeedbackCreateInfoEXT>;
+
+  //=== VK_LUNARG_direct_driver_loading ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DirectDriverLoadingInfoLUNARG>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DirectDriverLoadingListLUNARG>;
+
+  //=== VK_EXT_shader_module_identifier ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderModuleIdentifierFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderModuleIdentifierPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineShaderStageModuleIdentifierCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ShaderModuleIdentifierEXT>;
+
+  //=== VK_EXT_rasterization_order_attachment_access ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT>;
+
+  //=== VK_NV_optical_flow ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceOpticalFlowFeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceOpticalFlowPropertiesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::OpticalFlowImageFormatInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::OpticalFlowImageFormatPropertiesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::OpticalFlowSessionCreateInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::OpticalFlowSessionCreatePrivateDataInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::OpticalFlowExecuteInfoNV>;
+
+  //=== VK_EXT_legacy_dithering ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceLegacyDitheringFeaturesEXT>;
+
+  //=== VK_EXT_pipeline_protected_access ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePipelineProtectedAccessFeaturesEXT>;
+
+#if defined( VK_USE_PLATFORM_ANDROID_KHR )
+  //=== VK_ANDROID_external_format_resolve ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExternalFormatResolveFeaturesANDROID>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExternalFormatResolvePropertiesANDROID>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AndroidHardwareBufferFormatResolvePropertiesANDROID>;
+#endif /*VK_USE_PLATFORM_ANDROID_KHR*/
+
+  //=== VK_KHR_maintenance5 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMaintenance5FeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMaintenance5PropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderingAreaInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceImageSubresourceInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageSubresource2KHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubresourceLayout2KHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCreateFlags2CreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferUsageFlags2CreateInfoKHR>;
+
+  //=== VK_AMD_anti_lag ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceAntiLagFeaturesAMD>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AntiLagDataAMD>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AntiLagPresentationInfoAMD>;
+
+  //=== VK_KHR_ray_tracing_position_fetch ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRayTracingPositionFetchFeaturesKHR>;
+
+  //=== VK_EXT_shader_object ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderObjectFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderObjectPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ShaderCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VertexInputBindingDescription2EXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VertexInputAttributeDescription2EXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ColorBlendEquationEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ColorBlendAdvancedEXT>;
+
+  //=== VK_KHR_pipeline_binary ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePipelineBinaryFeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePipelineBinaryPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DevicePipelineBinaryInternalCacheControlKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineBinaryKeyKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineBinaryDataKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineBinaryKeysAndDataKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineBinaryCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineBinaryInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ReleaseCapturedPipelineDataInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineBinaryDataInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineBinaryHandlesInfoKHR>;
+
+  //=== VK_QCOM_tile_properties ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceTilePropertiesFeaturesQCOM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::TilePropertiesQCOM>;
+
+  //=== VK_SEC_amigo_profiling ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceAmigoProfilingFeaturesSEC>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AmigoProfilingSubmitInfoSEC>;
+
+  //=== VK_QCOM_multiview_per_view_viewports ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM>;
+
+  //=== VK_NV_ray_tracing_invocation_reorder ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRayTracingInvocationReorderPropertiesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRayTracingInvocationReorderFeaturesNV>;
+
+  //=== VK_NV_extended_sparse_address_space ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExtendedSparseAddressSpaceFeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExtendedSparseAddressSpacePropertiesNV>;
+
+  //=== VK_EXT_mutable_descriptor_type ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMutableDescriptorTypeFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MutableDescriptorTypeListEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MutableDescriptorTypeCreateInfoEXT>;
+
+  //=== VK_EXT_legacy_vertex_attributes ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceLegacyVertexAttributesFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceLegacyVertexAttributesPropertiesEXT>;
+
+  //=== VK_EXT_layer_settings ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::LayerSettingsCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::LayerSettingEXT>;
+
+  //=== VK_ARM_shader_core_builtins ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderCoreBuiltinsFeaturesARM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderCoreBuiltinsPropertiesARM>;
+
+  //=== VK_EXT_pipeline_library_group_handles ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT>;
+
+  //=== VK_EXT_dynamic_rendering_unused_attachments ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT>;
+
+  //=== VK_NV_low_latency2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::LatencySleepModeInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::LatencySleepInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SetLatencyMarkerInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::GetLatencyMarkerInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::LatencyTimingsFrameReportNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::LatencySubmissionPresentIdNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SwapchainLatencyCreateInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::OutOfBandQueueTypeInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::LatencySurfaceCapabilitiesNV>;
+
+  //=== VK_KHR_cooperative_matrix ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CooperativeMatrixPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCooperativeMatrixFeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCooperativeMatrixPropertiesKHR>;
+
+  //=== VK_QCOM_multiview_per_view_render_areas ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MultiviewPerViewRenderAreasRenderPassBeginInfoQCOM>;
+
+  //=== VK_KHR_compute_shader_derivatives ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceComputeShaderDerivativesFeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceComputeShaderDerivativesPropertiesKHR>;
+
+  //=== VK_KHR_video_decode_av1 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeAV1ProfileInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeAV1CapabilitiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeAV1SessionParametersCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeAV1PictureInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoDecodeAV1DpbSlotInfoKHR>;
+
+  //=== VK_KHR_video_maintenance1 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVideoMaintenance1FeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VideoInlineQueryInfoKHR>;
+
+  //=== VK_NV_per_stage_descriptor_set ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePerStageDescriptorSetFeaturesNV>;
+
+  //=== VK_QCOM_image_processing2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImageProcessing2FeaturesQCOM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImageProcessing2PropertiesQCOM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerBlockMatchWindowCreateInfoQCOM>;
+
+  //=== VK_QCOM_filter_cubic_weights ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCubicWeightsFeaturesQCOM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerCubicWeightsCreateInfoQCOM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BlitImageCubicWeightsInfoQCOM>;
+
+  //=== VK_QCOM_ycbcr_degamma ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceYcbcrDegammaFeaturesQCOM>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerYcbcrConversionYcbcrDegammaCreateInfoQCOM>;
+
+  //=== VK_QCOM_filter_cubic_clamp ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCubicClampFeaturesQCOM>;
+
+  //=== VK_EXT_attachment_feedback_loop_dynamic_state ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT>;
+
+  //=== VK_KHR_vertex_attribute_divisor ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVertexAttributeDivisorPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VertexInputBindingDivisorDescriptionKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineVertexInputDivisorStateCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVertexAttributeDivisorFeaturesKHR>;
+
+  //=== VK_KHR_shader_float_controls2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderFloatControls2FeaturesKHR>;
+
+#if defined( VK_USE_PLATFORM_SCREEN_QNX )
+  //=== VK_QNX_external_memory_screen_buffer ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ScreenBufferPropertiesQNX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ScreenBufferFormatPropertiesQNX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportScreenBufferInfoQNX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalFormatQNX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExternalMemoryScreenBufferFeaturesQNX>;
+#endif /*VK_USE_PLATFORM_SCREEN_QNX*/
+
+  //=== VK_MSFT_layered_driver ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceLayeredDriverPropertiesMSFT>;
+
+  //=== VK_KHR_index_type_uint8 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceIndexTypeUint8FeaturesKHR>;
+
+  //=== VK_KHR_line_rasterization ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceLineRasterizationFeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceLineRasterizationPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineRasterizationLineStateCreateInfoKHR>;
+
+  //=== VK_KHR_calibrated_timestamps ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CalibratedTimestampInfoKHR>;
+
+  //=== VK_KHR_shader_expect_assume ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderExpectAssumeFeaturesKHR>;
+
+  //=== VK_KHR_maintenance6 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMaintenance6FeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMaintenance6PropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindMemoryStatusKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindDescriptorSetsInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PushConstantsInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PushDescriptorSetInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PushDescriptorSetWithTemplateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SetDescriptorBufferOffsetsInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindDescriptorBufferEmbeddedSamplersInfoEXT>;
+
+  //=== VK_NV_descriptor_pool_overallocation ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDescriptorPoolOverallocationFeaturesNV>;
+
+  //=== VK_NV_raw_access_chains ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRawAccessChainsFeaturesNV>;
+
+  //=== VK_KHR_shader_relaxed_extended_instruction ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR>;
+
+  //=== VK_NV_command_buffer_inheritance ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCommandBufferInheritanceFeaturesNV>;
+
+  //=== VK_KHR_maintenance7 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMaintenance7FeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMaintenance7PropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceLayeredApiPropertiesListKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceLayeredApiPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceLayeredApiVulkanPropertiesKHR>;
+
+  //=== VK_NV_shader_atomic_float16_vector ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderAtomicFloat16VectorFeaturesNV>;
+
+  //=== VK_EXT_shader_replicated_composites ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderReplicatedCompositesFeaturesEXT>;
+
+  //=== VK_NV_ray_tracing_validation ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRayTracingValidationFeaturesNV>;
+
+  //=== VK_EXT_device_generated_commands ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDeviceGeneratedCommandsFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDeviceGeneratedCommandsPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::GeneratedCommandsMemoryRequirementsInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IndirectExecutionSetCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IndirectExecutionSetInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IndirectExecutionSetPipelineInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IndirectExecutionSetShaderInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::GeneratedCommandsInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::WriteIndirectExecutionSetPipelineEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IndirectCommandsLayoutCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IndirectCommandsLayoutTokenEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DrawIndirectCountIndirectCommandEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IndirectCommandsVertexBufferTokenEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindVertexBufferIndirectCommandEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IndirectCommandsIndexBufferTokenEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindIndexBufferIndirectCommandEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IndirectCommandsPushConstantTokenEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IndirectCommandsExecutionSetTokenEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IndirectCommandsTokenDataEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::IndirectExecutionSetShaderLayoutInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::GeneratedCommandsPipelineInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::GeneratedCommandsShaderInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::WriteIndirectExecutionSetShaderEXT>;
+
+  //=== VK_MESA_image_alignment_control ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImageAlignmentControlFeaturesMESA>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImageAlignmentControlPropertiesMESA>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageAlignmentControlCreateInfoMESA>;
+
+  //=== VK_EXT_depth_clamp_control ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDepthClampControlFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineViewportDepthClampControlCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DepthClampRangeEXT>;
+
+  //=== VK_HUAWEI_hdr_vivid ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceHdrVividFeaturesHUAWEI>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::HdrVividDynamicMetadataHUAWEI>;
+
+  //=== VK_NV_cooperative_matrix2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CooperativeMatrixFlexibleDimensionsPropertiesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCooperativeMatrix2FeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCooperativeMatrix2PropertiesNV>;
+
+}  // namespace std

--- a/vulkan/vulkansc.cppm
+++ b/vulkan/vulkansc.cppm
@@ -12,7 +12,7 @@ module;
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
-#if defined( __cpp_lib_modules )
+#if defined( __cpp_lib_modules ) && !defined( VULKAN_HPP_ENABLE_STD_MODULE )
 #  define VULKAN_HPP_ENABLE_STD_MODULE
 #endif
 
@@ -1929,3 +1929,1119 @@ export namespace VULKAN_HPP_NAMESPACE
   }  // namespace VULKAN_HPP_RAII_NAMESPACE
 #endif
 }  // namespace VULKAN_HPP_NAMESPACE
+
+export namespace std
+{
+
+  //=======================================
+  //=== HASH specialization for Flags types ===
+  //=======================================
+
+  template <typename BitType>
+  struct hash<VULKAN_HPP_NAMESPACE::Flags<BitType>>;
+
+  //========================================
+  //=== HASH specializations for handles ===
+  //========================================
+
+  //=== VK_VERSION_1_0 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Instance>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevice>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Device>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Queue>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceMemory>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Fence>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Semaphore>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Event>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueryPool>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Buffer>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferView>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Image>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageView>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ShaderModule>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCache>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Pipeline>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineLayout>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Sampler>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorPool>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSet>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSetLayout>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Framebuffer>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPass>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandPool>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandBuffer>;
+
+  //=== VK_VERSION_1_1 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerYcbcrConversion>;
+
+  //=== VK_VERSION_1_3 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PrivateDataSlot>;
+
+  //=== VK_KHR_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfaceKHR>;
+
+  //=== VK_KHR_swapchain ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SwapchainKHR>;
+
+  //=== VK_KHR_display ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayModeKHR>;
+
+  //=== VK_EXT_debug_utils ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DebugUtilsMessengerEXT>;
+
+#if defined( VK_USE_PLATFORM_SCI )
+  //=== VK_NV_external_sci_sync2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SemaphoreSciSyncPoolNV>;
+#endif /*VK_USE_PLATFORM_SCI*/
+
+  //========================================
+  //=== HASH specializations for structs ===
+  //========================================
+
+  //=== VK_VERSION_1_0 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Extent2D>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Extent3D>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Offset2D>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Offset3D>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Rect2D>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BaseInStructure>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BaseOutStructure>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferMemoryBarrier>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DispatchIndirectCommand>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DrawIndexedIndirectCommand>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DrawIndirectCommand>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageMemoryBarrier>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryBarrier>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCacheHeaderVersionOne>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AllocationCallbacks>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ApplicationInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FormatProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageFormatProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::InstanceCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryHeap>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryType>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceLimits>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMemoryProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSparseProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueueFamilyProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceQueueCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExtensionProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::LayerProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubmitInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MappedMemoryRange>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryAllocateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryRequirements>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageSubresource>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FenceCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SemaphoreCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::EventCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueryPoolCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferViewCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubresourceLayout>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ComponentMapping>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageSubresourceRange>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageViewCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCacheCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ComputePipelineCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::GraphicsPipelineCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineColorBlendAttachmentState>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineColorBlendStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineDepthStencilStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineDynamicStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineInputAssemblyStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineMultisampleStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineRasterizationStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineShaderStageCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineTessellationStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineVertexInputStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineViewportStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SpecializationInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SpecializationMapEntry>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::StencilOpState>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VertexInputAttributeDescription>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VertexInputBindingDescription>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::Viewport>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineLayoutCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PushConstantRange>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyDescriptorSet>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorBufferInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorImageInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorPoolCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorPoolSize>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSetAllocateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSetLayoutBinding>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSetLayoutCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::WriteDescriptorSet>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AttachmentDescription>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AttachmentReference>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FramebufferCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassDependency>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassDescription>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandPoolCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandBufferAllocateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandBufferBeginInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandBufferInheritanceInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferCopy>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferImageCopy>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ClearAttachment>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ClearColorValue>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ClearDepthStencilValue>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ClearRect>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ClearValue>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageBlit>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageCopy>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageResolve>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageSubresourceLayers>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassBeginInfo>;
+
+  //=== VK_VERSION_1_1 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSubgroupProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindBufferMemoryInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindImageMemoryInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevice16BitStorageFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryDedicatedRequirements>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryDedicatedAllocateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryAllocateFlagsInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceGroupRenderPassBeginInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceGroupCommandBufferBeginInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceGroupSubmitInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindBufferMemoryDeviceGroupInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindImageMemoryDeviceGroupInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceGroupProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceGroupDeviceCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferMemoryRequirementsInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageMemoryRequirementsInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryRequirements2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFeatures2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceProperties2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FormatProperties2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageFormatProperties2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImageFormatInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueueFamilyProperties2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMemoryProperties2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePointClippingProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassInputAttachmentAspectCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::InputAttachmentAspectReference>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageViewUsageCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineTessellationDomainOriginStateCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassMultiviewCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMultiviewFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMultiviewProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVariablePointersFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceProtectedMemoryFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceProtectedMemoryProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceQueueInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ProtectedSubmitInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerYcbcrConversionCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerYcbcrConversionInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindImagePlaneMemoryInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImagePlaneMemoryRequirementsInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSamplerYcbcrConversionFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerYcbcrConversionImageFormatProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalMemoryProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExternalImageFormatInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalImageFormatProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExternalBufferInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalBufferProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceIDProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalMemoryImageCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalMemoryBufferCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportMemoryAllocateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExternalFenceInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalFenceProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportFenceCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportSemaphoreCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExternalSemaphoreInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalSemaphoreProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMaintenance3Properties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSetLayoutSupport>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderDrawParametersFeatures>;
+
+  //=== VK_VERSION_1_2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVulkan11Features>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVulkan11Properties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVulkan12Features>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVulkan12Properties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageFormatListCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassCreateInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AttachmentDescription2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AttachmentReference2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassDescription2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassDependency2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassBeginInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassEndInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevice8BitStorageFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ConformanceVersion>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDriverProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderAtomicInt64Features>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderFloat16Int8Features>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFloatControlsProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSetLayoutBindingFlagsCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDescriptorIndexingFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDescriptorIndexingProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSetVariableDescriptorCountAllocateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorSetVariableDescriptorCountLayoutSupport>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassDescriptionDepthStencilResolve>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDepthStencilResolveProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceScalarBlockLayoutFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageStencilUsageCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerReductionModeCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSamplerFilterMinmaxProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVulkanMemoryModelFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImagelessFramebufferFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FramebufferAttachmentsCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FramebufferAttachmentImageInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassAttachmentBeginInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceUniformBufferStandardLayoutFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderSubgroupExtendedTypesFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSeparateDepthStencilLayoutsFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AttachmentReferenceStencilLayout>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AttachmentDescriptionStencilLayout>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceHostQueryResetFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceTimelineSemaphoreFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceTimelineSemaphoreProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SemaphoreTypeCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::TimelineSemaphoreSubmitInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SemaphoreWaitInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SemaphoreSignalInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceBufferDeviceAddressFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferDeviceAddressInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferOpaqueCaptureAddressCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryOpaqueCaptureAddressAllocateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceMemoryOpaqueCaptureAddressInfo>;
+
+  //=== VK_VERSION_1_3 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVulkan13Features>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVulkan13Properties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCreationFeedbackCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCreationFeedback>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderTerminateInvocationFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceToolProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderDemoteToHelperInvocationFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePrivateDataFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DevicePrivateDataCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PrivateDataSlotCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePipelineCreationCacheControlFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryBarrier2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferMemoryBarrier2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageMemoryBarrier2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DependencyInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubmitInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SemaphoreSubmitInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandBufferSubmitInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSynchronization2Features>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceZeroInitializeWorkgroupMemoryFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImageRobustnessFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyBufferInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyImageInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyBufferToImageInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CopyImageToBufferInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BlitImageInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ResolveImageInfo2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferCopy2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageCopy2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageBlit2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BufferImageCopy2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageResolve2>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSubgroupSizeControlFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSubgroupSizeControlProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineShaderStageRequiredSubgroupSizeCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceInlineUniformBlockFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceInlineUniformBlockProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::WriteDescriptorSetInlineUniformBlock>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DescriptorPoolInlineUniformBlockCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceTextureCompressionASTCHDRFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderingInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderingAttachmentInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineRenderingCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDynamicRenderingFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandBufferInheritanceRenderingInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderIntegerDotProductFeatures>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderIntegerDotProductProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceTexelBufferAlignmentProperties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FormatProperties3>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMaintenance4Features>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMaintenance4Properties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceBufferMemoryRequirements>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceImageMemoryRequirements>;
+
+  //=== VKSC_VERSION_1_0 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVulkanSC10Features>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVulkanSC10Properties>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceObjectReservationCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandPoolMemoryReservationCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CommandPoolMemoryConsumption>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelinePoolSize>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FaultData>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FaultCallbackInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineOfflineCreateInfo>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCacheStageValidationIndexEntry>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCacheSafetyCriticalIndexEntry>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineCacheHeaderVersionSafetyCriticalOne>;
+
+  //=== VK_KHR_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfaceCapabilitiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfaceFormatKHR>;
+
+  //=== VK_KHR_swapchain ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SwapchainCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PresentInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageSwapchainCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::BindImageMemorySwapchainInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AcquireNextImageInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceGroupPresentCapabilitiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceGroupPresentInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceGroupSwapchainCreateInfoKHR>;
+
+  //=== VK_KHR_display ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayModeCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayModeParametersKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayModePropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayPlaneCapabilitiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayPlanePropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplaySurfaceCreateInfoKHR>;
+
+  //=== VK_KHR_display_swapchain ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayPresentInfoKHR>;
+
+  //=== VK_EXT_astc_decode_mode ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageViewASTCDecodeModeEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceASTCDecodeFeaturesEXT>;
+
+  //=== VK_KHR_external_memory_fd ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportMemoryFdInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryFdPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryGetFdInfoKHR>;
+
+  //=== VK_KHR_external_semaphore_fd ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportSemaphoreFdInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SemaphoreGetFdInfoKHR>;
+
+  //=== VK_KHR_incremental_present ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PresentRegionsKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PresentRegionKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RectLayerKHR>;
+
+  //=== VK_EXT_display_surface_counter ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfaceCapabilities2EXT>;
+
+  //=== VK_EXT_display_control ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayPowerInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceEventInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayEventInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SwapchainCounterCreateInfoEXT>;
+
+  //=== VK_EXT_discard_rectangles ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDiscardRectanglePropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineDiscardRectangleStateCreateInfoEXT>;
+
+  //=== VK_EXT_conservative_rasterization ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceConservativeRasterizationPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineRasterizationConservativeStateCreateInfoEXT>;
+
+  //=== VK_EXT_depth_clip_enable ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceDepthClipEnableFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineRasterizationDepthClipStateCreateInfoEXT>;
+
+  //=== VK_EXT_hdr_metadata ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::HdrMetadataEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::XYColorEXT>;
+
+  //=== VK_KHR_shared_presentable_image ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SharedPresentSurfaceCapabilitiesKHR>;
+
+  //=== VK_KHR_external_fence_fd ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportFenceFdInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FenceGetFdInfoKHR>;
+
+  //=== VK_KHR_performance_query ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePerformanceQueryFeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePerformanceQueryPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PerformanceCounterKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PerformanceCounterDescriptionKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueryPoolPerformanceCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PerformanceCounterResultKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AcquireProfilingLockInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PerformanceQuerySubmitInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PerformanceQueryReservationInfoKHR>;
+
+  //=== VK_KHR_get_surface_capabilities2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSurfaceInfo2KHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfaceCapabilities2KHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SurfaceFormat2KHR>;
+
+  //=== VK_KHR_get_display_properties2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayProperties2KHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayPlaneProperties2KHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayModeProperties2KHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayPlaneInfo2KHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DisplayPlaneCapabilities2KHR>;
+
+  //=== VK_EXT_debug_utils ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DebugUtilsLabelEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DebugUtilsMessengerCallbackDataEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DebugUtilsMessengerCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DebugUtilsObjectNameInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DebugUtilsObjectTagInfoEXT>;
+
+  //=== VK_EXT_sample_locations ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SampleLocationEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SampleLocationsInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::AttachmentSampleLocationsEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SubpassSampleLocationsEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderPassSampleLocationsBeginInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineSampleLocationsStateCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceSampleLocationsPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MultisamplePropertiesEXT>;
+
+  //=== VK_EXT_blend_operation_advanced ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceBlendOperationAdvancedFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceBlendOperationAdvancedPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineColorBlendAdvancedStateCreateInfoEXT>;
+
+  //=== VK_EXT_image_drm_format_modifier ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DrmFormatModifierPropertiesListEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DrmFormatModifierPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImageDrmFormatModifierInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageDrmFormatModifierListCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageDrmFormatModifierExplicitCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImageDrmFormatModifierPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DrmFormatModifierPropertiesList2EXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DrmFormatModifierProperties2EXT>;
+
+  //=== VK_EXT_filter_cubic ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceImageViewImageFormatInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FilterCubicImageViewImageFormatPropertiesEXT>;
+
+  //=== VK_EXT_external_memory_host ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportMemoryHostPointerInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryHostPointerPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExternalMemoryHostPropertiesEXT>;
+
+  //=== VK_KHR_shader_clock ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderClockFeaturesKHR>;
+
+  //=== VK_KHR_global_priority ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceQueueGlobalPriorityCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceGlobalPriorityQueryFeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::QueueFamilyGlobalPriorityPropertiesKHR>;
+
+  //=== VK_EXT_pci_bus_info ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevicePCIBusInfoPropertiesEXT>;
+
+  //=== VK_KHR_fragment_shading_rate ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FragmentShadingRateAttachmentInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineFragmentShadingRateStateCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFragmentShadingRateFeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFragmentShadingRatePropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFragmentShadingRateKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RenderingFragmentShadingRateAttachmentInfoKHR>;
+
+  //=== VK_EXT_shader_image_atomic_int64 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderImageAtomicInt64FeaturesEXT>;
+
+  //=== VK_EXT_memory_budget ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceMemoryBudgetPropertiesEXT>;
+
+  //=== VK_EXT_validation_features ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ValidationFeaturesEXT>;
+
+  //=== VK_EXT_fragment_shader_interlock ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceFragmentShaderInterlockFeaturesEXT>;
+
+  //=== VK_EXT_ycbcr_image_arrays ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceYcbcrImageArraysFeaturesEXT>;
+
+  //=== VK_EXT_headless_surface ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::HeadlessSurfaceCreateInfoEXT>;
+
+  //=== VK_EXT_shader_atomic_float ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceShaderAtomicFloatFeaturesEXT>;
+
+  //=== VK_EXT_extended_dynamic_state ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExtendedDynamicStateFeaturesEXT>;
+
+  //=== VK_EXT_texel_buffer_alignment ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceTexelBufferAlignmentFeaturesEXT>;
+
+  //=== VK_EXT_robustness2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRobustness2FeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceRobustness2PropertiesEXT>;
+
+  //=== VK_EXT_custom_border_color ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SamplerCustomBorderColorCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCustomBorderColorPropertiesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceCustomBorderColorFeaturesEXT>;
+
+  //=== VK_KHR_object_refresh ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RefreshObjectListKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::RefreshObjectKHR>;
+
+  //=== VK_EXT_ycbcr_2plane_444_formats ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT>;
+
+  //=== VK_EXT_4444_formats ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDevice4444FormatsFeaturesEXT>;
+
+  //=== VK_EXT_vertex_input_dynamic_state ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVertexInputDynamicStateFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VertexInputBindingDescription2EXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VertexInputAttributeDescription2EXT>;
+
+#if defined( VK_USE_PLATFORM_SCI )
+  //=== VK_NV_external_sci_sync ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportFenceSciSyncInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportFenceSciSyncInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FenceGetSciSyncInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SciSyncAttributesInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportSemaphoreSciSyncInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportSemaphoreSciSyncInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SemaphoreGetSciSyncInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExternalSciSyncFeaturesNV>;
+#endif /*VK_USE_PLATFORM_SCI*/
+
+#if defined( VK_USE_PLATFORM_SCI )
+  //=== VK_NV_external_memory_sci_buf ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportMemorySciBufInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportMemorySciBufInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemoryGetSciBufInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::MemorySciBufPropertiesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExternalMemorySciBufFeaturesNV>;
+#endif /*VK_USE_PLATFORM_SCI*/
+
+  //=== VK_EXT_extended_dynamic_state2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExtendedDynamicState2FeaturesEXT>;
+
+  //=== VK_EXT_color_write_enable ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceColorWriteEnableFeaturesEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineColorWriteCreateInfoEXT>;
+
+  //=== VK_EXT_application_parameters ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ApplicationParametersEXT>;
+
+#if defined( VK_USE_PLATFORM_SCI )
+  //=== VK_NV_external_sci_sync2 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExternalSciSync2FeaturesNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SemaphoreSciSyncPoolCreateInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SemaphoreSciSyncCreateInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExportFenceSciSyncInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportFenceSciSyncInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::FenceGetSciSyncInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::SciSyncAttributesInfoNV>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::DeviceSemaphoreSciSyncPoolReservationCreateInfoNV>;
+#endif /*VK_USE_PLATFORM_SCI*/
+
+  //=== VK_EXT_layer_settings ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::LayerSettingsCreateInfoEXT>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::LayerSettingEXT>;
+
+  //=== VK_KHR_vertex_attribute_divisor ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVertexAttributeDivisorPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::VertexInputBindingDivisorDescriptionKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineVertexInputDivisorStateCreateInfoKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVertexAttributeDivisorFeaturesKHR>;
+
+#if defined( VK_USE_PLATFORM_SCREEN_QNX )
+  //=== VK_QNX_external_memory_screen_buffer ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ScreenBufferPropertiesQNX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ScreenBufferFormatPropertiesQNX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ImportScreenBufferInfoQNX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::ExternalFormatQNX>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceExternalMemoryScreenBufferFeaturesQNX>;
+#endif /*VK_USE_PLATFORM_SCREEN_QNX*/
+
+  //=== VK_KHR_index_type_uint8 ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceIndexTypeUint8FeaturesKHR>;
+
+  //=== VK_KHR_line_rasterization ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceLineRasterizationFeaturesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceLineRasterizationPropertiesKHR>;
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::PipelineRasterizationLineStateCreateInfoKHR>;
+
+  //=== VK_KHR_calibrated_timestamps ===
+  template <>
+  struct hash<VULKAN_HPP_NAMESPACE::CalibratedTimestampInfoKHR>;
+
+}  // namespace std

--- a/vulkan/vulkansc_extension_inspection.hpp
+++ b/vulkan/vulkansc_extension_inspection.hpp
@@ -24,7 +24,7 @@ namespace VULKAN_HPP_NAMESPACE
   //=== Extension inspection functions ===
   //======================================
 
-  VULKAN_HPP_CONSTEXPR_20 std::set<std::string> const &                getDeviceExtensions();
+  std::set<std::string> const &                                        getDeviceExtensions();
   std::set<std::string> const &                                        getInstanceExtensions();
   std::map<std::string, std::string> const &                           getDeprecatedExtensions();
   std::map<std::string, std::vector<std::vector<std::string>>> const & getExtensionDepends( std::string const & extension );
@@ -44,9 +44,9 @@ namespace VULKAN_HPP_NAMESPACE
   //=== Extension inspection function implementations ===
   //=====================================================
 
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_20std::map<std::string, std::string> const & getDeprecatedExtensions()
+  VULKAN_HPP_INLINE std::map<std::string, std::string> const & getDeprecatedExtensions()
   {
-    static std::map<std::string, std::string> deprecatedExtensions = {
+    static const std::map<std::string, std::string> deprecatedExtensions = {
       { "VK_EXT_validation_features", "VK_EXT_layer_settings" },
 #if defined( VK_USE_PLATFORM_SCI )
       { "VK_NV_external_sci_sync", "VK_NV_external_sci_sync2" }
@@ -55,7 +55,7 @@ namespace VULKAN_HPP_NAMESPACE
     return deprecatedExtensions;
   }
 
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_20 std::set<std::string> const & getDeviceExtensions()
+  VULKAN_HPP_INLINE std::set<std::string> const & getDeviceExtensions()
   {
     static const std::set<std::string> deviceExtensions = {
       "VK_KHR_swapchain",
@@ -135,25 +135,25 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::set<std::string> const & getInstanceExtensions()
   {
-    static std::set<std::string> instanceExtensions = { "VK_KHR_surface",
-                                                        "VK_KHR_display",
-                                                        "VK_EXT_direct_mode_display",
-                                                        "VK_EXT_display_surface_counter",
-                                                        "VK_EXT_swapchain_colorspace",
-                                                        "VK_KHR_get_surface_capabilities2",
-                                                        "VK_KHR_get_display_properties2",
-                                                        "VK_EXT_debug_utils",
-                                                        "VK_EXT_validation_features",
-                                                        "VK_EXT_headless_surface",
-                                                        "VK_EXT_application_parameters",
-                                                        "VK_EXT_layer_settings" };
+    static const std::set<std::string> instanceExtensions = { "VK_KHR_surface",
+                                                              "VK_KHR_display",
+                                                              "VK_EXT_direct_mode_display",
+                                                              "VK_EXT_display_surface_counter",
+                                                              "VK_EXT_swapchain_colorspace",
+                                                              "VK_KHR_get_surface_capabilities2",
+                                                              "VK_KHR_get_display_properties2",
+                                                              "VK_EXT_debug_utils",
+                                                              "VK_EXT_validation_features",
+                                                              "VK_EXT_headless_surface",
+                                                              "VK_EXT_application_parameters",
+                                                              "VK_EXT_layer_settings" };
     return instanceExtensions;
   }
 
   VULKAN_HPP_INLINE std::map<std::string, std::vector<std::vector<std::string>>> const & getExtensionDepends( std::string const & extension )
   {
-    static std::map<std::string, std::vector<std::vector<std::string>>>                        noDependencies;
-    static std::map<std::string, std::map<std::string, std::vector<std::vector<std::string>>>> dependencies = {
+    static const std::map<std::string, std::vector<std::vector<std::string>>>                        noDependencies;
+    static const std::map<std::string, std::map<std::string, std::vector<std::vector<std::string>>>> dependencies = {
       { "VK_KHR_swapchain",
         { { "VK_VERSION_1_0",
             { {
@@ -552,26 +552,26 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::map<std::string, std::string> const & getObsoletedExtensions()
   {
-    static std::map<std::string, std::string> obsoletedExtensions = {};
+    static const std::map<std::string, std::string> obsoletedExtensions = {};
     return obsoletedExtensions;
   }
 
   VULKAN_HPP_INLINE std::map<std::string, std::string> const & getPromotedExtensions()
   {
-    static std::map<std::string, std::string> promotedExtensions = { { "VK_EXT_texture_compression_astc_hdr", "VK_VERSION_1_3" },
-                                                                     { "VK_KHR_shader_terminate_invocation", "VK_VERSION_1_3" },
-                                                                     { "VK_EXT_subgroup_size_control", "VK_VERSION_1_3" },
-                                                                     { "VK_EXT_line_rasterization", "VK_KHR_line_rasterization" },
-                                                                     { "VK_EXT_index_type_uint8", "VK_KHR_index_type_uint8" },
-                                                                     { "VK_EXT_extended_dynamic_state", "VK_VERSION_1_3" },
-                                                                     { "VK_EXT_shader_demote_to_helper_invocation", "VK_VERSION_1_3" },
-                                                                     { "VK_EXT_texel_buffer_alignment", "VK_VERSION_1_3" },
-                                                                     { "VK_KHR_synchronization2", "VK_VERSION_1_3" },
-                                                                     { "VK_EXT_ycbcr_2plane_444_formats", "VK_VERSION_1_3" },
-                                                                     { "VK_EXT_image_robustness", "VK_VERSION_1_3" },
-                                                                     { "VK_KHR_copy_commands2", "VK_VERSION_1_3" },
-                                                                     { "VK_EXT_4444_formats", "VK_VERSION_1_3" },
-                                                                     { "VK_EXT_extended_dynamic_state2", "VK_VERSION_1_3" } };
+    static const std::map<std::string, std::string> promotedExtensions = { { "VK_EXT_texture_compression_astc_hdr", "VK_VERSION_1_3" },
+                                                                           { "VK_KHR_shader_terminate_invocation", "VK_VERSION_1_3" },
+                                                                           { "VK_EXT_subgroup_size_control", "VK_VERSION_1_3" },
+                                                                           { "VK_EXT_line_rasterization", "VK_KHR_line_rasterization" },
+                                                                           { "VK_EXT_index_type_uint8", "VK_KHR_index_type_uint8" },
+                                                                           { "VK_EXT_extended_dynamic_state", "VK_VERSION_1_3" },
+                                                                           { "VK_EXT_shader_demote_to_helper_invocation", "VK_VERSION_1_3" },
+                                                                           { "VK_EXT_texel_buffer_alignment", "VK_VERSION_1_3" },
+                                                                           { "VK_KHR_synchronization2", "VK_VERSION_1_3" },
+                                                                           { "VK_EXT_ycbcr_2plane_444_formats", "VK_VERSION_1_3" },
+                                                                           { "VK_EXT_image_robustness", "VK_VERSION_1_3" },
+                                                                           { "VK_KHR_copy_commands2", "VK_VERSION_1_3" },
+                                                                           { "VK_EXT_4444_formats", "VK_VERSION_1_3" },
+                                                                           { "VK_EXT_extended_dynamic_state2", "VK_VERSION_1_3" } };
     return promotedExtensions;
   }
 


### PR DESCRIPTION
Resolves #1943.