### PR TITLE
Suppress clang warning `-Wcast-function-type` for shared destroy

### DIFF
--- a/snippets/SharedDestroy.hpp
+++ b/snippets/SharedDestroy.hpp
@@ -3,7 +3,7 @@
 #if defined( __GNUC__ ) && !defined( __clang__ ) && !defined( __INTEL_COMPILER )
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wcast-function-type"
-#elif defined( __clang__ ) && !defined( __INTEL_COMPILER )
+#elif defined( __clang__ ) && (__clang_major__ >= 13) && !defined( __INTEL_COMPILER )
 #  pragma clang diagnostic push
 #  pragma clang diagnostic ignored "-Wcast-function-type"
 #endif

--- a/snippets/SharedDestroy.hpp
+++ b/snippets/SharedDestroy.hpp
@@ -3,6 +3,9 @@
 #if defined( __GNUC__ ) && !defined( __clang__ ) && !defined( __INTEL_COMPILER )
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wcast-function-type"
+#elif defined( __clang__ ) && !defined( __INTEL_COMPILER )
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
 #endif
 
 template <typename HandleType>
@@ -146,4 +149,6 @@ private:
 
 #if defined( __GNUC__ ) && !defined( __clang__ ) && !defined( __INTEL_COMPILER )
 #  pragma GCC diagnostic pop
+#elif defined( __clang__ ) && !defined( __INTEL_COMPILER )
+#  pragma clang diagnostic pop
 #endif

--- a/snippets/SharedDestroy.hpp
+++ b/snippets/SharedDestroy.hpp
@@ -149,6 +149,6 @@ private:
 
 #if defined( __GNUC__ ) && !defined( __clang__ ) && !defined( __INTEL_COMPILER )
 #  pragma GCC diagnostic pop
-#elif defined( __clang__ ) && !defined( __INTEL_COMPILER )
+#elif defined( __clang__ ) && (__clang_major__ >= 13) && !defined( __INTEL_COMPILER )
 #  pragma clang diagnostic pop
 #endif

--- a/snippets/SharedDestroy.hpp
+++ b/snippets/SharedDestroy.hpp
@@ -5,7 +5,7 @@
 #  pragma GCC diagnostic ignored "-Wcast-function-type"
 #elif defined( __clang__ ) && !defined( __INTEL_COMPILER )
 #  pragma clang diagnostic push
-#  pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
+#  pragma clang diagnostic ignored "-Wcast-function-type"
 #endif
 
 template <typename HandleType>

--- a/vulkan/vulkan_shared.hpp
+++ b/vulkan/vulkan_shared.hpp
@@ -462,7 +462,7 @@ namespace VULKAN_HPP_NAMESPACE
 
 #  if defined( __GNUC__ ) && !defined( __clang__ ) && !defined( __INTEL_COMPILER )
 #    pragma GCC diagnostic pop
-#  elif defined( __clang__ ) && !defined( __INTEL_COMPILER )
+#  elif defined( __clang__ ) && ( __clang_major__ >= 13 ) && !defined( __INTEL_COMPILER )
 #    pragma clang diagnostic pop
 #  endif
 

--- a/vulkan/vulkan_shared.hpp
+++ b/vulkan/vulkan_shared.hpp
@@ -315,6 +315,9 @@ namespace VULKAN_HPP_NAMESPACE
 #  if defined( __GNUC__ ) && !defined( __clang__ ) && !defined( __INTEL_COMPILER )
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wcast-function-type"
+#  elif defined( __clang__ ) && !defined( __INTEL_COMPILER )
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
 #  endif
 
     template <typename HandleType>
@@ -459,6 +462,8 @@ namespace VULKAN_HPP_NAMESPACE
 
 #  if defined( __GNUC__ ) && !defined( __clang__ ) && !defined( __INTEL_COMPILER )
 #    pragma GCC diagnostic pop
+#  elif defined( __clang__ ) && !defined( __INTEL_COMPILER )
+#    pragma clang diagnostic pop
 #  endif
 
   }  // namespace detail

--- a/vulkan/vulkan_shared.hpp
+++ b/vulkan/vulkan_shared.hpp
@@ -317,7 +317,7 @@ namespace VULKAN_HPP_NAMESPACE
 #    pragma GCC diagnostic ignored "-Wcast-function-type"
 #  elif defined( __clang__ ) && !defined( __INTEL_COMPILER )
 #    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
+#    pragma clang diagnostic ignored "-Wcast-function-type"
 #  endif
 
     template <typename HandleType>

--- a/vulkan/vulkan_shared.hpp
+++ b/vulkan/vulkan_shared.hpp
@@ -315,7 +315,7 @@ namespace VULKAN_HPP_NAMESPACE
 #  if defined( __GNUC__ ) && !defined( __clang__ ) && !defined( __INTEL_COMPILER )
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wcast-function-type"
-#  elif defined( __clang__ ) && !defined( __INTEL_COMPILER )
+#  elif defined( __clang__ ) && ( __clang_major__ >= 13 ) && !defined( __INTEL_COMPILER )
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wcast-function-type"
 #  endif


### PR DESCRIPTION
Clang 19.1.7 throws warnings due to the reinterpret cast to `m_destroy`.

Suppression implemented akin to the GCC one.
Used `defined( __clang__ ) && !defined( __INTEL_COMPILER )` without `!defined( __GNUC__ )`, as clang defines it to signify compatible GCC versions.

Also checking clang major version via `(__clang_major__ >= 13)`, as 13 is where the `-Wcast-function-type` was first introduced.