### PR TITLE
CMake: Offer multiple choices for Vulkan C headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,10 +219,10 @@ endif()
 # Get Vulkan C headers from subdirectory, existing target or FindVulkan
 if ( EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Vulkan-Headers/include" AND IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/Vulkan-Headers/include")
 	target_include_directories( VulkanHpp INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/Vulkan-Headers/include" )
-elseif ( TARGET Vulkan::Headers )
-	target_link_libraries( VulkanHpp INTERFACE Vulkan::Headers )
 else()
-	find_package( Vulkan REQUIRED )
+	if ( NOT TARGET Vulkan::Headers )
+		find_package( Vulkan REQUIRED )
+	endif()
 	target_link_libraries( VulkanHpp INTERFACE Vulkan::Headers )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,9 +213,17 @@ endif()
 add_library( VulkanHpp INTERFACE )
 add_library( Vulkan::Hpp ALIAS VulkanHpp )
 target_include_directories( VulkanHpp INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}" )
-target_include_directories( VulkanHpp INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/Vulkan-Headers/include" )
 if( VULKAN_HPP_RUN_GENERATOR )
 	add_dependencies( VulkanHpp build_vulkan_hpp build_video_hpp )
+endif()
+# Get Vulkan C headers from subdirectory, existing target or FindVulkan
+if ( EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Vulkan-Headers/include" AND IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/Vulkan-Headers/include")
+	target_include_directories( VulkanHpp INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/Vulkan-Headers/include" )
+elseif ( TARGET Vulkan::Headers )
+	target_link_libraries( VulkanHpp INTERFACE Vulkan::Headers )
+else()
+	find_package( Vulkan REQUIRED )
+	target_link_libraries( VulkanHpp INTERFACE Vulkan::Headers )
 endif()
 
 # set up compile definitions


### PR DESCRIPTION
Using following priority to determine where to get the C headers:

1. `Vulkan-Headers` subdirectory, if submodule is pulled
2. `Vulkan::Headers` target, if present (e.g. via `FindVulkan` or `add_subdirectory`)
3. `Vulkan::Headers` target, requiring `FindVulkan`