### PR TITLE
Make BreakBeforeConceptDeclarations a boolean for clang-format 14.

### DIFF
--- a/.clang-format_14
+++ b/.clang-format_14
@@ -44,7 +44,7 @@ BraceWrapping :
     SplitEmptyNamespace : true
 BreakBeforeBinaryOperators : None
 BreakBeforeBraces : Custom
-BreakBeforeConceptDeclarations : Always
+BreakBeforeConceptDeclarations : true		# This flag seems to be a boolean with clang-format 14 ?!?
 BreakBeforeTernaryOperators : true
 BreakConstructorInitializers : BeforeComma
 BreakInheritanceList : BeforeComma


### PR DESCRIPTION
Resolves #2065.