### PR TITLE
Export std::{tuple_size,tuple_element} for vk::StructureChain.

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -826,6 +826,11 @@ export namespace VULKAN_HPP_NAMESPACE
 export namespace std
 {
   ${hashSpecializations}
+
+#if !defined( VULKAN_HPP_DISABLE_ENHANCED_MODE )
+  using std::tuple_size;
+  using std::tuple_element;
+#endif
 }
 
 // This VkFlags type is used as part of a bitfield in some structure.


### PR DESCRIPTION
See [this compilation error reproducer](https://github.com/stripe2933/vk-structure-chain).

```
D:\a\vk-structure-chain\vk-structure-chain\main.cpp(15): error C3643: 'vk::StructureChain<vk::PhysicalDeviceProperties2,vk::PhysicalDeviceSubgroupProperties,vk::PhysicalDeviceDescriptorIndexingProperties>': cannot decompose type with non-static data-members in both 'std::tuple<vk::PhysicalDeviceProperties2,vk::PhysicalDeviceSubgroupProperties,vk::PhysicalDeviceDescriptorIndexingProperties>' and 'std::tuple<vk::PhysicalDeviceSubgroupProperties,vk::PhysicalDeviceDescriptorIndexingProperties>'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\include\tuple(829): note: see declaration of 'std::tuple<vk::PhysicalDeviceProperties2,vk::PhysicalDeviceSubgroupProperties,vk::PhysicalDeviceDescriptorIndexingProperties>::_Myfirst'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\include\tuple(829): note: see declaration of 'std::tuple<vk::PhysicalDeviceSubgroupProperties,vk::PhysicalDeviceDescriptorIndexingProperties>::_Myfirst'
D:\a\vk-structure-chain\vk-structure-chain\main.cpp(12): error C3448: the number of identifiers must match the number of array elements or members in a structured binding declaration
```

MSVC cannot decompose `vk::StructureChain<...>` with structured binding, since it inherits `std::tuple<...>` but `std::tuple_size` and `std::tuple_element` template specialization are not exported.

This PR fixes it by exporting them manually.