### PR TITLE
Add comparison operators for vk::raii handles, remove them for vk handles

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -233,31 +233,6 @@ ${handleForwardDeclarations}
 ${uniqueHandles}
 ${handles}
 }   // namespace VULKAN_HPP_NAMESPACE
-
-// operators to compare vk::-handles with nullptr
-template <typename T>
-typename std::enable_if<VULKAN_HPP_NAMESPACE::isVulkanHandleType<T>::value, bool>::type operator==( const T & v, std::nullptr_t )
-{
-  return !v;
-}
-
-template <typename T>
-typename std::enable_if<VULKAN_HPP_NAMESPACE::isVulkanHandleType<T>::value, bool>::type operator==( std::nullptr_t, const T & v )
-{
-  return !v;
-}
-
-template <typename T>
-typename std::enable_if<VULKAN_HPP_NAMESPACE::isVulkanHandleType<T>::value, bool>::type operator!=( const T & v, std::nullptr_t )
-{
-  return v;
-}
-
-template <typename T>
-typename std::enable_if<VULKAN_HPP_NAMESPACE::isVulkanHandleType<T>::value, bool>::type operator!=( std::nullptr_t, const T & v )
-{
-  return v;
-}
 #endif
 )";
 
@@ -8035,24 +8010,6 @@ ${typesafeConversionConditionalEnd}
       return *this;
     }
 
-#if defined(VULKAN_HPP_HAS_SPACESHIP_OPERATOR)
-    auto operator<=>( ${className} const & ) const = default;
-#else
-    bool operator==( ${className} const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_${memberName} == rhs.m_${memberName};
-    }
-
-    bool operator!=(${className} const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_${memberName} != rhs.m_${memberName};
-    }
-
-    bool operator<(${className} const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_${memberName} < rhs.m_${memberName};
-    }
-#endif
 ${commands}
     ${typesafeExplicitKeyword}operator Vk${className}() const VULKAN_HPP_NOEXCEPT
     {
@@ -8959,6 +8916,13 @@ ${memberFunctionsDeclarations}
   private:
     ${memberVariables}
   };
+
+  template <>
+  struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::${handleType}>
+  {
+    static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+  };
+
 ${leave})";
 
     str += replaceWithMap( handleTemplate,
@@ -10306,7 +10270,64 @@ ${forwardDeclarations}
   //=== RAII HANDLES ===
   //====================
 
+  template <typename Type>
+  struct isVulkanRAIIHandleType
+  {
+    static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = false;
+  };
+
 ${raiiHandles}
+
+  // operators to compare vk::raii-handles
+#if defined(VULKAN_HPP_HAS_SPACESHIP_OPERATOR)
+  template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value,bool>::type = 0>
+  auto operator<=>( T const & a, T const & b ) VULKAN_HPP_NOEXCEPT
+  {
+    return *a <=> *b;
+  }
+#else
+  template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value,bool>::type = 0>
+  bool operator==( T const & a, T const & b ) VULKAN_HPP_NOEXCEPT
+  {
+    return *a == *b;
+  }
+
+  template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value,bool>::type = 0>
+  bool operator!=(T const & a, T const & b ) VULKAN_HPP_NOEXCEPT
+  {
+    return *a != *b;
+  }
+
+  template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value,bool>::type = 0>
+  bool operator<(T const & a, T const & b ) VULKAN_HPP_NOEXCEPT
+  {
+    return *a < *b;
+  }
+#endif
+
+  template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value,bool>::type = 0>
+  bool operator==( const T & v, std::nullptr_t ) VULKAN_HPP_NOEXCEPT
+  {
+    return !*v;
+  }
+
+  template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value,bool>::type = 0>
+  bool operator==( std::nullptr_t, const T & v ) VULKAN_HPP_NOEXCEPT
+  {
+    return !*v;
+  }
+
+  template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value,bool>::type = 0>
+  bool operator!=( const T & v, std::nullptr_t ) VULKAN_HPP_NOEXCEPT
+  {
+    return *v;
+  }
+
+  template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value,bool>::type = 0>
+  bool operator!=( std::nullptr_t, const T & v ) VULKAN_HPP_NOEXCEPT
+  {
+    return *v;
+  }
 )";
 
   std::string forwardDeclarations;

--- a/tests/Handles/Handles.cpp
+++ b/tests/Handles/Handles.cpp
@@ -19,7 +19,7 @@
 #define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 0
 
 #include <iostream>
-#include <vulkan/vulkan.hpp>
+#include <vulkan/vulkan_raii.hpp>
 
 int main( int /*argc*/, char ** /*argv*/ )
 {
@@ -34,7 +34,83 @@ int main( int /*argc*/, char ** /*argv*/ )
     assert( instance != nullptr );
     assert( nullptr != instance );
 
+    vk::Instance instance2;
+    assert( instance != instance2 );
+    assert( !( instance == instance2 ) );
+
+    instance2 = vk::createInstance( {} );
+    assert( instance != instance2 );
+
+    if ( instance == instance2 )
+    {
+      std::cout << "hoho";
+    }
+    if (instance != instance2)
+    {
+      std::cout << "haha";
+    }
+    if (instance < instance2)
+    {
+      std::cout << "hihi";
+    }
+
+    VkInstance vki = 0;
+    if (vki == instance)
+    {
+      std::cout << "hoho";
+    }
+
+    vk::PhysicalDevice physicalDevice;
+    if (physicalDevice == instance )
+    {
+      std::cout << "hoho";
+    }
+
     instance.destroy();
+    instance2.destroy();
+
+    // test operator==() with vk::raii-handle and nullptr
+    vk::raii::Context context;
+
+    vk::raii::Instance i0 = context.createInstance( {} );
+    vk::raii::Instance i1 = context.createInstance( {} );
+
+    if ( i0 == i1 )
+    {
+      std::cout << "hahah";
+    }
+    if ( i0 != i1 )
+    {
+      std::cout << "hoho";
+    }
+    if ( i0 < i1 )
+    {
+      std::cout << "hihi";
+    }
+
+    if (i0 == nullptr)
+    {
+      std::cout << "kiki";
+    }
+    if (nullptr == i0)
+    {
+      std::cout << "kaka";
+    }
+    if (i0 != nullptr)
+    {
+      std::cout << "keke";
+    }
+    if (nullptr != i0)
+    {
+      std::cout << "kuku";
+    }
+
+    vk::raii::PhysicalDevices physicalDevices( i0 );
+    assert( physicalDevices.size() == 2 );
+    if ( physicalDevices[0] == physicalDevices[1] )
+    {
+      std::cout << "fufu";
+    }
   }
   catch ( vk::SystemError const & err )
   {

--- a/vulkan/vulkan_handles.hpp
+++ b/vulkan/vulkan_handles.hpp
@@ -2567,25 +2567,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( SurfaceKHR const & ) const = default;
-#else
-    bool operator==( SurfaceKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_surfaceKHR == rhs.m_surfaceKHR;
-    }
-
-    bool operator!=( SurfaceKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_surfaceKHR != rhs.m_surfaceKHR;
-    }
-
-    bool operator<( SurfaceKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_surfaceKHR < rhs.m_surfaceKHR;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkSurfaceKHR() const VULKAN_HPP_NOEXCEPT
     {
       return m_surfaceKHR;
@@ -2682,25 +2663,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_debugReportCallbackEXT = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( DebugReportCallbackEXT const & ) const = default;
-#else
-    bool operator==( DebugReportCallbackEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_debugReportCallbackEXT == rhs.m_debugReportCallbackEXT;
-    }
-
-    bool operator!=( DebugReportCallbackEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_debugReportCallbackEXT != rhs.m_debugReportCallbackEXT;
-    }
-
-    bool operator<( DebugReportCallbackEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_debugReportCallbackEXT < rhs.m_debugReportCallbackEXT;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkDebugReportCallbackEXT() const VULKAN_HPP_NOEXCEPT
     {
@@ -2799,25 +2761,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( DebugUtilsMessengerEXT const & ) const = default;
-#else
-    bool operator==( DebugUtilsMessengerEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_debugUtilsMessengerEXT == rhs.m_debugUtilsMessengerEXT;
-    }
-
-    bool operator!=( DebugUtilsMessengerEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_debugUtilsMessengerEXT != rhs.m_debugUtilsMessengerEXT;
-    }
-
-    bool operator<( DebugUtilsMessengerEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_debugUtilsMessengerEXT < rhs.m_debugUtilsMessengerEXT;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkDebugUtilsMessengerEXT() const VULKAN_HPP_NOEXCEPT
     {
       return m_debugUtilsMessengerEXT;
@@ -2902,25 +2845,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_displayKHR = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( DisplayKHR const & ) const = default;
-#else
-    bool operator==( DisplayKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_displayKHR == rhs.m_displayKHR;
-    }
-
-    bool operator!=( DisplayKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_displayKHR != rhs.m_displayKHR;
-    }
-
-    bool operator<( DisplayKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_displayKHR < rhs.m_displayKHR;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkDisplayKHR() const VULKAN_HPP_NOEXCEPT
     {
@@ -3013,25 +2937,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( SwapchainKHR const & ) const = default;
-#else
-    bool operator==( SwapchainKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_swapchainKHR == rhs.m_swapchainKHR;
-    }
-
-    bool operator!=( SwapchainKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_swapchainKHR != rhs.m_swapchainKHR;
-    }
-
-    bool operator<( SwapchainKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_swapchainKHR < rhs.m_swapchainKHR;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkSwapchainKHR() const VULKAN_HPP_NOEXCEPT
     {
       return m_swapchainKHR;
@@ -3123,25 +3028,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Semaphore const & ) const = default;
-#else
-    bool operator==( Semaphore const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_semaphore == rhs.m_semaphore;
-    }
-
-    bool operator!=( Semaphore const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_semaphore != rhs.m_semaphore;
-    }
-
-    bool operator<( Semaphore const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_semaphore < rhs.m_semaphore;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkSemaphore() const VULKAN_HPP_NOEXCEPT
     {
       return m_semaphore;
@@ -3232,25 +3118,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_fence = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Fence const & ) const = default;
-#else
-    bool operator==( Fence const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_fence == rhs.m_fence;
-    }
-
-    bool operator!=( Fence const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_fence != rhs.m_fence;
-    }
-
-    bool operator<( Fence const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_fence < rhs.m_fence;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkFence() const VULKAN_HPP_NOEXCEPT
     {
@@ -3349,25 +3216,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( PerformanceConfigurationINTEL const & ) const = default;
-#else
-    bool operator==( PerformanceConfigurationINTEL const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_performanceConfigurationINTEL == rhs.m_performanceConfigurationINTEL;
-    }
-
-    bool operator!=( PerformanceConfigurationINTEL const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_performanceConfigurationINTEL != rhs.m_performanceConfigurationINTEL;
-    }
-
-    bool operator<( PerformanceConfigurationINTEL const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_performanceConfigurationINTEL < rhs.m_performanceConfigurationINTEL;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkPerformanceConfigurationINTEL() const VULKAN_HPP_NOEXCEPT
     {
       return m_performanceConfigurationINTEL;
@@ -3452,25 +3300,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_queryPool = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( QueryPool const & ) const = default;
-#else
-    bool operator==( QueryPool const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_queryPool == rhs.m_queryPool;
-    }
-
-    bool operator!=( QueryPool const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_queryPool != rhs.m_queryPool;
-    }
-
-    bool operator<( QueryPool const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_queryPool < rhs.m_queryPool;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkQueryPool() const VULKAN_HPP_NOEXCEPT
     {
@@ -3563,25 +3392,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Buffer const & ) const = default;
-#else
-    bool operator==( Buffer const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_buffer == rhs.m_buffer;
-    }
-
-    bool operator!=( Buffer const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_buffer != rhs.m_buffer;
-    }
-
-    bool operator<( Buffer const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_buffer < rhs.m_buffer;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkBuffer() const VULKAN_HPP_NOEXCEPT
     {
       return m_buffer;
@@ -3672,25 +3482,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_pipelineLayout = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( PipelineLayout const & ) const = default;
-#else
-    bool operator==( PipelineLayout const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipelineLayout == rhs.m_pipelineLayout;
-    }
-
-    bool operator!=( PipelineLayout const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipelineLayout != rhs.m_pipelineLayout;
-    }
-
-    bool operator<( PipelineLayout const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipelineLayout < rhs.m_pipelineLayout;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkPipelineLayout() const VULKAN_HPP_NOEXCEPT
     {
@@ -3783,25 +3574,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( DescriptorSet const & ) const = default;
-#else
-    bool operator==( DescriptorSet const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorSet == rhs.m_descriptorSet;
-    }
-
-    bool operator!=( DescriptorSet const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorSet != rhs.m_descriptorSet;
-    }
-
-    bool operator<( DescriptorSet const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorSet < rhs.m_descriptorSet;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkDescriptorSet() const VULKAN_HPP_NOEXCEPT
     {
       return m_descriptorSet;
@@ -3892,25 +3664,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_imageView = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( ImageView const & ) const = default;
-#else
-    bool operator==( ImageView const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_imageView == rhs.m_imageView;
-    }
-
-    bool operator!=( ImageView const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_imageView != rhs.m_imageView;
-    }
-
-    bool operator<( ImageView const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_imageView < rhs.m_imageView;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkImageView() const VULKAN_HPP_NOEXCEPT
     {
@@ -4003,25 +3756,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Pipeline const & ) const = default;
-#else
-    bool operator==( Pipeline const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipeline == rhs.m_pipeline;
-    }
-
-    bool operator!=( Pipeline const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipeline != rhs.m_pipeline;
-    }
-
-    bool operator<( Pipeline const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipeline < rhs.m_pipeline;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkPipeline() const VULKAN_HPP_NOEXCEPT
     {
       return m_pipeline;
@@ -4113,25 +3847,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( ShaderEXT const & ) const = default;
-#else
-    bool operator==( ShaderEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_shaderEXT == rhs.m_shaderEXT;
-    }
-
-    bool operator!=( ShaderEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_shaderEXT != rhs.m_shaderEXT;
-    }
-
-    bool operator<( ShaderEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_shaderEXT < rhs.m_shaderEXT;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkShaderEXT() const VULKAN_HPP_NOEXCEPT
     {
       return m_shaderEXT;
@@ -4216,25 +3931,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_image = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Image const & ) const = default;
-#else
-    bool operator==( Image const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_image == rhs.m_image;
-    }
-
-    bool operator!=( Image const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_image != rhs.m_image;
-    }
-
-    bool operator<( Image const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_image < rhs.m_image;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkImage() const VULKAN_HPP_NOEXCEPT
     {
@@ -4333,25 +4029,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( AccelerationStructureNV const & ) const = default;
-#else
-    bool operator==( AccelerationStructureNV const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_accelerationStructureNV == rhs.m_accelerationStructureNV;
-    }
-
-    bool operator!=( AccelerationStructureNV const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_accelerationStructureNV != rhs.m_accelerationStructureNV;
-    }
-
-    bool operator<( AccelerationStructureNV const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_accelerationStructureNV < rhs.m_accelerationStructureNV;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkAccelerationStructureNV() const VULKAN_HPP_NOEXCEPT
     {
       return m_accelerationStructureNV;
@@ -4449,25 +4126,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( OpticalFlowSessionNV const & ) const = default;
-#else
-    bool operator==( OpticalFlowSessionNV const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_opticalFlowSessionNV == rhs.m_opticalFlowSessionNV;
-    }
-
-    bool operator!=( OpticalFlowSessionNV const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_opticalFlowSessionNV != rhs.m_opticalFlowSessionNV;
-    }
-
-    bool operator<( OpticalFlowSessionNV const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_opticalFlowSessionNV < rhs.m_opticalFlowSessionNV;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkOpticalFlowSessionNV() const VULKAN_HPP_NOEXCEPT
     {
       return m_opticalFlowSessionNV;
@@ -4558,25 +4216,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_descriptorUpdateTemplate = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( DescriptorUpdateTemplate const & ) const = default;
-#else
-    bool operator==( DescriptorUpdateTemplate const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorUpdateTemplate == rhs.m_descriptorUpdateTemplate;
-    }
-
-    bool operator!=( DescriptorUpdateTemplate const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorUpdateTemplate != rhs.m_descriptorUpdateTemplate;
-    }
-
-    bool operator<( DescriptorUpdateTemplate const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorUpdateTemplate < rhs.m_descriptorUpdateTemplate;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkDescriptorUpdateTemplate() const VULKAN_HPP_NOEXCEPT
     {
@@ -4670,25 +4309,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_event = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Event const & ) const = default;
-#else
-    bool operator==( Event const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_event == rhs.m_event;
-    }
-
-    bool operator!=( Event const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_event != rhs.m_event;
-    }
-
-    bool operator<( Event const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_event < rhs.m_event;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkEvent() const VULKAN_HPP_NOEXCEPT
     {
@@ -4787,25 +4407,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( AccelerationStructureKHR const & ) const = default;
-#else
-    bool operator==( AccelerationStructureKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_accelerationStructureKHR == rhs.m_accelerationStructureKHR;
-    }
-
-    bool operator!=( AccelerationStructureKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_accelerationStructureKHR != rhs.m_accelerationStructureKHR;
-    }
-
-    bool operator<( AccelerationStructureKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_accelerationStructureKHR < rhs.m_accelerationStructureKHR;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkAccelerationStructureKHR() const VULKAN_HPP_NOEXCEPT
     {
       return m_accelerationStructureKHR;
@@ -4897,25 +4498,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( MicromapEXT const & ) const = default;
-#else
-    bool operator==( MicromapEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_micromapEXT == rhs.m_micromapEXT;
-    }
-
-    bool operator!=( MicromapEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_micromapEXT != rhs.m_micromapEXT;
-    }
-
-    bool operator<( MicromapEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_micromapEXT < rhs.m_micromapEXT;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkMicromapEXT() const VULKAN_HPP_NOEXCEPT
     {
       return m_micromapEXT;
@@ -4998,25 +4580,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_commandBuffer = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( CommandBuffer const & ) const = default;
-#else
-    bool operator==( CommandBuffer const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_commandBuffer == rhs.m_commandBuffer;
-    }
-
-    bool operator!=( CommandBuffer const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_commandBuffer != rhs.m_commandBuffer;
-    }
-
-    bool operator<( CommandBuffer const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_commandBuffer < rhs.m_commandBuffer;
-    }
-#endif
 
     //=== VK_VERSION_1_0 ===
 
@@ -7454,25 +7017,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( DeviceMemory const & ) const = default;
-#else
-    bool operator==( DeviceMemory const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_deviceMemory == rhs.m_deviceMemory;
-    }
-
-    bool operator!=( DeviceMemory const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_deviceMemory != rhs.m_deviceMemory;
-    }
-
-    bool operator<( DeviceMemory const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_deviceMemory < rhs.m_deviceMemory;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkDeviceMemory() const VULKAN_HPP_NOEXCEPT
     {
       return m_deviceMemory;
@@ -7564,25 +7108,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( VideoSessionKHR const & ) const = default;
-#else
-    bool operator==( VideoSessionKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_videoSessionKHR == rhs.m_videoSessionKHR;
-    }
-
-    bool operator!=( VideoSessionKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_videoSessionKHR != rhs.m_videoSessionKHR;
-    }
-
-    bool operator<( VideoSessionKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_videoSessionKHR < rhs.m_videoSessionKHR;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkVideoSessionKHR() const VULKAN_HPP_NOEXCEPT
     {
       return m_videoSessionKHR;
@@ -7673,25 +7198,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_deferredOperationKHR = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( DeferredOperationKHR const & ) const = default;
-#else
-    bool operator==( DeferredOperationKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_deferredOperationKHR == rhs.m_deferredOperationKHR;
-    }
-
-    bool operator!=( DeferredOperationKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_deferredOperationKHR != rhs.m_deferredOperationKHR;
-    }
-
-    bool operator<( DeferredOperationKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_deferredOperationKHR < rhs.m_deferredOperationKHR;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkDeferredOperationKHR() const VULKAN_HPP_NOEXCEPT
     {
@@ -7785,25 +7291,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#  if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( BufferCollectionFUCHSIA const & ) const = default;
-#  else
-    bool operator==( BufferCollectionFUCHSIA const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_bufferCollectionFUCHSIA == rhs.m_bufferCollectionFUCHSIA;
-    }
-
-    bool operator!=( BufferCollectionFUCHSIA const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_bufferCollectionFUCHSIA != rhs.m_bufferCollectionFUCHSIA;
-    }
-
-    bool operator<( BufferCollectionFUCHSIA const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_bufferCollectionFUCHSIA < rhs.m_bufferCollectionFUCHSIA;
-    }
-#  endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkBufferCollectionFUCHSIA() const VULKAN_HPP_NOEXCEPT
     {
       return m_bufferCollectionFUCHSIA;
@@ -7896,25 +7383,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( BufferView const & ) const = default;
-#else
-    bool operator==( BufferView const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_bufferView == rhs.m_bufferView;
-    }
-
-    bool operator!=( BufferView const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_bufferView != rhs.m_bufferView;
-    }
-
-    bool operator<( BufferView const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_bufferView < rhs.m_bufferView;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkBufferView() const VULKAN_HPP_NOEXCEPT
     {
       return m_bufferView;
@@ -8005,25 +7473,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_commandPool = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( CommandPool const & ) const = default;
-#else
-    bool operator==( CommandPool const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_commandPool == rhs.m_commandPool;
-    }
-
-    bool operator!=( CommandPool const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_commandPool != rhs.m_commandPool;
-    }
-
-    bool operator<( CommandPool const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_commandPool < rhs.m_commandPool;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkCommandPool() const VULKAN_HPP_NOEXCEPT
     {
@@ -8116,25 +7565,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( PipelineCache const & ) const = default;
-#else
-    bool operator==( PipelineCache const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipelineCache == rhs.m_pipelineCache;
-    }
-
-    bool operator!=( PipelineCache const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipelineCache != rhs.m_pipelineCache;
-    }
-
-    bool operator<( PipelineCache const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipelineCache < rhs.m_pipelineCache;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkPipelineCache() const VULKAN_HPP_NOEXCEPT
     {
       return m_pipelineCache;
@@ -8225,25 +7655,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_cuFunctionNVX = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( CuFunctionNVX const & ) const = default;
-#else
-    bool operator==( CuFunctionNVX const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_cuFunctionNVX == rhs.m_cuFunctionNVX;
-    }
-
-    bool operator!=( CuFunctionNVX const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_cuFunctionNVX != rhs.m_cuFunctionNVX;
-    }
-
-    bool operator<( CuFunctionNVX const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_cuFunctionNVX < rhs.m_cuFunctionNVX;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkCuFunctionNVX() const VULKAN_HPP_NOEXCEPT
     {
@@ -8336,25 +7747,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( CuModuleNVX const & ) const = default;
-#else
-    bool operator==( CuModuleNVX const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_cuModuleNVX == rhs.m_cuModuleNVX;
-    }
-
-    bool operator!=( CuModuleNVX const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_cuModuleNVX != rhs.m_cuModuleNVX;
-    }
-
-    bool operator<( CuModuleNVX const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_cuModuleNVX < rhs.m_cuModuleNVX;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkCuModuleNVX() const VULKAN_HPP_NOEXCEPT
     {
       return m_cuModuleNVX;
@@ -8446,25 +7838,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_cudaFunctionNV = {};
       return *this;
     }
-
-#  if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( CudaFunctionNV const & ) const = default;
-#  else
-    bool operator==( CudaFunctionNV const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_cudaFunctionNV == rhs.m_cudaFunctionNV;
-    }
-
-    bool operator!=( CudaFunctionNV const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_cudaFunctionNV != rhs.m_cudaFunctionNV;
-    }
-
-    bool operator<( CudaFunctionNV const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_cudaFunctionNV < rhs.m_cudaFunctionNV;
-    }
-#  endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkCudaFunctionNV() const VULKAN_HPP_NOEXCEPT
     {
@@ -8559,25 +7932,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#  if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( CudaModuleNV const & ) const = default;
-#  else
-    bool operator==( CudaModuleNV const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_cudaModuleNV == rhs.m_cudaModuleNV;
-    }
-
-    bool operator!=( CudaModuleNV const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_cudaModuleNV != rhs.m_cudaModuleNV;
-    }
-
-    bool operator<( CudaModuleNV const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_cudaModuleNV < rhs.m_cudaModuleNV;
-    }
-#  endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkCudaModuleNV() const VULKAN_HPP_NOEXCEPT
     {
       return m_cudaModuleNV;
@@ -8669,25 +8023,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_descriptorPool = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( DescriptorPool const & ) const = default;
-#else
-    bool operator==( DescriptorPool const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorPool == rhs.m_descriptorPool;
-    }
-
-    bool operator!=( DescriptorPool const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorPool != rhs.m_descriptorPool;
-    }
-
-    bool operator<( DescriptorPool const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorPool < rhs.m_descriptorPool;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkDescriptorPool() const VULKAN_HPP_NOEXCEPT
     {
@@ -8786,25 +8121,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( DescriptorSetLayout const & ) const = default;
-#else
-    bool operator==( DescriptorSetLayout const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorSetLayout == rhs.m_descriptorSetLayout;
-    }
-
-    bool operator!=( DescriptorSetLayout const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorSetLayout != rhs.m_descriptorSetLayout;
-    }
-
-    bool operator<( DescriptorSetLayout const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorSetLayout < rhs.m_descriptorSetLayout;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkDescriptorSetLayout() const VULKAN_HPP_NOEXCEPT
     {
       return m_descriptorSetLayout;
@@ -8895,25 +8211,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_framebuffer = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Framebuffer const & ) const = default;
-#else
-    bool operator==( Framebuffer const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_framebuffer == rhs.m_framebuffer;
-    }
-
-    bool operator!=( Framebuffer const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_framebuffer != rhs.m_framebuffer;
-    }
-
-    bool operator<( Framebuffer const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_framebuffer < rhs.m_framebuffer;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkFramebuffer() const VULKAN_HPP_NOEXCEPT
     {
@@ -9012,25 +8309,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( IndirectCommandsLayoutEXT const & ) const = default;
-#else
-    bool operator==( IndirectCommandsLayoutEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_indirectCommandsLayoutEXT == rhs.m_indirectCommandsLayoutEXT;
-    }
-
-    bool operator!=( IndirectCommandsLayoutEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_indirectCommandsLayoutEXT != rhs.m_indirectCommandsLayoutEXT;
-    }
-
-    bool operator<( IndirectCommandsLayoutEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_indirectCommandsLayoutEXT < rhs.m_indirectCommandsLayoutEXT;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkIndirectCommandsLayoutEXT() const VULKAN_HPP_NOEXCEPT
     {
       return m_indirectCommandsLayoutEXT;
@@ -9121,25 +8399,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_indirectCommandsLayoutNV = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( IndirectCommandsLayoutNV const & ) const = default;
-#else
-    bool operator==( IndirectCommandsLayoutNV const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_indirectCommandsLayoutNV == rhs.m_indirectCommandsLayoutNV;
-    }
-
-    bool operator!=( IndirectCommandsLayoutNV const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_indirectCommandsLayoutNV != rhs.m_indirectCommandsLayoutNV;
-    }
-
-    bool operator<( IndirectCommandsLayoutNV const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_indirectCommandsLayoutNV < rhs.m_indirectCommandsLayoutNV;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkIndirectCommandsLayoutNV() const VULKAN_HPP_NOEXCEPT
     {
@@ -9232,25 +8491,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( IndirectExecutionSetEXT const & ) const = default;
-#else
-    bool operator==( IndirectExecutionSetEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_indirectExecutionSetEXT == rhs.m_indirectExecutionSetEXT;
-    }
-
-    bool operator!=( IndirectExecutionSetEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_indirectExecutionSetEXT != rhs.m_indirectExecutionSetEXT;
-    }
-
-    bool operator<( IndirectExecutionSetEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_indirectExecutionSetEXT < rhs.m_indirectExecutionSetEXT;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkIndirectExecutionSetEXT() const VULKAN_HPP_NOEXCEPT
     {
       return m_indirectExecutionSetEXT;
@@ -9335,25 +8575,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_privateDataSlot = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( PrivateDataSlot const & ) const = default;
-#else
-    bool operator==( PrivateDataSlot const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_privateDataSlot == rhs.m_privateDataSlot;
-    }
-
-    bool operator!=( PrivateDataSlot const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_privateDataSlot != rhs.m_privateDataSlot;
-    }
-
-    bool operator<( PrivateDataSlot const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_privateDataSlot < rhs.m_privateDataSlot;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkPrivateDataSlot() const VULKAN_HPP_NOEXCEPT
     {
@@ -9441,25 +8662,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_renderPass = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( RenderPass const & ) const = default;
-#else
-    bool operator==( RenderPass const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_renderPass == rhs.m_renderPass;
-    }
-
-    bool operator!=( RenderPass const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_renderPass != rhs.m_renderPass;
-    }
-
-    bool operator<( RenderPass const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_renderPass < rhs.m_renderPass;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkRenderPass() const VULKAN_HPP_NOEXCEPT
     {
@@ -9551,25 +8753,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_sampler = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Sampler const & ) const = default;
-#else
-    bool operator==( Sampler const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_sampler == rhs.m_sampler;
-    }
-
-    bool operator!=( Sampler const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_sampler != rhs.m_sampler;
-    }
-
-    bool operator<( Sampler const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_sampler < rhs.m_sampler;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkSampler() const VULKAN_HPP_NOEXCEPT
     {
@@ -9668,25 +8851,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( SamplerYcbcrConversion const & ) const = default;
-#else
-    bool operator==( SamplerYcbcrConversion const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_samplerYcbcrConversion == rhs.m_samplerYcbcrConversion;
-    }
-
-    bool operator!=( SamplerYcbcrConversion const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_samplerYcbcrConversion != rhs.m_samplerYcbcrConversion;
-    }
-
-    bool operator<( SamplerYcbcrConversion const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_samplerYcbcrConversion < rhs.m_samplerYcbcrConversion;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkSamplerYcbcrConversion() const VULKAN_HPP_NOEXCEPT
     {
       return m_samplerYcbcrConversion;
@@ -9779,25 +8943,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_shaderModule = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( ShaderModule const & ) const = default;
-#else
-    bool operator==( ShaderModule const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_shaderModule == rhs.m_shaderModule;
-    }
-
-    bool operator!=( ShaderModule const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_shaderModule != rhs.m_shaderModule;
-    }
-
-    bool operator<( ShaderModule const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_shaderModule < rhs.m_shaderModule;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkShaderModule() const VULKAN_HPP_NOEXCEPT
     {
@@ -9893,25 +9038,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_validationCacheEXT = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( ValidationCacheEXT const & ) const = default;
-#else
-    bool operator==( ValidationCacheEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_validationCacheEXT == rhs.m_validationCacheEXT;
-    }
-
-    bool operator!=( ValidationCacheEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_validationCacheEXT != rhs.m_validationCacheEXT;
-    }
-
-    bool operator<( ValidationCacheEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_validationCacheEXT < rhs.m_validationCacheEXT;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkValidationCacheEXT() const VULKAN_HPP_NOEXCEPT
     {
@@ -10010,25 +9136,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( VideoSessionParametersKHR const & ) const = default;
-#else
-    bool operator==( VideoSessionParametersKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_videoSessionParametersKHR == rhs.m_videoSessionParametersKHR;
-    }
-
-    bool operator!=( VideoSessionParametersKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_videoSessionParametersKHR != rhs.m_videoSessionParametersKHR;
-    }
-
-    bool operator<( VideoSessionParametersKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_videoSessionParametersKHR < rhs.m_videoSessionParametersKHR;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkVideoSessionParametersKHR() const VULKAN_HPP_NOEXCEPT
     {
       return m_videoSessionParametersKHR;
@@ -10114,25 +9221,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( PipelineBinaryKHR const & ) const = default;
-#else
-    bool operator==( PipelineBinaryKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipelineBinaryKHR == rhs.m_pipelineBinaryKHR;
-    }
-
-    bool operator!=( PipelineBinaryKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipelineBinaryKHR != rhs.m_pipelineBinaryKHR;
-    }
-
-    bool operator<( PipelineBinaryKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipelineBinaryKHR < rhs.m_pipelineBinaryKHR;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkPipelineBinaryKHR() const VULKAN_HPP_NOEXCEPT
     {
       return m_pipelineBinaryKHR;
@@ -10215,25 +9303,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_queue = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Queue const & ) const = default;
-#else
-    bool operator==( Queue const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_queue == rhs.m_queue;
-    }
-
-    bool operator!=( Queue const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_queue != rhs.m_queue;
-    }
-
-    bool operator<( Queue const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_queue < rhs.m_queue;
-    }
-#endif
 
     //=== VK_VERSION_1_0 ===
 
@@ -10487,25 +9556,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_device = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Device const & ) const = default;
-#else
-    bool operator==( Device const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_device == rhs.m_device;
-    }
-
-    bool operator!=( Device const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_device != rhs.m_device;
-    }
-
-    bool operator<( Device const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_device < rhs.m_device;
-    }
-#endif
 
     //=== VK_VERSION_1_0 ===
 
@@ -16020,25 +15070,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( DisplayModeKHR const & ) const = default;
-#else
-    bool operator==( DisplayModeKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_displayModeKHR == rhs.m_displayModeKHR;
-    }
-
-    bool operator!=( DisplayModeKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_displayModeKHR != rhs.m_displayModeKHR;
-    }
-
-    bool operator<( DisplayModeKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_displayModeKHR < rhs.m_displayModeKHR;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkDisplayModeKHR() const VULKAN_HPP_NOEXCEPT
     {
       return m_displayModeKHR;
@@ -16127,25 +15158,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_physicalDevice = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( PhysicalDevice const & ) const = default;
-#else
-    bool operator==( PhysicalDevice const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_physicalDevice == rhs.m_physicalDevice;
-    }
-
-    bool operator!=( PhysicalDevice const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_physicalDevice != rhs.m_physicalDevice;
-    }
-
-    bool operator<( PhysicalDevice const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_physicalDevice < rhs.m_physicalDevice;
-    }
-#endif
 
     //=== VK_VERSION_1_0 ===
 
@@ -17685,25 +16697,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Instance const & ) const = default;
-#else
-    bool operator==( Instance const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_instance == rhs.m_instance;
-    }
-
-    bool operator!=( Instance const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_instance != rhs.m_instance;
-    }
-
-    bool operator<( Instance const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_instance < rhs.m_instance;
-    }
-#endif
-
     //=== VK_VERSION_1_0 ===
 
     template <typename Dispatch = VULKAN_HPP_DEFAULT_DISPATCHER_TYPE>
@@ -18411,29 +17404,4 @@ namespace VULKAN_HPP_NAMESPACE
 #endif /* VULKAN_HPP_DISABLE_ENHANCED_MODE */
 
 }  // namespace VULKAN_HPP_NAMESPACE
-
-// operators to compare vk::-handles with nullptr
-template <typename T>
-typename std::enable_if<VULKAN_HPP_NAMESPACE::isVulkanHandleType<T>::value, bool>::type operator==( const T & v, std::nullptr_t )
-{
-  return !v;
-}
-
-template <typename T>
-typename std::enable_if<VULKAN_HPP_NAMESPACE::isVulkanHandleType<T>::value, bool>::type operator==( std::nullptr_t, const T & v )
-{
-  return !v;
-}
-
-template <typename T>
-typename std::enable_if<VULKAN_HPP_NAMESPACE::isVulkanHandleType<T>::value, bool>::type operator!=( const T & v, std::nullptr_t )
-{
-  return v;
-}
-
-template <typename T>
-typename std::enable_if<VULKAN_HPP_NAMESPACE::isVulkanHandleType<T>::value, bool>::type operator!=( std::nullptr_t, const T & v )
-{
-  return v;
-}
 #endif

--- a/vulkan/vulkan_raii.hpp
+++ b/vulkan/vulkan_raii.hpp
@@ -2770,6 +2770,12 @@ namespace VULKAN_HPP_NAMESPACE
     //=== RAII HANDLES ===
     //====================
 
+    template <typename Type>
+    struct isVulkanRAIIHandleType
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = false;
+    };
+
     class Context
     {
     public:
@@ -3142,6 +3148,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::Instance                                                               m_instance  = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                            m_allocator = {};
       std::unique_ptr<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::InstanceDispatcher> m_dispatcher;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Instance>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class PhysicalDevice
@@ -3583,6 +3595,12 @@ namespace VULKAN_HPP_NAMESPACE
     private:
       VULKAN_HPP_NAMESPACE::PhysicalDevice                                                m_physicalDevice = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::InstanceDispatcher const * m_dispatcher     = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::PhysicalDevice>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class PhysicalDevices : public std::vector<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::PhysicalDevice>
@@ -4746,6 +4764,12 @@ namespace VULKAN_HPP_NAMESPACE
       std::unique_ptr<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher> m_dispatcher;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class AccelerationStructureKHR
     {
     public:
@@ -4864,6 +4888,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::AccelerationStructureKHR                                    m_accelerationStructure = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator             = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher            = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::AccelerationStructureKHR>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class AccelerationStructureNV
@@ -4994,6 +5024,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher            = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::AccelerationStructureNV>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class Buffer
     {
     public:
@@ -5117,6 +5153,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::Buffer                                                      m_buffer     = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Buffer>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
 #  if defined( VK_USE_PLATFORM_FUCHSIA )
@@ -5247,6 +5289,13 @@ namespace VULKAN_HPP_NAMESPACE
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::BufferCollectionFUCHSIA>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
 #  endif /*VK_USE_PLATFORM_FUCHSIA*/
 
     class BufferView
@@ -5366,6 +5415,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::BufferView                                                  m_bufferView = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::BufferView>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class CommandPool
@@ -5497,6 +5552,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::CommandPool                                                 m_commandPool = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator   = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher  = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::CommandPool>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class CommandBuffer
@@ -6561,6 +6622,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher    = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::CommandBuffer>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class CommandBuffers : public std::vector<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::CommandBuffer>
     {
     public:
@@ -6706,6 +6773,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::CuFunctionNVX>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class CuModuleNVX
     {
     public:
@@ -6823,6 +6896,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::CuModuleNVX                                                 m_module     = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::CuModuleNVX>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
 #  if defined( VK_ENABLE_BETA_EXTENSIONS )
@@ -6944,6 +7023,13 @@ namespace VULKAN_HPP_NAMESPACE
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::CudaFunctionNV>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
 #  endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
 #  if defined( VK_ENABLE_BETA_EXTENSIONS )
@@ -7069,6 +7155,13 @@ namespace VULKAN_HPP_NAMESPACE
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::CudaModuleNV>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
 #  endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
     class DebugReportCallbackEXT
@@ -7191,6 +7284,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::InstanceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DebugReportCallbackEXT>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class DebugUtilsMessengerEXT
     {
     public:
@@ -7309,6 +7408,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::DebugUtilsMessengerEXT                                        m_messenger  = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                   m_allocator  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::InstanceDispatcher const * m_dispatcher = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DebugUtilsMessengerEXT>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class DeferredOperationKHR
@@ -7438,6 +7543,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DeferredOperationKHR>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class DescriptorPool
     {
     public:
@@ -7562,6 +7673,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher     = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DescriptorPool>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class DescriptorSet
     {
     public:
@@ -7681,6 +7798,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::DescriptorPool                                              m_descriptorPool = {};
       VULKAN_HPP_NAMESPACE::DescriptorSet                                               m_descriptorSet  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher     = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DescriptorSet>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class DescriptorSets : public std::vector<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DescriptorSet>
@@ -7835,6 +7958,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher          = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DescriptorSetLayout>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class DescriptorUpdateTemplate
     {
     public:
@@ -7953,6 +8082,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::DescriptorUpdateTemplate                                    m_descriptorUpdateTemplate = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator                = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher               = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DescriptorUpdateTemplate>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class DeviceMemory
@@ -8092,6 +8227,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::DeviceMemory                                                m_memory     = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DeviceMemory>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class DisplayKHR
@@ -8236,6 +8377,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::InstanceDispatcher const * m_dispatcher     = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DisplayKHR>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class DisplayKHRs : public std::vector<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DisplayKHR>
     {
     public:
@@ -8369,6 +8516,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::InstanceDispatcher const * m_dispatcher     = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DisplayModeKHR>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class Event
     {
     public:
@@ -8494,6 +8647,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::Event                                                       m_event      = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Event>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class Fence
@@ -8638,6 +8797,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Fence>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class Framebuffer
     {
     public:
@@ -8759,6 +8924,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::Framebuffer                                                 m_framebuffer = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator   = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher  = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Framebuffer>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class Image
@@ -8913,6 +9084,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Image>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class ImageView
     {
     public:
@@ -9036,6 +9213,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::ImageView>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class IndirectCommandsLayoutEXT
     {
     public:
@@ -9156,6 +9339,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher             = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::IndirectCommandsLayoutEXT>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class IndirectCommandsLayoutNV
     {
     public:
@@ -9274,6 +9463,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::IndirectCommandsLayoutNV                                    m_indirectCommandsLayout = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator              = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher             = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::IndirectCommandsLayoutNV>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class IndirectExecutionSetEXT
@@ -9404,6 +9599,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher           = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::IndirectExecutionSetEXT>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class MicromapEXT
     {
     public:
@@ -9521,6 +9722,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::MicromapEXT                                                 m_micromap   = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::MicromapEXT>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class OpticalFlowSessionNV
@@ -9649,6 +9856,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::OpticalFlowSessionNV>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class PerformanceConfigurationINTEL
     {
     public:
@@ -9754,6 +9967,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::Device                                                      m_device        = {};
       VULKAN_HPP_NAMESPACE::PerformanceConfigurationINTEL                               m_configuration = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher    = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::PerformanceConfigurationINTEL>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class PipelineCache
@@ -9880,6 +10099,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::PipelineCache                                               m_pipelineCache = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator     = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher    = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::PipelineCache>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class Pipeline
@@ -10099,6 +10324,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher             = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Pipeline>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class Pipelines : public std::vector<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Pipeline>
     {
     public:
@@ -10294,6 +10525,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher             = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::PipelineBinaryKHR>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class PipelineBinaryKHRs : public std::vector<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::PipelineBinaryKHR>
     {
     public:
@@ -10441,6 +10678,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher     = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::PipelineLayout>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class PrivateDataSlot
     {
     public:
@@ -10559,6 +10802,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::PrivateDataSlot                                             m_privateDataSlot = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator       = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher      = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::PrivateDataSlot>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class QueryPool
@@ -10703,6 +10952,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::QueryPool                                                   m_queryPool  = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::QueryPool>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class Queue
@@ -10853,6 +11108,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Queue>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class RenderPass
     {
     public:
@@ -10989,6 +11250,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::RenderPass>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class Sampler
     {
     public:
@@ -11106,6 +11373,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::Sampler                                                     m_sampler    = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Sampler>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class SamplerYcbcrConversion
@@ -11226,6 +11499,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::SamplerYcbcrConversion                                      m_ycbcrConversion = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator       = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher      = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::SamplerYcbcrConversion>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class Semaphore
@@ -11353,6 +11632,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::Semaphore                                                   m_semaphore  = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Semaphore>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class ShaderEXT
@@ -11489,6 +11774,12 @@ namespace VULKAN_HPP_NAMESPACE
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator              = {};
       VULKAN_HPP_NAMESPACE::Result                                                      m_constructorSuccessCode = VULKAN_HPP_NAMESPACE::Result::eErrorUnknown;
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher             = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::ShaderEXT>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class ShaderEXTs : public std::vector<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::ShaderEXT>
@@ -11639,6 +11930,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::ShaderModule                                                m_shaderModule = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator    = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher   = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::ShaderModule>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class SurfaceKHR
@@ -11912,6 +12209,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::InstanceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::SurfaceKHR>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class SwapchainKHR
     {
     public:
@@ -12080,6 +12383,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::SwapchainKHR>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class SwapchainKHRs : public std::vector<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::SwapchainKHR>
     {
     public:
@@ -12233,6 +12542,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher      = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::ValidationCacheEXT>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class VideoSessionKHR
     {
     public:
@@ -12359,6 +12674,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher   = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::VideoSessionKHR>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class VideoSessionParametersKHR
     {
     public:
@@ -12482,6 +12803,63 @@ namespace VULKAN_HPP_NAMESPACE
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator              = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher             = nullptr;
     };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::VideoSessionParametersKHR>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
+    // operators to compare vk::raii-handles
+#  if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
+    template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value, bool>::type = 0>
+    auto operator<=>( T const & a, T const & b ) VULKAN_HPP_NOEXCEPT
+    {
+      return *a <=> *b;
+    }
+#  else
+    template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value, bool>::type = 0>
+    bool operator==( T const & a, T const & b ) VULKAN_HPP_NOEXCEPT
+    {
+      return *a == *b;
+    }
+
+    template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value, bool>::type = 0>
+    bool operator!=( T const & a, T const & b ) VULKAN_HPP_NOEXCEPT
+    {
+      return *a != *b;
+    }
+
+    template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value, bool>::type = 0>
+    bool operator<( T const & a, T const & b ) VULKAN_HPP_NOEXCEPT
+    {
+      return *a < *b;
+    }
+#  endif
+
+    template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value, bool>::type = 0>
+    bool operator==( const T & v, std::nullptr_t ) VULKAN_HPP_NOEXCEPT
+    {
+      return !*v;
+    }
+
+    template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value, bool>::type = 0>
+    bool operator==( std::nullptr_t, const T & v ) VULKAN_HPP_NOEXCEPT
+    {
+      return !*v;
+    }
+
+    template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value, bool>::type = 0>
+    bool operator!=( const T & v, std::nullptr_t ) VULKAN_HPP_NOEXCEPT
+    {
+      return *v;
+    }
+
+    template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value, bool>::type = 0>
+    bool operator!=( std::nullptr_t, const T & v ) VULKAN_HPP_NOEXCEPT
+    {
+      return *v;
+    }
 
     //===========================
     //=== COMMAND Definitions ===

--- a/vulkan/vulkansc_handles.hpp
+++ b/vulkan/vulkansc_handles.hpp
@@ -1094,25 +1094,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( DebugUtilsMessengerEXT const & ) const = default;
-#else
-    bool operator==( DebugUtilsMessengerEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_debugUtilsMessengerEXT == rhs.m_debugUtilsMessengerEXT;
-    }
-
-    bool operator!=( DebugUtilsMessengerEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_debugUtilsMessengerEXT != rhs.m_debugUtilsMessengerEXT;
-    }
-
-    bool operator<( DebugUtilsMessengerEXT const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_debugUtilsMessengerEXT < rhs.m_debugUtilsMessengerEXT;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkDebugUtilsMessengerEXT() const VULKAN_HPP_NOEXCEPT
     {
       return m_debugUtilsMessengerEXT;
@@ -1197,25 +1178,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_surfaceKHR = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( SurfaceKHR const & ) const = default;
-#else
-    bool operator==( SurfaceKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_surfaceKHR == rhs.m_surfaceKHR;
-    }
-
-    bool operator!=( SurfaceKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_surfaceKHR != rhs.m_surfaceKHR;
-    }
-
-    bool operator<( SurfaceKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_surfaceKHR < rhs.m_surfaceKHR;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkSurfaceKHR() const VULKAN_HPP_NOEXCEPT
     {
@@ -1308,25 +1270,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( DisplayKHR const & ) const = default;
-#else
-    bool operator==( DisplayKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_displayKHR == rhs.m_displayKHR;
-    }
-
-    bool operator!=( DisplayKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_displayKHR != rhs.m_displayKHR;
-    }
-
-    bool operator<( DisplayKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_displayKHR < rhs.m_displayKHR;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkDisplayKHR() const VULKAN_HPP_NOEXCEPT
     {
       return m_displayKHR;
@@ -1417,25 +1360,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_swapchainKHR = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( SwapchainKHR const & ) const = default;
-#else
-    bool operator==( SwapchainKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_swapchainKHR == rhs.m_swapchainKHR;
-    }
-
-    bool operator!=( SwapchainKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_swapchainKHR != rhs.m_swapchainKHR;
-    }
-
-    bool operator<( SwapchainKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_swapchainKHR < rhs.m_swapchainKHR;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkSwapchainKHR() const VULKAN_HPP_NOEXCEPT
     {
@@ -1528,25 +1452,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Semaphore const & ) const = default;
-#else
-    bool operator==( Semaphore const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_semaphore == rhs.m_semaphore;
-    }
-
-    bool operator!=( Semaphore const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_semaphore != rhs.m_semaphore;
-    }
-
-    bool operator<( Semaphore const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_semaphore < rhs.m_semaphore;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkSemaphore() const VULKAN_HPP_NOEXCEPT
     {
       return m_semaphore;
@@ -1637,25 +1542,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_fence = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Fence const & ) const = default;
-#else
-    bool operator==( Fence const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_fence == rhs.m_fence;
-    }
-
-    bool operator!=( Fence const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_fence != rhs.m_fence;
-    }
-
-    bool operator<( Fence const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_fence < rhs.m_fence;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkFence() const VULKAN_HPP_NOEXCEPT
     {
@@ -1748,25 +1634,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( QueryPool const & ) const = default;
-#else
-    bool operator==( QueryPool const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_queryPool == rhs.m_queryPool;
-    }
-
-    bool operator!=( QueryPool const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_queryPool != rhs.m_queryPool;
-    }
-
-    bool operator<( QueryPool const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_queryPool < rhs.m_queryPool;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkQueryPool() const VULKAN_HPP_NOEXCEPT
     {
       return m_queryPool;
@@ -1857,25 +1724,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_pipelineLayout = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( PipelineLayout const & ) const = default;
-#else
-    bool operator==( PipelineLayout const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipelineLayout == rhs.m_pipelineLayout;
-    }
-
-    bool operator!=( PipelineLayout const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipelineLayout != rhs.m_pipelineLayout;
-    }
-
-    bool operator<( PipelineLayout const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipelineLayout < rhs.m_pipelineLayout;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkPipelineLayout() const VULKAN_HPP_NOEXCEPT
     {
@@ -1968,25 +1816,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( DescriptorSet const & ) const = default;
-#else
-    bool operator==( DescriptorSet const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorSet == rhs.m_descriptorSet;
-    }
-
-    bool operator!=( DescriptorSet const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorSet != rhs.m_descriptorSet;
-    }
-
-    bool operator<( DescriptorSet const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorSet < rhs.m_descriptorSet;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkDescriptorSet() const VULKAN_HPP_NOEXCEPT
     {
       return m_descriptorSet;
@@ -2077,25 +1906,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_buffer = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Buffer const & ) const = default;
-#else
-    bool operator==( Buffer const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_buffer == rhs.m_buffer;
-    }
-
-    bool operator!=( Buffer const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_buffer != rhs.m_buffer;
-    }
-
-    bool operator<( Buffer const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_buffer < rhs.m_buffer;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkBuffer() const VULKAN_HPP_NOEXCEPT
     {
@@ -2188,25 +1998,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Pipeline const & ) const = default;
-#else
-    bool operator==( Pipeline const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipeline == rhs.m_pipeline;
-    }
-
-    bool operator!=( Pipeline const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipeline != rhs.m_pipeline;
-    }
-
-    bool operator<( Pipeline const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipeline < rhs.m_pipeline;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkPipeline() const VULKAN_HPP_NOEXCEPT
     {
       return m_pipeline;
@@ -2297,25 +2088,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_image = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Image const & ) const = default;
-#else
-    bool operator==( Image const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_image == rhs.m_image;
-    }
-
-    bool operator!=( Image const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_image != rhs.m_image;
-    }
-
-    bool operator<( Image const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_image < rhs.m_image;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkImage() const VULKAN_HPP_NOEXCEPT
     {
@@ -2408,25 +2180,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Event const & ) const = default;
-#else
-    bool operator==( Event const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_event == rhs.m_event;
-    }
-
-    bool operator!=( Event const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_event != rhs.m_event;
-    }
-
-    bool operator<( Event const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_event < rhs.m_event;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkEvent() const VULKAN_HPP_NOEXCEPT
     {
       return m_event;
@@ -2515,25 +2268,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_commandBuffer = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( CommandBuffer const & ) const = default;
-#else
-    bool operator==( CommandBuffer const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_commandBuffer == rhs.m_commandBuffer;
-    }
-
-    bool operator!=( CommandBuffer const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_commandBuffer != rhs.m_commandBuffer;
-    }
-
-    bool operator<( CommandBuffer const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_commandBuffer < rhs.m_commandBuffer;
-    }
-#endif
 
     //=== VK_VERSION_1_0 ===
 
@@ -3679,25 +3413,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( DeviceMemory const & ) const = default;
-#else
-    bool operator==( DeviceMemory const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_deviceMemory == rhs.m_deviceMemory;
-    }
-
-    bool operator!=( DeviceMemory const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_deviceMemory != rhs.m_deviceMemory;
-    }
-
-    bool operator<( DeviceMemory const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_deviceMemory < rhs.m_deviceMemory;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkDeviceMemory() const VULKAN_HPP_NOEXCEPT
     {
       return m_deviceMemory;
@@ -3788,25 +3503,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_bufferView = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( BufferView const & ) const = default;
-#else
-    bool operator==( BufferView const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_bufferView == rhs.m_bufferView;
-    }
-
-    bool operator!=( BufferView const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_bufferView != rhs.m_bufferView;
-    }
-
-    bool operator<( BufferView const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_bufferView < rhs.m_bufferView;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkBufferView() const VULKAN_HPP_NOEXCEPT
     {
@@ -3899,25 +3595,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( CommandPool const & ) const = default;
-#else
-    bool operator==( CommandPool const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_commandPool == rhs.m_commandPool;
-    }
-
-    bool operator!=( CommandPool const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_commandPool != rhs.m_commandPool;
-    }
-
-    bool operator<( CommandPool const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_commandPool < rhs.m_commandPool;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkCommandPool() const VULKAN_HPP_NOEXCEPT
     {
       return m_commandPool;
@@ -4009,25 +3686,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( PipelineCache const & ) const = default;
-#else
-    bool operator==( PipelineCache const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipelineCache == rhs.m_pipelineCache;
-    }
-
-    bool operator!=( PipelineCache const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipelineCache != rhs.m_pipelineCache;
-    }
-
-    bool operator<( PipelineCache const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_pipelineCache < rhs.m_pipelineCache;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkPipelineCache() const VULKAN_HPP_NOEXCEPT
     {
       return m_pipelineCache;
@@ -4118,25 +3776,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_descriptorPool = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( DescriptorPool const & ) const = default;
-#else
-    bool operator==( DescriptorPool const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorPool == rhs.m_descriptorPool;
-    }
-
-    bool operator!=( DescriptorPool const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorPool != rhs.m_descriptorPool;
-    }
-
-    bool operator<( DescriptorPool const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorPool < rhs.m_descriptorPool;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkDescriptorPool() const VULKAN_HPP_NOEXCEPT
     {
@@ -4235,25 +3874,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( DescriptorSetLayout const & ) const = default;
-#else
-    bool operator==( DescriptorSetLayout const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorSetLayout == rhs.m_descriptorSetLayout;
-    }
-
-    bool operator!=( DescriptorSetLayout const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorSetLayout != rhs.m_descriptorSetLayout;
-    }
-
-    bool operator<( DescriptorSetLayout const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_descriptorSetLayout < rhs.m_descriptorSetLayout;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkDescriptorSetLayout() const VULKAN_HPP_NOEXCEPT
     {
       return m_descriptorSetLayout;
@@ -4344,25 +3964,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_framebuffer = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Framebuffer const & ) const = default;
-#else
-    bool operator==( Framebuffer const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_framebuffer == rhs.m_framebuffer;
-    }
-
-    bool operator!=( Framebuffer const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_framebuffer != rhs.m_framebuffer;
-    }
-
-    bool operator<( Framebuffer const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_framebuffer < rhs.m_framebuffer;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkFramebuffer() const VULKAN_HPP_NOEXCEPT
     {
@@ -4455,25 +4056,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( ImageView const & ) const = default;
-#else
-    bool operator==( ImageView const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_imageView == rhs.m_imageView;
-    }
-
-    bool operator!=( ImageView const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_imageView != rhs.m_imageView;
-    }
-
-    bool operator<( ImageView const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_imageView < rhs.m_imageView;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkImageView() const VULKAN_HPP_NOEXCEPT
     {
       return m_imageView;
@@ -4565,25 +4147,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( PrivateDataSlot const & ) const = default;
-#else
-    bool operator==( PrivateDataSlot const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_privateDataSlot == rhs.m_privateDataSlot;
-    }
-
-    bool operator!=( PrivateDataSlot const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_privateDataSlot != rhs.m_privateDataSlot;
-    }
-
-    bool operator<( PrivateDataSlot const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_privateDataSlot < rhs.m_privateDataSlot;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkPrivateDataSlot() const VULKAN_HPP_NOEXCEPT
     {
       return m_privateDataSlot;
@@ -4670,25 +4233,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_renderPass = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( RenderPass const & ) const = default;
-#else
-    bool operator==( RenderPass const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_renderPass == rhs.m_renderPass;
-    }
-
-    bool operator!=( RenderPass const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_renderPass != rhs.m_renderPass;
-    }
-
-    bool operator<( RenderPass const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_renderPass < rhs.m_renderPass;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkRenderPass() const VULKAN_HPP_NOEXCEPT
     {
@@ -4780,25 +4324,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_sampler = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Sampler const & ) const = default;
-#else
-    bool operator==( Sampler const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_sampler == rhs.m_sampler;
-    }
-
-    bool operator!=( Sampler const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_sampler != rhs.m_sampler;
-    }
-
-    bool operator<( Sampler const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_sampler < rhs.m_sampler;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkSampler() const VULKAN_HPP_NOEXCEPT
     {
@@ -4896,25 +4421,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_samplerYcbcrConversion = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( SamplerYcbcrConversion const & ) const = default;
-#else
-    bool operator==( SamplerYcbcrConversion const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_samplerYcbcrConversion == rhs.m_samplerYcbcrConversion;
-    }
-
-    bool operator!=( SamplerYcbcrConversion const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_samplerYcbcrConversion != rhs.m_samplerYcbcrConversion;
-    }
-
-    bool operator<( SamplerYcbcrConversion const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_samplerYcbcrConversion < rhs.m_samplerYcbcrConversion;
-    }
-#endif
 
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkSamplerYcbcrConversion() const VULKAN_HPP_NOEXCEPT
     {
@@ -5016,25 +4522,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#  if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( SemaphoreSciSyncPoolNV const & ) const = default;
-#  else
-    bool operator==( SemaphoreSciSyncPoolNV const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_semaphoreSciSyncPoolNV == rhs.m_semaphoreSciSyncPoolNV;
-    }
-
-    bool operator!=( SemaphoreSciSyncPoolNV const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_semaphoreSciSyncPoolNV != rhs.m_semaphoreSciSyncPoolNV;
-    }
-
-    bool operator<( SemaphoreSciSyncPoolNV const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_semaphoreSciSyncPoolNV < rhs.m_semaphoreSciSyncPoolNV;
-    }
-#  endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkSemaphoreSciSyncPoolNV() const VULKAN_HPP_NOEXCEPT
     {
       return m_semaphoreSciSyncPoolNV;
@@ -5118,25 +4605,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_queue = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Queue const & ) const = default;
-#else
-    bool operator==( Queue const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_queue == rhs.m_queue;
-    }
-
-    bool operator!=( Queue const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_queue != rhs.m_queue;
-    }
-
-    bool operator<( Queue const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_queue < rhs.m_queue;
-    }
-#endif
 
     //=== VK_VERSION_1_0 ===
 
@@ -5313,25 +4781,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_device = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Device const & ) const = default;
-#else
-    bool operator==( Device const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_device == rhs.m_device;
-    }
-
-    bool operator!=( Device const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_device != rhs.m_device;
-    }
-
-    bool operator<( Device const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_device < rhs.m_device;
-    }
-#endif
 
     //=== VK_VERSION_1_0 ===
 
@@ -7516,25 +6965,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( DisplayModeKHR const & ) const = default;
-#else
-    bool operator==( DisplayModeKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_displayModeKHR == rhs.m_displayModeKHR;
-    }
-
-    bool operator!=( DisplayModeKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_displayModeKHR != rhs.m_displayModeKHR;
-    }
-
-    bool operator<( DisplayModeKHR const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_displayModeKHR < rhs.m_displayModeKHR;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkDisplayModeKHR() const VULKAN_HPP_NOEXCEPT
     {
       return m_displayModeKHR;
@@ -7623,25 +7053,6 @@ namespace VULKAN_HPP_NAMESPACE
       m_physicalDevice = {};
       return *this;
     }
-
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( PhysicalDevice const & ) const = default;
-#else
-    bool operator==( PhysicalDevice const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_physicalDevice == rhs.m_physicalDevice;
-    }
-
-    bool operator!=( PhysicalDevice const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_physicalDevice != rhs.m_physicalDevice;
-    }
-
-    bool operator<( PhysicalDevice const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_physicalDevice < rhs.m_physicalDevice;
-    }
-#endif
 
     //=== VK_VERSION_1_0 ===
 
@@ -8584,25 +7995,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Instance const & ) const = default;
-#else
-    bool operator==( Instance const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_instance == rhs.m_instance;
-    }
-
-    bool operator!=( Instance const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_instance != rhs.m_instance;
-    }
-
-    bool operator<( Instance const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_instance < rhs.m_instance;
-    }
-#endif
-
     //=== VK_VERSION_1_0 ===
 
     template <typename Dispatch = VULKAN_HPP_DEFAULT_DISPATCHER_TYPE>
@@ -8952,25 +8344,6 @@ namespace VULKAN_HPP_NAMESPACE
       return *this;
     }
 
-#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( ShaderModule const & ) const = default;
-#else
-    bool operator==( ShaderModule const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_shaderModule == rhs.m_shaderModule;
-    }
-
-    bool operator!=( ShaderModule const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_shaderModule != rhs.m_shaderModule;
-    }
-
-    bool operator<( ShaderModule const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_shaderModule < rhs.m_shaderModule;
-    }
-#endif
-
     VULKAN_HPP_TYPESAFE_EXPLICIT operator VkShaderModule() const VULKAN_HPP_NOEXCEPT
     {
       return m_shaderModule;
@@ -9017,29 +8390,4 @@ namespace VULKAN_HPP_NAMESPACE
   };
 
 }  // namespace VULKAN_HPP_NAMESPACE
-
-// operators to compare vk::-handles with nullptr
-template <typename T>
-typename std::enable_if<VULKAN_HPP_NAMESPACE::isVulkanHandleType<T>::value, bool>::type operator==( const T & v, std::nullptr_t )
-{
-  return !v;
-}
-
-template <typename T>
-typename std::enable_if<VULKAN_HPP_NAMESPACE::isVulkanHandleType<T>::value, bool>::type operator==( std::nullptr_t, const T & v )
-{
-  return !v;
-}
-
-template <typename T>
-typename std::enable_if<VULKAN_HPP_NAMESPACE::isVulkanHandleType<T>::value, bool>::type operator!=( const T & v, std::nullptr_t )
-{
-  return v;
-}
-
-template <typename T>
-typename std::enable_if<VULKAN_HPP_NAMESPACE::isVulkanHandleType<T>::value, bool>::type operator!=( std::nullptr_t, const T & v )
-{
-  return v;
-}
 #endif

--- a/vulkan/vulkansc_raii.hpp
+++ b/vulkan/vulkansc_raii.hpp
@@ -1127,6 +1127,12 @@ namespace VULKAN_HPP_NAMESPACE
     //=== RAII HANDLES ===
     //====================
 
+    template <typename Type>
+    struct isVulkanRAIIHandleType
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = false;
+    };
+
     class Context
     {
     public:
@@ -1349,6 +1355,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::Instance                                                               m_instance  = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                            m_allocator = {};
       std::unique_ptr<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::InstanceDispatcher> m_dispatcher;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Instance>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class PhysicalDevice
@@ -1619,6 +1631,12 @@ namespace VULKAN_HPP_NAMESPACE
     private:
       VULKAN_HPP_NAMESPACE::PhysicalDevice                                                m_physicalDevice = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::InstanceDispatcher const * m_dispatcher     = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::PhysicalDevice>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class PhysicalDevices : public std::vector<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::PhysicalDevice>
@@ -2124,6 +2142,12 @@ namespace VULKAN_HPP_NAMESPACE
       std::unique_ptr<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher> m_dispatcher;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Device>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class Buffer
     {
     public:
@@ -2249,6 +2273,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Buffer>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class BufferView
     {
     public:
@@ -2366,6 +2396,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::BufferView                                                  m_bufferView = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::BufferView>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class CommandPool
@@ -2494,6 +2530,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::CommandPool                                                 m_commandPool = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator   = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher  = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::CommandPool>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class CommandBuffer
@@ -3002,6 +3044,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher    = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::CommandBuffer>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class CommandBuffers : public std::vector<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::CommandBuffer>
     {
     public:
@@ -3148,6 +3196,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::InstanceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DebugUtilsMessengerEXT>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class DescriptorPool
     {
     public:
@@ -3272,6 +3326,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher     = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DescriptorPool>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class DescriptorSet
     {
     public:
@@ -3377,6 +3437,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::DescriptorPool                                              m_descriptorPool = {};
       VULKAN_HPP_NAMESPACE::DescriptorSet                                               m_descriptorSet  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher     = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DescriptorSet>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class DescriptorSets : public std::vector<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DescriptorSet>
@@ -3525,6 +3591,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher          = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DescriptorSetLayout>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class DeviceMemory
     {
     public:
@@ -3654,6 +3726,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DeviceMemory>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class DisplayKHR
     {
     public:
@@ -3778,6 +3856,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::PhysicalDevice                                                m_physicalDevice = {};
       VULKAN_HPP_NAMESPACE::DisplayKHR                                                    m_display        = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::InstanceDispatcher const * m_dispatcher     = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DisplayKHR>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class DisplayKHRs : public std::vector<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DisplayKHR>
@@ -3913,6 +3997,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::InstanceDispatcher const * m_dispatcher     = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::DisplayModeKHR>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class Event
     {
     public:
@@ -4038,6 +4128,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::Event                                                       m_event      = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Event>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class Fence
@@ -4182,6 +4278,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Fence>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class Framebuffer
     {
     public:
@@ -4299,6 +4401,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::Framebuffer                                                 m_framebuffer = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator   = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher  = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Framebuffer>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class Image
@@ -4433,6 +4541,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Image>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class ImageView
     {
     public:
@@ -4550,6 +4664,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::ImageView                                                   m_imageView  = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::ImageView>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class PipelineCache
@@ -4696,6 +4816,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher    = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::PipelineCache>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class Pipeline
     {
     public:
@@ -4837,6 +4963,12 @@ namespace VULKAN_HPP_NAMESPACE
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator              = {};
       VULKAN_HPP_NAMESPACE::Result                                                      m_constructorSuccessCode = VULKAN_HPP_NAMESPACE::Result::eErrorUnknown;
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher             = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Pipeline>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class Pipelines : public std::vector<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Pipeline>
@@ -4997,6 +5129,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher     = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::PipelineLayout>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class PrivateDataSlot
     {
     public:
@@ -5115,6 +5253,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::PrivateDataSlot                                             m_privateDataSlot = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator       = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher      = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::PrivateDataSlot>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class QueryPool
@@ -5257,6 +5401,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::QueryPool>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class Queue
     {
     public:
@@ -5386,6 +5536,12 @@ namespace VULKAN_HPP_NAMESPACE
     private:
       VULKAN_HPP_NAMESPACE::Queue                                                       m_queue      = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Queue>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class RenderPass
@@ -5520,6 +5676,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::RenderPass>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class Sampler
     {
     public:
@@ -5637,6 +5799,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::Sampler                                                     m_sampler    = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Sampler>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class SamplerYcbcrConversion
@@ -5757,6 +5925,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::SamplerYcbcrConversion                                      m_ycbcrConversion = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator       = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher      = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::SamplerYcbcrConversion>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class Semaphore
@@ -5882,6 +6056,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::Semaphore>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
 #  if defined( VK_USE_PLATFORM_SCI )
     class SemaphoreSciSyncPoolNV
     {
@@ -6002,6 +6182,13 @@ namespace VULKAN_HPP_NAMESPACE
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator     = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher    = nullptr;
     };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::SemaphoreSciSyncPoolNV>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
 #  endif /*VK_USE_PLATFORM_SCI*/
 
     class ShaderModule
@@ -6121,6 +6308,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::ShaderModule                                                m_shaderModule = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                 m_allocator    = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher   = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::ShaderModule>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class SurfaceKHR
@@ -6249,6 +6442,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::SurfaceKHR                                                    m_surface    = {};
       const VULKAN_HPP_NAMESPACE::AllocationCallbacks *                                   m_allocator  = {};
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::InstanceDispatcher const * m_dispatcher = nullptr;
+    };
+
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::SurfaceKHR>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
     };
 
     class SwapchainKHR
@@ -6387,6 +6586,12 @@ namespace VULKAN_HPP_NAMESPACE
       VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::detail::DeviceDispatcher const * m_dispatcher = nullptr;
     };
 
+    template <>
+    struct isVulkanRAIIHandleType<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::SwapchainKHR>
+    {
+      static VULKAN_HPP_CONST_OR_CONSTEXPR bool value = true;
+    };
+
     class SwapchainKHRs : public std::vector<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::SwapchainKHR>
     {
     public:
@@ -6413,6 +6618,57 @@ namespace VULKAN_HPP_NAMESPACE
         std::swap( *this, rhs );
       }
     };
+
+    // operators to compare vk::raii-handles
+#  if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
+    template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value, bool>::type = 0>
+    auto operator<=>( T const & a, T const & b ) VULKAN_HPP_NOEXCEPT
+    {
+      return *a <=> *b;
+    }
+#  else
+    template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value, bool>::type = 0>
+    bool operator==( T const & a, T const & b ) VULKAN_HPP_NOEXCEPT
+    {
+      return *a == *b;
+    }
+
+    template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value, bool>::type = 0>
+    bool operator!=( T const & a, T const & b ) VULKAN_HPP_NOEXCEPT
+    {
+      return *a != *b;
+    }
+
+    template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value, bool>::type = 0>
+    bool operator<( T const & a, T const & b ) VULKAN_HPP_NOEXCEPT
+    {
+      return *a < *b;
+    }
+#  endif
+
+    template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value, bool>::type = 0>
+    bool operator==( const T & v, std::nullptr_t ) VULKAN_HPP_NOEXCEPT
+    {
+      return !*v;
+    }
+
+    template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value, bool>::type = 0>
+    bool operator==( std::nullptr_t, const T & v ) VULKAN_HPP_NOEXCEPT
+    {
+      return !*v;
+    }
+
+    template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value, bool>::type = 0>
+    bool operator!=( const T & v, std::nullptr_t ) VULKAN_HPP_NOEXCEPT
+    {
+      return *v;
+    }
+
+    template <typename T, typename std::enable_if<VULKAN_HPP_NAMESPACE::VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType<T>::value, bool>::type = 0>
+    bool operator!=( std::nullptr_t, const T & v ) VULKAN_HPP_NOEXCEPT
+    {
+      return *v;
+    }
 
     //===========================
     //=== COMMAND Definitions ===


### PR DESCRIPTION
The comparison operators for vk-handles are not need, as due the implicit cast operators comparisons are passed on to the corresponding C-handle types.

Resolves #1996.