### PR TITLE
CI: Another attempt to fix windows ci..

### DIFF
--- a/XMLHelper.hpp
+++ b/XMLHelper.hpp
@@ -559,13 +559,15 @@ inline std::string trimStars( std::string const & input )
 
 void writeToFile( std::string const & str, std::string const & fileName )
 {
-  {
-    std::ofstream ofs( fileName );
-    assert( !ofs.fail() );
-    ofs << str;
-  }
+  std::ofstream ofs( fileName );
+  assert( !ofs.fail() );
+  ofs << str;
+  ofs.close();
 
 #if defined( CLANG_FORMAT_EXECUTABLE )
+  // explicitly flush std::cout, as std::system spawns a sub-process
+  std::cout.flush();
+
   messager.message( "VulkanHppGenerator: Formatting " + fileName + " ...\n" );
   const std::string commandString = "\"" CLANG_FORMAT_EXECUTABLE "\" -i --style=file " + fileName;
   const int         ret           = std::system( commandString.c_str() );


### PR DESCRIPTION
Seeing how it failed again, I dug a bit deeper into what could cause it.

Flushing the `std::ofstream` seems to only guarantee synchronization for the current application. The OS has to decide what to actually do, where Windows seems to have some trouble, as we spawn a separate process with `std::system`.

From what I found, there are two solutions, one being a hacky one that someone suggested on SO:
https://stackoverflow.com/a/9667875
which essentially just opens a new stream, which seems to force windows to actually finalize the write to disk.

There might be a better solution though, looking at the spec of `std::system` itself:
https://en.cppreference.com/w/cpp/utility/program/system
> _An explicit flush of [std::cout](https://en.cppreference.com/w/cpp/io/cout) is also necessary before a call to std::system, if the spawned process performs any screen I/O._

Talk about fine print..
Anyways, I've reverted the `ofs` to what it was before, but added a `std::cout.flush()` right before we do the clangd-formatting step. If this doesn't work, the reopening of the ofs in append mode or a separate std::ifstream seems like a good solution.