### PR TITLE
Add additional type conversion operators to the struct classes to make it easier to interoperate with the Vulkan C API

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -11983,9 +11983,14 @@ ${constructorsAndSetters}
       return *reinterpret_cast<Vk${structureType}*>( this );
     }
 
-    operator Vk${structureType} const 8() VULKAN_HPP_NOEXCEPT
+    operator Vk${structureType} const *() const VULKAN_HPP_NOEXCEPT
     {
-      return reinterpret_cast<Vk${structureType} const *>( this );
+      return reinterpret_cast<const Vk${structureType}*>( this );
+    }
+
+    operator Vk${structureType} *() VULKAN_HPP_NOEXCEPT
+    {
+      return reinterpret_cast<Vk${structureType}*>( this );
     }
 ${reflect}
 ${compareOperators}

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -11982,6 +11982,11 @@ ${constructorsAndSetters}
     {
       return *reinterpret_cast<Vk${structureType}*>( this );
     }
+
+    operator Vk${structureType} const 8() VULKAN_HPP_NOEXCEPT
+    {
+      return reinterpret_cast<Vk${structureType} const *>( this );
+    }
 ${reflect}
 ${compareOperators}
     public:


### PR DESCRIPTION
These new operators allow the Vulkan-Hpp struct classes to be more easily used directly with the Vulkan C API.

For example, instead of this:
```c++
vk::BufferCreateInfo bufferInfo { .size{sizeof vertexData}, .usage{vk::BufferUsageFlagBits::eVertexBuffer} };
vmaCreateBuffer(allocator, &static_cast<VkBufferCreateInfo const &>(bufferInfo), &bufferAllocationInfo, &vertexBuffer, &vertexBufferAllocation, nullptr);
```

Apps can do this:
```c++
vk::BufferCreateInfo bufferInfo { .size{sizeof vertexData}, .usage{vk::BufferUsageFlagBits::eVertexBuffer} };
vmaCreateBuffer(allocator, bufferInfo, &bufferAllocationInfo, &vertexBuffer, &vertexBufferAllocation, nullptr);
```
