### PR TITLE
CI: Attempt to fix build failure on windows

### DIFF
--- a/XMLHelper.hpp
+++ b/XMLHelper.hpp
@@ -559,11 +559,11 @@ inline std::string trimStars( std::string const & input )
 
 void writeToFile( std::string const & str, std::string const & fileName )
 {
-  std::ofstream ofs( fileName );
-  assert( !ofs.fail() );
-  ofs << str;
-  ofs.flush();
-  ofs.close();
+  {
+    std::ofstream ofs( fileName );
+    assert( !ofs.fail() );
+    ofs << str;
+  }
 
 #if defined( CLANG_FORMAT_EXECUTABLE )
   messager.message( "VulkanHppGenerator: Formatting " + fileName + " ...\n" );

--- a/XMLHelper.hpp
+++ b/XMLHelper.hpp
@@ -562,6 +562,7 @@ void writeToFile( std::string const & str, std::string const & fileName )
   std::ofstream ofs( fileName );
   assert( !ofs.fail() );
   ofs << str;
+  ofs.flush();
   ofs.close();
 
 #if defined( CLANG_FORMAT_EXECUTABLE )


### PR DESCRIPTION
Window CI sometimes fails due to "permission errors":

<details>
<summary>Output</summary>

```batch
run VulkanHppGenerator
  clang-format version 18.1.8
  VulkanHppGenerator: Found VulkanHppGenerator: Loading D:\a\Vulkan-Hpp\Vulkan-Hpp\Vulkan-Headers\registry\vk.xml
  VulkanHppGenerator: Parsing D:\a\Vulkan-Hpp\Vulkan-Hpp\Vulkan-Headers\registry\vk.xml
  VulkanHppGenerator: Spec warning on line 642: enum <VkDeviceCreateFlagBits> not required in any feature or extension!
  VulkanHppGenerator: Spec warning on line 798: enum <VkImageFormatConstraintsFlagBitsFUCHSIA> not required in any feature or extension!
  VulkanHppGenerator: Spec warning on line 621: enum <VkQueryPoolCreateFlagBits> not required in any feature or extension!
  VulkanHppGenerator: Spec warning on line 700: enum <VkSemaphoreCreateFlagBits> not required in any feature or extension!
  VulkanHppGenerator: Spec warning on line 777: enum <VkShaderModuleCreateFlagBits> not required in any feature or extension!
CUSTOMBUILD : clang-format error : unable to overwrite file D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan.cppm: permission denied [D:\a\Vulkan-Hpp\Vulkan-Hpp\build\11\Debug\build_vulkan_hpp.vcxproj]
  VulkanHppGenerator: Generating D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan.cppm ...
  VulkanHppGenerator: Generating D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan.hpp ...
  VulkanHppGenerator: Generating D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_enums.hpp ...
  VulkanHppGenerator: Generating D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_extension_inspection.hpp ...
  VulkanHppGenerator: Formatting D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_extension_inspection.hpp ...
  VulkanHppGenerator: Generating D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_format_traits.hpp ...
  VulkanHppGenerator: Generating D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_funcs.hpp ...
  VulkanHppGenerator: Generating D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_handles.hpp ...
  VulkanHppGenerator: Generating D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_hash.hpp ...
  VulkanHppGenerator: Generating D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_hpp_macros.hpp ...
  VulkanHppGenerator: Formatting D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_hpp_macros.hpp ...
  VulkanHppGenerator: Generating D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_shared.hpp ...
  VulkanHppGenerator: Generating D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_static_assertions.hpp ...
  VulkanHppGenerator: Formatting D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_shared.hpp ...
  VulkanHppGenerator: Generating D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_structs.hpp ...
  VulkanHppGenerator: Generating D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_to_string.hpp ...
  VulkanHppGenerator: Formatting D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_format_traits.hpp ...
  VulkanHppGenerator: Formatting D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan.hpp ...
  VulkanHppGenerator: Formatting D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan.cppm ...
  VulkanHppGenerator: Formatting D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_enums.hpp ...
  VulkanHppGenerator: Formatting D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_hash.hpp ...
  VulkanHppGenerator: Formatting D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_static_assertions.hpp ...
  VulkanHppGenerator: Formatting D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_to_string.hpp ...
  VulkanHppGenerator: Formatting D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_handles.hpp ...
  VulkanHppGenerator: Formatting D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_funcs.hpp ...
  VulkanHppGenerator: Formatting D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_structs.hpp ...
  VulkanHppGenerator: Generating D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_raii.hpp ...
  VulkanHppGenerator: Formatting D:/a/Vulkan-Hpp/Vulkan-Hpp/vulkan/vulkan_raii.hpp ...
  Building Custom Rule D:/a/Vulkan-Hpp/Vulkan-Hpp/CMakeLists.txt
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(254,5): error MSB8066: Custom build for 'D:\a\Vulkan-Hpp\Vulkan-Hpp\build\11\Debug\CMakeFiles\b72a330e21ee03dd2afda6fc8f956936\vulkan.hpp.rule;D:\a\Vulkan-Hpp\Vulkan-Hpp\build\11\Debug\CMakeFiles\50308fb54619814b0b89830c2dc6d[167](https://github.com/KhronosGroup/Vulkan-Hpp/actions/runs/13414491313/job/37471943457#step:4:168)\build_vulkan_hpp.rule;D:\a\Vulkan-Hpp\Vulkan-Hpp\CMakeLists.txt' exited with code -1. [D:\a\Vulkan-Hpp\Vulkan-Hpp\build\11\Debug\build_vulkan_hpp.vcxproj]
Error: Process completed with exit code 1.
```

</details>

I've encountered this sort of error in other projects on windows when trying to write to still opened files. The only place in the generator code where this error can occur is in the `writeToFile` function, specifically after closing the `ofstream` and trying to write to the newly created file via `clangd-format`:

https://github.com/KhronosGroup/Vulkan-Hpp/blob/8ab6cb5d8b60abc610b8c8758b3d5947cd0af8b0/XMLHelper.hpp#L560-L576

Normally, I would _expect_ `ofs.close()` to flush the stream, but as it never explicitly calls `flush()` internally, I've added it manually. Let's see if it actually helps..