### PR TITLE
C++Module: Fix export of `VkGeometryInstanceFlagsKHR` symbol

### DIFF
--- a/snippets/CppModuleFileTemplate.hpp
+++ b/snippets/CppModuleFileTemplate.hpp
@@ -50,5 +50,5 @@ export namespace std
 }
 
 // This VkFlags type is used as part of a bitfield in some structure.
-// As it that can't be mimiced by vk-data types, we need to export just that!!
-export VkGeometryInstanceFlagsKHR;
+// As it can't be mimicked by vk-data types, we need to export just that!!
+export using ::VkGeometryInstanceFlagsKHR;

--- a/vulkan/vulkan.cppm
+++ b/vulkan/vulkan.cppm
@@ -8496,5 +8496,5 @@ export namespace std
 }  // namespace std
 
 // This VkFlags type is used as part of a bitfield in some structure.
-// As it that can't be mimiced by vk-data types, we need to export just that!!
-export VkGeometryInstanceFlagsKHR;
+// As it can't be mimicked by vk-data types, we need to export just that!!
+export using ::VkGeometryInstanceFlagsKHR;


### PR DESCRIPTION
Previously, the `VkGeometryInstanceFlagsKHR` symbol was exported like this:

```cpp
export VkGeometryInstanceFlagsKHR;
```

but as this does not declare anything, compilers will complain (clang warning, gcc error):

```
vulkan/vulkan.cppm:8490:8: warning: declaration does not declare anything [-Wmissing-declarations]
 8490 | export VkGeometryInstanceFlagsKHR;
```

and, based on the comment, I assume the symbol was meant to be exported like this into global namespace:

```cpp
export using ::VkGeometryInstanceFlagsKHR;
```