### PR TITLE
C++20 module: Hide to_string behind VULKAN_HPP_NO_TO_STRING

### DIFF
--- a/snippets/CppModuleFileTemplate.hpp
+++ b/snippets/CppModuleFileTemplate.hpp
@@ -18,7 +18,7 @@ module;
 #include <vulkan/${api}_raii.hpp>
 #include <vulkan/${api}_shared.hpp>
 #ifndef VULKAN_HPP_NO_TO_STRING
-#  include <vulkan/${api}_to_string.hpp>
+#include <vulkan/${api}_to_string.hpp>
 #endif
 
 export module ${api}_hpp;

--- a/snippets/CppModuleFileTemplate.hpp
+++ b/snippets/CppModuleFileTemplate.hpp
@@ -17,7 +17,9 @@ module;
 #include <vulkan/${api}_hash.hpp>
 #include <vulkan/${api}_raii.hpp>
 #include <vulkan/${api}_shared.hpp>
-#include <vulkan/${api}_to_string.hpp>
+#ifndef VULKAN_HPP_NO_TO_STRING
+#  include <vulkan/${api}_to_string.hpp>
+#endif
 
 export module ${api}_hpp;
 

--- a/vulkan/vulkan.cppm
+++ b/vulkan/vulkan.cppm
@@ -22,7 +22,9 @@ module;
 #include <vulkan/vulkan_hash.hpp>
 #include <vulkan/vulkan_raii.hpp>
 #include <vulkan/vulkan_shared.hpp>
-#include <vulkan/vulkan_to_string.hpp>
+#ifndef VULKAN_HPP_NO_TO_STRING
+#  include <vulkan/vulkan_to_string.hpp>
+#endif
 
 export module vulkan_hpp;
 


### PR DESCRIPTION
Resolves #2076