### PR TITLE
Export the C-type VkGeometryInstanceFlagsKHR in vulkan.cppm.

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -781,6 +781,10 @@ export namespace std
 {
   ${hashSpecializations}
 }
+
+// This VkFlags type is used as part of a bitfield in some structure.
+// As it that can't be mimiced by vk-data types, we need to export just that!!
+using VkGeometryInstanceFlagsKHR;
 )";
 
   auto const str = replaceWithMap( vulkanCppmTemplate,

--- a/vulkan/vulkan.cppm
+++ b/vulkan/vulkan.cppm
@@ -8246,3 +8246,7 @@ export namespace std
   struct hash<VULKAN_HPP_NAMESPACE::PhysicalDeviceVertexAttributeRobustnessFeaturesEXT>;
 
 }  // namespace std
+
+// This VkFlags type is used as part of a bitfield in some structure.
+// As it that can't be mimiced by vk-data types, we need to export just that!!
+using VkGeometryInstanceFlagsKHR;


### PR DESCRIPTION
This type is used as a bit field in some structures, which can't be mimiced by a vk-data type!