### PR TITLE
README: Fixing extension inspection typo and RAII-classes title format

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ Some functions might provide information that depends on the vulkan version. As 
 - `std::map<std::string, std::string> const & getDeprecatedExtensions();`
 	Gets a map of all deprecated extensions to the extension or vulkan version that is supposed to replace that functionality.
 - `std::map<std::string, std::vector<std::vector<std::string>>> const & getExtensionDepends( std::string const & extension );`
-	Some extensions depends on other extensions. That dependencies might differ for different vulkan versions, and there might be different sets of dependencies for the very same vulkan version. This function gets a vector of vectors of extensions per vulkan version that the given extension depends on.
+	Some extensions depend on other extensions. These dependencies might differ for different vulkan versions, and there might be different sets of dependencies for the very same vulkan version. This function gets a vector of vectors of extensions per vulkan version that the given extension depends on.
 - `std::pair<bool, std::vector<std::vector<std::string>> const &> getExtensionDepends( std::string const & version, std::string const & extension );`
 	The `first` member of the returned `std::pair` is true, if the given extension is specified for the given vulkan version, otherwise `false`. The `second` member of the returned `std::pair` is a vector of vectors of extensions, listing the separate sets of extensions the given extension depends on for the given vulkan version.
 - `std::map<std::string, std::string> const & getObsoletedExtensions();`

--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ protected:
 
 The API will be extended to provide creation functions in the future.
 
-## RAII-classes
+### RAII-classes
 
 In addition to `vk::UniqueHandles` and `vk::SharedHandles`, there's a set of wrapper classes for all the handle types that follow the RAII-paradigm (resource acquisition is initialization), provided in the `vk::raii` namespace.
 


### PR DESCRIPTION
It ain't much, but it's honest work