### PR TITLE
Optimize `to_string` functions for enums

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -2586,12 +2586,13 @@ std::string VulkanHppGenerator::generateBitmaskToString( std::map<std::string, B
     static const std::string bitmaskToStringTemplate = R"(
   VULKAN_HPP_INLINE std::string to_string( ${bitmaskName} value )
   {
-    if ( !value )
-      return "${emptyValue}";
-
-    std::string result;
+    std::string result = "{";
 ${toStringChecks}
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else 
+      result = "${emptyValue}";
+    return result;
   }
 )";
 
@@ -2612,7 +2613,7 @@ ${toStringChecks}
         {
           const auto [enter, leave] = generateProtection( value.protect );
           toStringChecks += ( ( previousEnter != enter ) ? ( previousLeave + enter ) : "" ) + "    if ( value & " + enumName + "::" + valueName +
-                            " ) result += \"" + valueName.substr( 1 ) + " | \";\n";
+                            " ) result += \" " + valueName.substr( 1 ) + " |\";\n";
           previousEnter = enter;
           previousLeave = leave;
         }

--- a/vulkan/vulkan_to_string.hpp
+++ b/vulkan/vulkan_to_string.hpp
@@ -3942,15 +3942,9 @@ namespace VULKAN_HPP_NAMESPACE
 
   //=== VK_KHR_maintenance8 ===
 
-  VULKAN_HPP_INLINE std::string to_string( AccessFlags3KHR value )
+  VULKAN_HPP_INLINE std::string to_string( AccessFlags3KHR )
   {
-    std::string result = "{";
-
-    if ( result.size() > 1 )
-      result.back() = '}';
-    else
-      result = "None";
-    return result;
+    return "None";
   }
 
   //=======================

--- a/vulkan/vulkan_to_string.hpp
+++ b/vulkan/vulkan_to_string.hpp
@@ -40,284 +40,292 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( FormatFeatureFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & FormatFeatureFlagBits::eSampledImage )
-      result += "SampledImage | ";
+      result += " SampledImage |";
     if ( value & FormatFeatureFlagBits::eStorageImage )
-      result += "StorageImage | ";
+      result += " StorageImage |";
     if ( value & FormatFeatureFlagBits::eStorageImageAtomic )
-      result += "StorageImageAtomic | ";
+      result += " StorageImageAtomic |";
     if ( value & FormatFeatureFlagBits::eUniformTexelBuffer )
-      result += "UniformTexelBuffer | ";
+      result += " UniformTexelBuffer |";
     if ( value & FormatFeatureFlagBits::eStorageTexelBuffer )
-      result += "StorageTexelBuffer | ";
+      result += " StorageTexelBuffer |";
     if ( value & FormatFeatureFlagBits::eStorageTexelBufferAtomic )
-      result += "StorageTexelBufferAtomic | ";
+      result += " StorageTexelBufferAtomic |";
     if ( value & FormatFeatureFlagBits::eVertexBuffer )
-      result += "VertexBuffer | ";
+      result += " VertexBuffer |";
     if ( value & FormatFeatureFlagBits::eColorAttachment )
-      result += "ColorAttachment | ";
+      result += " ColorAttachment |";
     if ( value & FormatFeatureFlagBits::eColorAttachmentBlend )
-      result += "ColorAttachmentBlend | ";
+      result += " ColorAttachmentBlend |";
     if ( value & FormatFeatureFlagBits::eDepthStencilAttachment )
-      result += "DepthStencilAttachment | ";
+      result += " DepthStencilAttachment |";
     if ( value & FormatFeatureFlagBits::eBlitSrc )
-      result += "BlitSrc | ";
+      result += " BlitSrc |";
     if ( value & FormatFeatureFlagBits::eBlitDst )
-      result += "BlitDst | ";
+      result += " BlitDst |";
     if ( value & FormatFeatureFlagBits::eSampledImageFilterLinear )
-      result += "SampledImageFilterLinear | ";
+      result += " SampledImageFilterLinear |";
     if ( value & FormatFeatureFlagBits::eTransferSrc )
-      result += "TransferSrc | ";
+      result += " TransferSrc |";
     if ( value & FormatFeatureFlagBits::eTransferDst )
-      result += "TransferDst | ";
+      result += " TransferDst |";
     if ( value & FormatFeatureFlagBits::eMidpointChromaSamples )
-      result += "MidpointChromaSamples | ";
+      result += " MidpointChromaSamples |";
     if ( value & FormatFeatureFlagBits::eSampledImageYcbcrConversionLinearFilter )
-      result += "SampledImageYcbcrConversionLinearFilter | ";
+      result += " SampledImageYcbcrConversionLinearFilter |";
     if ( value & FormatFeatureFlagBits::eSampledImageYcbcrConversionSeparateReconstructionFilter )
-      result += "SampledImageYcbcrConversionSeparateReconstructionFilter | ";
+      result += " SampledImageYcbcrConversionSeparateReconstructionFilter |";
     if ( value & FormatFeatureFlagBits::eSampledImageYcbcrConversionChromaReconstructionExplicit )
-      result += "SampledImageYcbcrConversionChromaReconstructionExplicit | ";
+      result += " SampledImageYcbcrConversionChromaReconstructionExplicit |";
     if ( value & FormatFeatureFlagBits::eSampledImageYcbcrConversionChromaReconstructionExplicitForceable )
-      result += "SampledImageYcbcrConversionChromaReconstructionExplicitForceable | ";
+      result += " SampledImageYcbcrConversionChromaReconstructionExplicitForceable |";
     if ( value & FormatFeatureFlagBits::eDisjoint )
-      result += "Disjoint | ";
+      result += " Disjoint |";
     if ( value & FormatFeatureFlagBits::eCositedChromaSamples )
-      result += "CositedChromaSamples | ";
+      result += " CositedChromaSamples |";
     if ( value & FormatFeatureFlagBits::eSampledImageFilterMinmax )
-      result += "SampledImageFilterMinmax | ";
+      result += " SampledImageFilterMinmax |";
     if ( value & FormatFeatureFlagBits::eVideoDecodeOutputKHR )
-      result += "VideoDecodeOutputKHR | ";
+      result += " VideoDecodeOutputKHR |";
     if ( value & FormatFeatureFlagBits::eVideoDecodeDpbKHR )
-      result += "VideoDecodeDpbKHR | ";
+      result += " VideoDecodeDpbKHR |";
     if ( value & FormatFeatureFlagBits::eAccelerationStructureVertexBufferKHR )
-      result += "AccelerationStructureVertexBufferKHR | ";
+      result += " AccelerationStructureVertexBufferKHR |";
     if ( value & FormatFeatureFlagBits::eSampledImageFilterCubicEXT )
-      result += "SampledImageFilterCubicEXT | ";
+      result += " SampledImageFilterCubicEXT |";
     if ( value & FormatFeatureFlagBits::eFragmentDensityMapEXT )
-      result += "FragmentDensityMapEXT | ";
+      result += " FragmentDensityMapEXT |";
     if ( value & FormatFeatureFlagBits::eFragmentShadingRateAttachmentKHR )
-      result += "FragmentShadingRateAttachmentKHR | ";
+      result += " FragmentShadingRateAttachmentKHR |";
     if ( value & FormatFeatureFlagBits::eVideoEncodeInputKHR )
-      result += "VideoEncodeInputKHR | ";
+      result += " VideoEncodeInputKHR |";
     if ( value & FormatFeatureFlagBits::eVideoEncodeDpbKHR )
-      result += "VideoEncodeDpbKHR | ";
+      result += " VideoEncodeDpbKHR |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( ImageCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ImageCreateFlagBits::eSparseBinding )
-      result += "SparseBinding | ";
+      result += " SparseBinding |";
     if ( value & ImageCreateFlagBits::eSparseResidency )
-      result += "SparseResidency | ";
+      result += " SparseResidency |";
     if ( value & ImageCreateFlagBits::eSparseAliased )
-      result += "SparseAliased | ";
+      result += " SparseAliased |";
     if ( value & ImageCreateFlagBits::eMutableFormat )
-      result += "MutableFormat | ";
+      result += " MutableFormat |";
     if ( value & ImageCreateFlagBits::eCubeCompatible )
-      result += "CubeCompatible | ";
+      result += " CubeCompatible |";
     if ( value & ImageCreateFlagBits::eAlias )
-      result += "Alias | ";
+      result += " Alias |";
     if ( value & ImageCreateFlagBits::eSplitInstanceBindRegions )
-      result += "SplitInstanceBindRegions | ";
+      result += " SplitInstanceBindRegions |";
     if ( value & ImageCreateFlagBits::e2DArrayCompatible )
-      result += "2DArrayCompatible | ";
+      result += " 2DArrayCompatible |";
     if ( value & ImageCreateFlagBits::eBlockTexelViewCompatible )
-      result += "BlockTexelViewCompatible | ";
+      result += " BlockTexelViewCompatible |";
     if ( value & ImageCreateFlagBits::eExtendedUsage )
-      result += "ExtendedUsage | ";
+      result += " ExtendedUsage |";
     if ( value & ImageCreateFlagBits::eProtected )
-      result += "Protected | ";
+      result += " Protected |";
     if ( value & ImageCreateFlagBits::eDisjoint )
-      result += "Disjoint | ";
+      result += " Disjoint |";
     if ( value & ImageCreateFlagBits::eCornerSampledNV )
-      result += "CornerSampledNV | ";
+      result += " CornerSampledNV |";
     if ( value & ImageCreateFlagBits::eSampleLocationsCompatibleDepthEXT )
-      result += "SampleLocationsCompatibleDepthEXT | ";
+      result += " SampleLocationsCompatibleDepthEXT |";
     if ( value & ImageCreateFlagBits::eSubsampledEXT )
-      result += "SubsampledEXT | ";
+      result += " SubsampledEXT |";
     if ( value & ImageCreateFlagBits::eDescriptorBufferCaptureReplayEXT )
-      result += "DescriptorBufferCaptureReplayEXT | ";
+      result += " DescriptorBufferCaptureReplayEXT |";
     if ( value & ImageCreateFlagBits::eMultisampledRenderToSingleSampledEXT )
-      result += "MultisampledRenderToSingleSampledEXT | ";
+      result += " MultisampledRenderToSingleSampledEXT |";
     if ( value & ImageCreateFlagBits::e2DViewCompatibleEXT )
-      result += "2DViewCompatibleEXT | ";
+      result += " 2DViewCompatibleEXT |";
     if ( value & ImageCreateFlagBits::eFragmentDensityMapOffsetQCOM )
-      result += "FragmentDensityMapOffsetQCOM | ";
+      result += " FragmentDensityMapOffsetQCOM |";
     if ( value & ImageCreateFlagBits::eVideoProfileIndependentKHR )
-      result += "VideoProfileIndependentKHR | ";
+      result += " VideoProfileIndependentKHR |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( ImageUsageFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ImageUsageFlagBits::eTransferSrc )
-      result += "TransferSrc | ";
+      result += " TransferSrc |";
     if ( value & ImageUsageFlagBits::eTransferDst )
-      result += "TransferDst | ";
+      result += " TransferDst |";
     if ( value & ImageUsageFlagBits::eSampled )
-      result += "Sampled | ";
+      result += " Sampled |";
     if ( value & ImageUsageFlagBits::eStorage )
-      result += "Storage | ";
+      result += " Storage |";
     if ( value & ImageUsageFlagBits::eColorAttachment )
-      result += "ColorAttachment | ";
+      result += " ColorAttachment |";
     if ( value & ImageUsageFlagBits::eDepthStencilAttachment )
-      result += "DepthStencilAttachment | ";
+      result += " DepthStencilAttachment |";
     if ( value & ImageUsageFlagBits::eTransientAttachment )
-      result += "TransientAttachment | ";
+      result += " TransientAttachment |";
     if ( value & ImageUsageFlagBits::eInputAttachment )
-      result += "InputAttachment | ";
+      result += " InputAttachment |";
     if ( value & ImageUsageFlagBits::eHostTransfer )
-      result += "HostTransfer | ";
+      result += " HostTransfer |";
     if ( value & ImageUsageFlagBits::eVideoDecodeDstKHR )
-      result += "VideoDecodeDstKHR | ";
+      result += " VideoDecodeDstKHR |";
     if ( value & ImageUsageFlagBits::eVideoDecodeSrcKHR )
-      result += "VideoDecodeSrcKHR | ";
+      result += " VideoDecodeSrcKHR |";
     if ( value & ImageUsageFlagBits::eVideoDecodeDpbKHR )
-      result += "VideoDecodeDpbKHR | ";
+      result += " VideoDecodeDpbKHR |";
     if ( value & ImageUsageFlagBits::eFragmentDensityMapEXT )
-      result += "FragmentDensityMapEXT | ";
+      result += " FragmentDensityMapEXT |";
     if ( value & ImageUsageFlagBits::eFragmentShadingRateAttachmentKHR )
-      result += "FragmentShadingRateAttachmentKHR | ";
+      result += " FragmentShadingRateAttachmentKHR |";
     if ( value & ImageUsageFlagBits::eVideoEncodeDstKHR )
-      result += "VideoEncodeDstKHR | ";
+      result += " VideoEncodeDstKHR |";
     if ( value & ImageUsageFlagBits::eVideoEncodeSrcKHR )
-      result += "VideoEncodeSrcKHR | ";
+      result += " VideoEncodeSrcKHR |";
     if ( value & ImageUsageFlagBits::eVideoEncodeDpbKHR )
-      result += "VideoEncodeDpbKHR | ";
+      result += " VideoEncodeDpbKHR |";
     if ( value & ImageUsageFlagBits::eAttachmentFeedbackLoopEXT )
-      result += "AttachmentFeedbackLoopEXT | ";
+      result += " AttachmentFeedbackLoopEXT |";
     if ( value & ImageUsageFlagBits::eInvocationMaskHUAWEI )
-      result += "InvocationMaskHUAWEI | ";
+      result += " InvocationMaskHUAWEI |";
     if ( value & ImageUsageFlagBits::eSampleWeightQCOM )
-      result += "SampleWeightQCOM | ";
+      result += " SampleWeightQCOM |";
     if ( value & ImageUsageFlagBits::eSampleBlockMatchQCOM )
-      result += "SampleBlockMatchQCOM | ";
+      result += " SampleBlockMatchQCOM |";
     if ( value & ImageUsageFlagBits::eVideoEncodeQuantizationDeltaMapKHR )
-      result += "VideoEncodeQuantizationDeltaMapKHR | ";
+      result += " VideoEncodeQuantizationDeltaMapKHR |";
     if ( value & ImageUsageFlagBits::eVideoEncodeEmphasisMapKHR )
-      result += "VideoEncodeEmphasisMapKHR | ";
+      result += " VideoEncodeEmphasisMapKHR |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( InstanceCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & InstanceCreateFlagBits::eEnumeratePortabilityKHR )
-      result += "EnumeratePortabilityKHR | ";
+      result += " EnumeratePortabilityKHR |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( MemoryHeapFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & MemoryHeapFlagBits::eDeviceLocal )
-      result += "DeviceLocal | ";
+      result += " DeviceLocal |";
     if ( value & MemoryHeapFlagBits::eMultiInstance )
-      result += "MultiInstance | ";
+      result += " MultiInstance |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( MemoryPropertyFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & MemoryPropertyFlagBits::eDeviceLocal )
-      result += "DeviceLocal | ";
+      result += " DeviceLocal |";
     if ( value & MemoryPropertyFlagBits::eHostVisible )
-      result += "HostVisible | ";
+      result += " HostVisible |";
     if ( value & MemoryPropertyFlagBits::eHostCoherent )
-      result += "HostCoherent | ";
+      result += " HostCoherent |";
     if ( value & MemoryPropertyFlagBits::eHostCached )
-      result += "HostCached | ";
+      result += " HostCached |";
     if ( value & MemoryPropertyFlagBits::eLazilyAllocated )
-      result += "LazilyAllocated | ";
+      result += " LazilyAllocated |";
     if ( value & MemoryPropertyFlagBits::eProtected )
-      result += "Protected | ";
+      result += " Protected |";
     if ( value & MemoryPropertyFlagBits::eDeviceCoherentAMD )
-      result += "DeviceCoherentAMD | ";
+      result += " DeviceCoherentAMD |";
     if ( value & MemoryPropertyFlagBits::eDeviceUncachedAMD )
-      result += "DeviceUncachedAMD | ";
+      result += " DeviceUncachedAMD |";
     if ( value & MemoryPropertyFlagBits::eRdmaCapableNV )
-      result += "RdmaCapableNV | ";
+      result += " RdmaCapableNV |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( QueueFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & QueueFlagBits::eGraphics )
-      result += "Graphics | ";
+      result += " Graphics |";
     if ( value & QueueFlagBits::eCompute )
-      result += "Compute | ";
+      result += " Compute |";
     if ( value & QueueFlagBits::eTransfer )
-      result += "Transfer | ";
+      result += " Transfer |";
     if ( value & QueueFlagBits::eSparseBinding )
-      result += "SparseBinding | ";
+      result += " SparseBinding |";
     if ( value & QueueFlagBits::eProtected )
-      result += "Protected | ";
+      result += " Protected |";
     if ( value & QueueFlagBits::eVideoDecodeKHR )
-      result += "VideoDecodeKHR | ";
+      result += " VideoDecodeKHR |";
     if ( value & QueueFlagBits::eVideoEncodeKHR )
-      result += "VideoEncodeKHR | ";
+      result += " VideoEncodeKHR |";
     if ( value & QueueFlagBits::eOpticalFlowNV )
-      result += "OpticalFlowNV | ";
+      result += " OpticalFlowNV |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( SampleCountFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & SampleCountFlagBits::e1 )
-      result += "1 | ";
+      result += " 1 |";
     if ( value & SampleCountFlagBits::e2 )
-      result += "2 | ";
+      result += " 2 |";
     if ( value & SampleCountFlagBits::e4 )
-      result += "4 | ";
+      result += " 4 |";
     if ( value & SampleCountFlagBits::e8 )
-      result += "8 | ";
+      result += " 8 |";
     if ( value & SampleCountFlagBits::e16 )
-      result += "16 | ";
+      result += " 16 |";
     if ( value & SampleCountFlagBits::e32 )
-      result += "32 | ";
+      result += " 32 |";
     if ( value & SampleCountFlagBits::e64 )
-      result += "64 | ";
+      result += " 64 |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( DeviceCreateFlags )
@@ -327,160 +335,167 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( DeviceQueueCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & DeviceQueueCreateFlagBits::eProtected )
-      result += "Protected | ";
+      result += " Protected |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( PipelineStageFlags value )
   {
-    if ( !value )
-      return "None";
-
-    std::string result;
+    std::string result = "{";
     if ( value & PipelineStageFlagBits::eTopOfPipe )
-      result += "TopOfPipe | ";
+      result += " TopOfPipe |";
     if ( value & PipelineStageFlagBits::eDrawIndirect )
-      result += "DrawIndirect | ";
+      result += " DrawIndirect |";
     if ( value & PipelineStageFlagBits::eVertexInput )
-      result += "VertexInput | ";
+      result += " VertexInput |";
     if ( value & PipelineStageFlagBits::eVertexShader )
-      result += "VertexShader | ";
+      result += " VertexShader |";
     if ( value & PipelineStageFlagBits::eTessellationControlShader )
-      result += "TessellationControlShader | ";
+      result += " TessellationControlShader |";
     if ( value & PipelineStageFlagBits::eTessellationEvaluationShader )
-      result += "TessellationEvaluationShader | ";
+      result += " TessellationEvaluationShader |";
     if ( value & PipelineStageFlagBits::eGeometryShader )
-      result += "GeometryShader | ";
+      result += " GeometryShader |";
     if ( value & PipelineStageFlagBits::eFragmentShader )
-      result += "FragmentShader | ";
+      result += " FragmentShader |";
     if ( value & PipelineStageFlagBits::eEarlyFragmentTests )
-      result += "EarlyFragmentTests | ";
+      result += " EarlyFragmentTests |";
     if ( value & PipelineStageFlagBits::eLateFragmentTests )
-      result += "LateFragmentTests | ";
+      result += " LateFragmentTests |";
     if ( value & PipelineStageFlagBits::eColorAttachmentOutput )
-      result += "ColorAttachmentOutput | ";
+      result += " ColorAttachmentOutput |";
     if ( value & PipelineStageFlagBits::eComputeShader )
-      result += "ComputeShader | ";
+      result += " ComputeShader |";
     if ( value & PipelineStageFlagBits::eTransfer )
-      result += "Transfer | ";
+      result += " Transfer |";
     if ( value & PipelineStageFlagBits::eBottomOfPipe )
-      result += "BottomOfPipe | ";
+      result += " BottomOfPipe |";
     if ( value & PipelineStageFlagBits::eHost )
-      result += "Host | ";
+      result += " Host |";
     if ( value & PipelineStageFlagBits::eAllGraphics )
-      result += "AllGraphics | ";
+      result += " AllGraphics |";
     if ( value & PipelineStageFlagBits::eAllCommands )
-      result += "AllCommands | ";
+      result += " AllCommands |";
     if ( value & PipelineStageFlagBits::eTransformFeedbackEXT )
-      result += "TransformFeedbackEXT | ";
+      result += " TransformFeedbackEXT |";
     if ( value & PipelineStageFlagBits::eConditionalRenderingEXT )
-      result += "ConditionalRenderingEXT | ";
+      result += " ConditionalRenderingEXT |";
     if ( value & PipelineStageFlagBits::eAccelerationStructureBuildKHR )
-      result += "AccelerationStructureBuildKHR | ";
+      result += " AccelerationStructureBuildKHR |";
     if ( value & PipelineStageFlagBits::eRayTracingShaderKHR )
-      result += "RayTracingShaderKHR | ";
+      result += " RayTracingShaderKHR |";
     if ( value & PipelineStageFlagBits::eFragmentDensityProcessEXT )
-      result += "FragmentDensityProcessEXT | ";
+      result += " FragmentDensityProcessEXT |";
     if ( value & PipelineStageFlagBits::eFragmentShadingRateAttachmentKHR )
-      result += "FragmentShadingRateAttachmentKHR | ";
+      result += " FragmentShadingRateAttachmentKHR |";
     if ( value & PipelineStageFlagBits::eCommandPreprocessNV )
-      result += "CommandPreprocessNV | ";
+      result += " CommandPreprocessNV |";
     if ( value & PipelineStageFlagBits::eTaskShaderEXT )
-      result += "TaskShaderEXT | ";
+      result += " TaskShaderEXT |";
     if ( value & PipelineStageFlagBits::eMeshShaderEXT )
-      result += "MeshShaderEXT | ";
+      result += " MeshShaderEXT |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "None";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( MemoryMapFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & MemoryMapFlagBits::ePlacedEXT )
-      result += "PlacedEXT | ";
+      result += " PlacedEXT |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( ImageAspectFlags value )
   {
-    if ( !value )
-      return "None";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ImageAspectFlagBits::eColor )
-      result += "Color | ";
+      result += " Color |";
     if ( value & ImageAspectFlagBits::eDepth )
-      result += "Depth | ";
+      result += " Depth |";
     if ( value & ImageAspectFlagBits::eStencil )
-      result += "Stencil | ";
+      result += " Stencil |";
     if ( value & ImageAspectFlagBits::eMetadata )
-      result += "Metadata | ";
+      result += " Metadata |";
     if ( value & ImageAspectFlagBits::ePlane0 )
-      result += "Plane0 | ";
+      result += " Plane0 |";
     if ( value & ImageAspectFlagBits::ePlane1 )
-      result += "Plane1 | ";
+      result += " Plane1 |";
     if ( value & ImageAspectFlagBits::ePlane2 )
-      result += "Plane2 | ";
+      result += " Plane2 |";
     if ( value & ImageAspectFlagBits::eMemoryPlane0EXT )
-      result += "MemoryPlane0EXT | ";
+      result += " MemoryPlane0EXT |";
     if ( value & ImageAspectFlagBits::eMemoryPlane1EXT )
-      result += "MemoryPlane1EXT | ";
+      result += " MemoryPlane1EXT |";
     if ( value & ImageAspectFlagBits::eMemoryPlane2EXT )
-      result += "MemoryPlane2EXT | ";
+      result += " MemoryPlane2EXT |";
     if ( value & ImageAspectFlagBits::eMemoryPlane3EXT )
-      result += "MemoryPlane3EXT | ";
+      result += " MemoryPlane3EXT |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "None";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( SparseImageFormatFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & SparseImageFormatFlagBits::eSingleMiptail )
-      result += "SingleMiptail | ";
+      result += " SingleMiptail |";
     if ( value & SparseImageFormatFlagBits::eAlignedMipSize )
-      result += "AlignedMipSize | ";
+      result += " AlignedMipSize |";
     if ( value & SparseImageFormatFlagBits::eNonstandardBlockSize )
-      result += "NonstandardBlockSize | ";
+      result += " NonstandardBlockSize |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( SparseMemoryBindFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & SparseMemoryBindFlagBits::eMetadata )
-      result += "Metadata | ";
+      result += " Metadata |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( FenceCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & FenceCreateFlagBits::eSignaled )
-      result += "Signaled | ";
+      result += " Signaled |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( SemaphoreCreateFlags )
@@ -490,52 +505,54 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( EventCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & EventCreateFlagBits::eDeviceOnly )
-      result += "DeviceOnly | ";
+      result += " DeviceOnly |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( QueryPipelineStatisticFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & QueryPipelineStatisticFlagBits::eInputAssemblyVertices )
-      result += "InputAssemblyVertices | ";
+      result += " InputAssemblyVertices |";
     if ( value & QueryPipelineStatisticFlagBits::eInputAssemblyPrimitives )
-      result += "InputAssemblyPrimitives | ";
+      result += " InputAssemblyPrimitives |";
     if ( value & QueryPipelineStatisticFlagBits::eVertexShaderInvocations )
-      result += "VertexShaderInvocations | ";
+      result += " VertexShaderInvocations |";
     if ( value & QueryPipelineStatisticFlagBits::eGeometryShaderInvocations )
-      result += "GeometryShaderInvocations | ";
+      result += " GeometryShaderInvocations |";
     if ( value & QueryPipelineStatisticFlagBits::eGeometryShaderPrimitives )
-      result += "GeometryShaderPrimitives | ";
+      result += " GeometryShaderPrimitives |";
     if ( value & QueryPipelineStatisticFlagBits::eClippingInvocations )
-      result += "ClippingInvocations | ";
+      result += " ClippingInvocations |";
     if ( value & QueryPipelineStatisticFlagBits::eClippingPrimitives )
-      result += "ClippingPrimitives | ";
+      result += " ClippingPrimitives |";
     if ( value & QueryPipelineStatisticFlagBits::eFragmentShaderInvocations )
-      result += "FragmentShaderInvocations | ";
+      result += " FragmentShaderInvocations |";
     if ( value & QueryPipelineStatisticFlagBits::eTessellationControlShaderPatches )
-      result += "TessellationControlShaderPatches | ";
+      result += " TessellationControlShaderPatches |";
     if ( value & QueryPipelineStatisticFlagBits::eTessellationEvaluationShaderInvocations )
-      result += "TessellationEvaluationShaderInvocations | ";
+      result += " TessellationEvaluationShaderInvocations |";
     if ( value & QueryPipelineStatisticFlagBits::eComputeShaderInvocations )
-      result += "ComputeShaderInvocations | ";
+      result += " ComputeShaderInvocations |";
     if ( value & QueryPipelineStatisticFlagBits::eTaskShaderInvocationsEXT )
-      result += "TaskShaderInvocationsEXT | ";
+      result += " TaskShaderInvocationsEXT |";
     if ( value & QueryPipelineStatisticFlagBits::eMeshShaderInvocationsEXT )
-      result += "MeshShaderInvocationsEXT | ";
+      result += " MeshShaderInvocationsEXT |";
     if ( value & QueryPipelineStatisticFlagBits::eClusterCullingShaderInvocationsHUAWEI )
-      result += "ClusterCullingShaderInvocationsHUAWEI | ";
+      result += " ClusterCullingShaderInvocationsHUAWEI |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( QueryPoolCreateFlags )
@@ -545,110 +562,113 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( QueryResultFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & QueryResultFlagBits::e64 )
-      result += "64 | ";
+      result += " 64 |";
     if ( value & QueryResultFlagBits::eWait )
-      result += "Wait | ";
+      result += " Wait |";
     if ( value & QueryResultFlagBits::eWithAvailability )
-      result += "WithAvailability | ";
+      result += " WithAvailability |";
     if ( value & QueryResultFlagBits::ePartial )
-      result += "Partial | ";
+      result += " Partial |";
     if ( value & QueryResultFlagBits::eWithStatusKHR )
-      result += "WithStatusKHR | ";
+      result += " WithStatusKHR |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( BufferCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & BufferCreateFlagBits::eSparseBinding )
-      result += "SparseBinding | ";
+      result += " SparseBinding |";
     if ( value & BufferCreateFlagBits::eSparseResidency )
-      result += "SparseResidency | ";
+      result += " SparseResidency |";
     if ( value & BufferCreateFlagBits::eSparseAliased )
-      result += "SparseAliased | ";
+      result += " SparseAliased |";
     if ( value & BufferCreateFlagBits::eProtected )
-      result += "Protected | ";
+      result += " Protected |";
     if ( value & BufferCreateFlagBits::eDeviceAddressCaptureReplay )
-      result += "DeviceAddressCaptureReplay | ";
+      result += " DeviceAddressCaptureReplay |";
     if ( value & BufferCreateFlagBits::eDescriptorBufferCaptureReplayEXT )
-      result += "DescriptorBufferCaptureReplayEXT | ";
+      result += " DescriptorBufferCaptureReplayEXT |";
     if ( value & BufferCreateFlagBits::eVideoProfileIndependentKHR )
-      result += "VideoProfileIndependentKHR | ";
+      result += " VideoProfileIndependentKHR |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( BufferUsageFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & BufferUsageFlagBits::eTransferSrc )
-      result += "TransferSrc | ";
+      result += " TransferSrc |";
     if ( value & BufferUsageFlagBits::eTransferDst )
-      result += "TransferDst | ";
+      result += " TransferDst |";
     if ( value & BufferUsageFlagBits::eUniformTexelBuffer )
-      result += "UniformTexelBuffer | ";
+      result += " UniformTexelBuffer |";
     if ( value & BufferUsageFlagBits::eStorageTexelBuffer )
-      result += "StorageTexelBuffer | ";
+      result += " StorageTexelBuffer |";
     if ( value & BufferUsageFlagBits::eUniformBuffer )
-      result += "UniformBuffer | ";
+      result += " UniformBuffer |";
     if ( value & BufferUsageFlagBits::eStorageBuffer )
-      result += "StorageBuffer | ";
+      result += " StorageBuffer |";
     if ( value & BufferUsageFlagBits::eIndexBuffer )
-      result += "IndexBuffer | ";
+      result += " IndexBuffer |";
     if ( value & BufferUsageFlagBits::eVertexBuffer )
-      result += "VertexBuffer | ";
+      result += " VertexBuffer |";
     if ( value & BufferUsageFlagBits::eIndirectBuffer )
-      result += "IndirectBuffer | ";
+      result += " IndirectBuffer |";
     if ( value & BufferUsageFlagBits::eShaderDeviceAddress )
-      result += "ShaderDeviceAddress | ";
+      result += " ShaderDeviceAddress |";
     if ( value & BufferUsageFlagBits::eVideoDecodeSrcKHR )
-      result += "VideoDecodeSrcKHR | ";
+      result += " VideoDecodeSrcKHR |";
     if ( value & BufferUsageFlagBits::eVideoDecodeDstKHR )
-      result += "VideoDecodeDstKHR | ";
+      result += " VideoDecodeDstKHR |";
     if ( value & BufferUsageFlagBits::eTransformFeedbackBufferEXT )
-      result += "TransformFeedbackBufferEXT | ";
+      result += " TransformFeedbackBufferEXT |";
     if ( value & BufferUsageFlagBits::eTransformFeedbackCounterBufferEXT )
-      result += "TransformFeedbackCounterBufferEXT | ";
+      result += " TransformFeedbackCounterBufferEXT |";
     if ( value & BufferUsageFlagBits::eConditionalRenderingEXT )
-      result += "ConditionalRenderingEXT | ";
+      result += " ConditionalRenderingEXT |";
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
     if ( value & BufferUsageFlagBits::eExecutionGraphScratchAMDX )
-      result += "ExecutionGraphScratchAMDX | ";
+      result += " ExecutionGraphScratchAMDX |";
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
     if ( value & BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR )
-      result += "AccelerationStructureBuildInputReadOnlyKHR | ";
+      result += " AccelerationStructureBuildInputReadOnlyKHR |";
     if ( value & BufferUsageFlagBits::eAccelerationStructureStorageKHR )
-      result += "AccelerationStructureStorageKHR | ";
+      result += " AccelerationStructureStorageKHR |";
     if ( value & BufferUsageFlagBits::eShaderBindingTableKHR )
-      result += "ShaderBindingTableKHR | ";
+      result += " ShaderBindingTableKHR |";
     if ( value & BufferUsageFlagBits::eVideoEncodeDstKHR )
-      result += "VideoEncodeDstKHR | ";
+      result += " VideoEncodeDstKHR |";
     if ( value & BufferUsageFlagBits::eVideoEncodeSrcKHR )
-      result += "VideoEncodeSrcKHR | ";
+      result += " VideoEncodeSrcKHR |";
     if ( value & BufferUsageFlagBits::eSamplerDescriptorBufferEXT )
-      result += "SamplerDescriptorBufferEXT | ";
+      result += " SamplerDescriptorBufferEXT |";
     if ( value & BufferUsageFlagBits::eResourceDescriptorBufferEXT )
-      result += "ResourceDescriptorBufferEXT | ";
+      result += " ResourceDescriptorBufferEXT |";
     if ( value & BufferUsageFlagBits::ePushDescriptorsDescriptorBufferEXT )
-      result += "PushDescriptorsDescriptorBufferEXT | ";
+      result += " PushDescriptorsDescriptorBufferEXT |";
     if ( value & BufferUsageFlagBits::eMicromapBuildInputReadOnlyEXT )
-      result += "MicromapBuildInputReadOnlyEXT | ";
+      result += " MicromapBuildInputReadOnlyEXT |";
     if ( value & BufferUsageFlagBits::eMicromapStorageEXT )
-      result += "MicromapStorageEXT | ";
+      result += " MicromapStorageEXT |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( BufferViewCreateFlags )
@@ -658,18 +678,19 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( ImageViewCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ImageViewCreateFlagBits::eFragmentDensityMapDynamicEXT )
-      result += "FragmentDensityMapDynamicEXT | ";
+      result += " FragmentDensityMapDynamicEXT |";
     if ( value & ImageViewCreateFlagBits::eDescriptorBufferCaptureReplayEXT )
-      result += "DescriptorBufferCaptureReplayEXT | ";
+      result += " DescriptorBufferCaptureReplayEXT |";
     if ( value & ImageViewCreateFlagBits::eFragmentDensityMapDeferredEXT )
-      result += "FragmentDensityMapDeferredEXT | ";
+      result += " FragmentDensityMapDeferredEXT |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( ShaderModuleCreateFlags )
@@ -679,148 +700,154 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( PipelineCacheCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & PipelineCacheCreateFlagBits::eExternallySynchronized )
-      result += "ExternallySynchronized | ";
+      result += " ExternallySynchronized |";
     if ( value & PipelineCacheCreateFlagBits::eInternallySynchronizedMergeKHR )
-      result += "InternallySynchronizedMergeKHR | ";
+      result += " InternallySynchronizedMergeKHR |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( ColorComponentFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ColorComponentFlagBits::eR )
-      result += "R | ";
+      result += " R |";
     if ( value & ColorComponentFlagBits::eG )
-      result += "G | ";
+      result += " G |";
     if ( value & ColorComponentFlagBits::eB )
-      result += "B | ";
+      result += " B |";
     if ( value & ColorComponentFlagBits::eA )
-      result += "A | ";
+      result += " A |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( CullModeFlags value )
   {
-    if ( !value )
-      return "None";
-
-    std::string result;
+    std::string result = "{";
     if ( value & CullModeFlagBits::eFront )
-      result += "Front | ";
+      result += " Front |";
     if ( value & CullModeFlagBits::eBack )
-      result += "Back | ";
+      result += " Back |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "None";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( PipelineColorBlendStateCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & PipelineColorBlendStateCreateFlagBits::eRasterizationOrderAttachmentAccessEXT )
-      result += "RasterizationOrderAttachmentAccessEXT | ";
+      result += " RasterizationOrderAttachmentAccessEXT |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( PipelineCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & PipelineCreateFlagBits::eDisableOptimization )
-      result += "DisableOptimization | ";
+      result += " DisableOptimization |";
     if ( value & PipelineCreateFlagBits::eAllowDerivatives )
-      result += "AllowDerivatives | ";
+      result += " AllowDerivatives |";
     if ( value & PipelineCreateFlagBits::eDerivative )
-      result += "Derivative | ";
+      result += " Derivative |";
     if ( value & PipelineCreateFlagBits::eViewIndexFromDeviceIndex )
-      result += "ViewIndexFromDeviceIndex | ";
+      result += " ViewIndexFromDeviceIndex |";
     if ( value & PipelineCreateFlagBits::eDispatchBase )
-      result += "DispatchBase | ";
+      result += " DispatchBase |";
     if ( value & PipelineCreateFlagBits::eFailOnPipelineCompileRequired )
-      result += "FailOnPipelineCompileRequired | ";
+      result += " FailOnPipelineCompileRequired |";
     if ( value & PipelineCreateFlagBits::eEarlyReturnOnFailure )
-      result += "EarlyReturnOnFailure | ";
+      result += " EarlyReturnOnFailure |";
     if ( value & PipelineCreateFlagBits::eNoProtectedAccess )
-      result += "NoProtectedAccess | ";
+      result += " NoProtectedAccess |";
     if ( value & PipelineCreateFlagBits::eProtectedAccessOnly )
-      result += "ProtectedAccessOnly | ";
+      result += " ProtectedAccessOnly |";
     if ( value & PipelineCreateFlagBits::eRayTracingNoNullAnyHitShadersKHR )
-      result += "RayTracingNoNullAnyHitShadersKHR | ";
+      result += " RayTracingNoNullAnyHitShadersKHR |";
     if ( value & PipelineCreateFlagBits::eRayTracingNoNullClosestHitShadersKHR )
-      result += "RayTracingNoNullClosestHitShadersKHR | ";
+      result += " RayTracingNoNullClosestHitShadersKHR |";
     if ( value & PipelineCreateFlagBits::eRayTracingNoNullMissShadersKHR )
-      result += "RayTracingNoNullMissShadersKHR | ";
+      result += " RayTracingNoNullMissShadersKHR |";
     if ( value & PipelineCreateFlagBits::eRayTracingNoNullIntersectionShadersKHR )
-      result += "RayTracingNoNullIntersectionShadersKHR | ";
+      result += " RayTracingNoNullIntersectionShadersKHR |";
     if ( value & PipelineCreateFlagBits::eRayTracingSkipTrianglesKHR )
-      result += "RayTracingSkipTrianglesKHR | ";
+      result += " RayTracingSkipTrianglesKHR |";
     if ( value & PipelineCreateFlagBits::eRayTracingSkipAabbsKHR )
-      result += "RayTracingSkipAabbsKHR | ";
+      result += " RayTracingSkipAabbsKHR |";
     if ( value & PipelineCreateFlagBits::eRayTracingShaderGroupHandleCaptureReplayKHR )
-      result += "RayTracingShaderGroupHandleCaptureReplayKHR | ";
+      result += " RayTracingShaderGroupHandleCaptureReplayKHR |";
     if ( value & PipelineCreateFlagBits::eDeferCompileNV )
-      result += "DeferCompileNV | ";
+      result += " DeferCompileNV |";
     if ( value & PipelineCreateFlagBits::eRenderingFragmentDensityMapAttachmentEXT )
-      result += "RenderingFragmentDensityMapAttachmentEXT | ";
+      result += " RenderingFragmentDensityMapAttachmentEXT |";
     if ( value & PipelineCreateFlagBits::eRenderingFragmentShadingRateAttachmentKHR )
-      result += "RenderingFragmentShadingRateAttachmentKHR | ";
+      result += " RenderingFragmentShadingRateAttachmentKHR |";
     if ( value & PipelineCreateFlagBits::eCaptureStatisticsKHR )
-      result += "CaptureStatisticsKHR | ";
+      result += " CaptureStatisticsKHR |";
     if ( value & PipelineCreateFlagBits::eCaptureInternalRepresentationsKHR )
-      result += "CaptureInternalRepresentationsKHR | ";
+      result += " CaptureInternalRepresentationsKHR |";
     if ( value & PipelineCreateFlagBits::eIndirectBindableNV )
-      result += "IndirectBindableNV | ";
+      result += " IndirectBindableNV |";
     if ( value & PipelineCreateFlagBits::eLibraryKHR )
-      result += "LibraryKHR | ";
+      result += " LibraryKHR |";
     if ( value & PipelineCreateFlagBits::eDescriptorBufferEXT )
-      result += "DescriptorBufferEXT | ";
+      result += " DescriptorBufferEXT |";
     if ( value & PipelineCreateFlagBits::eRetainLinkTimeOptimizationInfoEXT )
-      result += "RetainLinkTimeOptimizationInfoEXT | ";
+      result += " RetainLinkTimeOptimizationInfoEXT |";
     if ( value & PipelineCreateFlagBits::eLinkTimeOptimizationEXT )
-      result += "LinkTimeOptimizationEXT | ";
+      result += " LinkTimeOptimizationEXT |";
     if ( value & PipelineCreateFlagBits::eRayTracingAllowMotionNV )
-      result += "RayTracingAllowMotionNV | ";
+      result += " RayTracingAllowMotionNV |";
     if ( value & PipelineCreateFlagBits::eColorAttachmentFeedbackLoopEXT )
-      result += "ColorAttachmentFeedbackLoopEXT | ";
+      result += " ColorAttachmentFeedbackLoopEXT |";
     if ( value & PipelineCreateFlagBits::eDepthStencilAttachmentFeedbackLoopEXT )
-      result += "DepthStencilAttachmentFeedbackLoopEXT | ";
+      result += " DepthStencilAttachmentFeedbackLoopEXT |";
     if ( value & PipelineCreateFlagBits::eRayTracingOpacityMicromapEXT )
-      result += "RayTracingOpacityMicromapEXT | ";
+      result += " RayTracingOpacityMicromapEXT |";
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
     if ( value & PipelineCreateFlagBits::eRayTracingDisplacementMicromapNV )
-      result += "RayTracingDisplacementMicromapNV | ";
+      result += " RayTracingDisplacementMicromapNV |";
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( PipelineDepthStencilStateCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & PipelineDepthStencilStateCreateFlagBits::eRasterizationOrderAttachmentDepthAccessEXT )
-      result += "RasterizationOrderAttachmentDepthAccessEXT | ";
+      result += " RasterizationOrderAttachmentDepthAccessEXT |";
     if ( value & PipelineDepthStencilStateCreateFlagBits::eRasterizationOrderAttachmentStencilAccessEXT )
-      result += "RasterizationOrderAttachmentStencilAccessEXT | ";
+      result += " RasterizationOrderAttachmentStencilAccessEXT |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( PipelineDynamicStateCreateFlags )
@@ -835,14 +862,15 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( PipelineLayoutCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & PipelineLayoutCreateFlagBits::eIndependentSetsEXT )
-      result += "IndependentSetsEXT | ";
+      result += " IndependentSetsEXT |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( PipelineMultisampleStateCreateFlags )
@@ -857,16 +885,17 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( PipelineShaderStageCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & PipelineShaderStageCreateFlagBits::eAllowVaryingSubgroupSize )
-      result += "AllowVaryingSubgroupSize | ";
+      result += " AllowVaryingSubgroupSize |";
     if ( value & PipelineShaderStageCreateFlagBits::eRequireFullSubgroups )
-      result += "RequireFullSubgroups | ";
+      result += " RequireFullSubgroups |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( PipelineTessellationStateCreateFlags )
@@ -886,84 +915,87 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( ShaderStageFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ShaderStageFlagBits::eVertex )
-      result += "Vertex | ";
+      result += " Vertex |";
     if ( value & ShaderStageFlagBits::eTessellationControl )
-      result += "TessellationControl | ";
+      result += " TessellationControl |";
     if ( value & ShaderStageFlagBits::eTessellationEvaluation )
-      result += "TessellationEvaluation | ";
+      result += " TessellationEvaluation |";
     if ( value & ShaderStageFlagBits::eGeometry )
-      result += "Geometry | ";
+      result += " Geometry |";
     if ( value & ShaderStageFlagBits::eFragment )
-      result += "Fragment | ";
+      result += " Fragment |";
     if ( value & ShaderStageFlagBits::eCompute )
-      result += "Compute | ";
+      result += " Compute |";
     if ( value & ShaderStageFlagBits::eRaygenKHR )
-      result += "RaygenKHR | ";
+      result += " RaygenKHR |";
     if ( value & ShaderStageFlagBits::eAnyHitKHR )
-      result += "AnyHitKHR | ";
+      result += " AnyHitKHR |";
     if ( value & ShaderStageFlagBits::eClosestHitKHR )
-      result += "ClosestHitKHR | ";
+      result += " ClosestHitKHR |";
     if ( value & ShaderStageFlagBits::eMissKHR )
-      result += "MissKHR | ";
+      result += " MissKHR |";
     if ( value & ShaderStageFlagBits::eIntersectionKHR )
-      result += "IntersectionKHR | ";
+      result += " IntersectionKHR |";
     if ( value & ShaderStageFlagBits::eCallableKHR )
-      result += "CallableKHR | ";
+      result += " CallableKHR |";
     if ( value & ShaderStageFlagBits::eTaskEXT )
-      result += "TaskEXT | ";
+      result += " TaskEXT |";
     if ( value & ShaderStageFlagBits::eMeshEXT )
-      result += "MeshEXT | ";
+      result += " MeshEXT |";
     if ( value & ShaderStageFlagBits::eSubpassShadingHUAWEI )
-      result += "SubpassShadingHUAWEI | ";
+      result += " SubpassShadingHUAWEI |";
     if ( value & ShaderStageFlagBits::eClusterCullingHUAWEI )
-      result += "ClusterCullingHUAWEI | ";
+      result += " ClusterCullingHUAWEI |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( SamplerCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & SamplerCreateFlagBits::eSubsampledEXT )
-      result += "SubsampledEXT | ";
+      result += " SubsampledEXT |";
     if ( value & SamplerCreateFlagBits::eSubsampledCoarseReconstructionEXT )
-      result += "SubsampledCoarseReconstructionEXT | ";
+      result += " SubsampledCoarseReconstructionEXT |";
     if ( value & SamplerCreateFlagBits::eDescriptorBufferCaptureReplayEXT )
-      result += "DescriptorBufferCaptureReplayEXT | ";
+      result += " DescriptorBufferCaptureReplayEXT |";
     if ( value & SamplerCreateFlagBits::eNonSeamlessCubeMapEXT )
-      result += "NonSeamlessCubeMapEXT | ";
+      result += " NonSeamlessCubeMapEXT |";
     if ( value & SamplerCreateFlagBits::eImageProcessingQCOM )
-      result += "ImageProcessingQCOM | ";
+      result += " ImageProcessingQCOM |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( DescriptorPoolCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & DescriptorPoolCreateFlagBits::eFreeDescriptorSet )
-      result += "FreeDescriptorSet | ";
+      result += " FreeDescriptorSet |";
     if ( value & DescriptorPoolCreateFlagBits::eUpdateAfterBind )
-      result += "UpdateAfterBind | ";
+      result += " UpdateAfterBind |";
     if ( value & DescriptorPoolCreateFlagBits::eHostOnlyEXT )
-      result += "HostOnlyEXT | ";
+      result += " HostOnlyEXT |";
     if ( value & DescriptorPoolCreateFlagBits::eAllowOverallocationSetsNV )
-      result += "AllowOverallocationSetsNV | ";
+      result += " AllowOverallocationSetsNV |";
     if ( value & DescriptorPoolCreateFlagBits::eAllowOverallocationPoolsNV )
-      result += "AllowOverallocationPoolsNV | ";
+      result += " AllowOverallocationPoolsNV |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( DescriptorPoolResetFlags )
@@ -973,324 +1005,340 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( DescriptorSetLayoutCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & DescriptorSetLayoutCreateFlagBits::eUpdateAfterBindPool )
-      result += "UpdateAfterBindPool | ";
+      result += " UpdateAfterBindPool |";
     if ( value & DescriptorSetLayoutCreateFlagBits::ePushDescriptor )
-      result += "PushDescriptor | ";
+      result += " PushDescriptor |";
     if ( value & DescriptorSetLayoutCreateFlagBits::eDescriptorBufferEXT )
-      result += "DescriptorBufferEXT | ";
+      result += " DescriptorBufferEXT |";
     if ( value & DescriptorSetLayoutCreateFlagBits::eEmbeddedImmutableSamplersEXT )
-      result += "EmbeddedImmutableSamplersEXT | ";
+      result += " EmbeddedImmutableSamplersEXT |";
     if ( value & DescriptorSetLayoutCreateFlagBits::eIndirectBindableNV )
-      result += "IndirectBindableNV | ";
+      result += " IndirectBindableNV |";
     if ( value & DescriptorSetLayoutCreateFlagBits::eHostOnlyPoolEXT )
-      result += "HostOnlyPoolEXT | ";
+      result += " HostOnlyPoolEXT |";
     if ( value & DescriptorSetLayoutCreateFlagBits::ePerStageNV )
-      result += "PerStageNV | ";
+      result += " PerStageNV |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( AccessFlags value )
   {
-    if ( !value )
-      return "None";
-
-    std::string result;
+    std::string result = "{";
     if ( value & AccessFlagBits::eIndirectCommandRead )
-      result += "IndirectCommandRead | ";
+      result += " IndirectCommandRead |";
     if ( value & AccessFlagBits::eIndexRead )
-      result += "IndexRead | ";
+      result += " IndexRead |";
     if ( value & AccessFlagBits::eVertexAttributeRead )
-      result += "VertexAttributeRead | ";
+      result += " VertexAttributeRead |";
     if ( value & AccessFlagBits::eUniformRead )
-      result += "UniformRead | ";
+      result += " UniformRead |";
     if ( value & AccessFlagBits::eInputAttachmentRead )
-      result += "InputAttachmentRead | ";
+      result += " InputAttachmentRead |";
     if ( value & AccessFlagBits::eShaderRead )
-      result += "ShaderRead | ";
+      result += " ShaderRead |";
     if ( value & AccessFlagBits::eShaderWrite )
-      result += "ShaderWrite | ";
+      result += " ShaderWrite |";
     if ( value & AccessFlagBits::eColorAttachmentRead )
-      result += "ColorAttachmentRead | ";
+      result += " ColorAttachmentRead |";
     if ( value & AccessFlagBits::eColorAttachmentWrite )
-      result += "ColorAttachmentWrite | ";
+      result += " ColorAttachmentWrite |";
     if ( value & AccessFlagBits::eDepthStencilAttachmentRead )
-      result += "DepthStencilAttachmentRead | ";
+      result += " DepthStencilAttachmentRead |";
     if ( value & AccessFlagBits::eDepthStencilAttachmentWrite )
-      result += "DepthStencilAttachmentWrite | ";
+      result += " DepthStencilAttachmentWrite |";
     if ( value & AccessFlagBits::eTransferRead )
-      result += "TransferRead | ";
+      result += " TransferRead |";
     if ( value & AccessFlagBits::eTransferWrite )
-      result += "TransferWrite | ";
+      result += " TransferWrite |";
     if ( value & AccessFlagBits::eHostRead )
-      result += "HostRead | ";
+      result += " HostRead |";
     if ( value & AccessFlagBits::eHostWrite )
-      result += "HostWrite | ";
+      result += " HostWrite |";
     if ( value & AccessFlagBits::eMemoryRead )
-      result += "MemoryRead | ";
+      result += " MemoryRead |";
     if ( value & AccessFlagBits::eMemoryWrite )
-      result += "MemoryWrite | ";
+      result += " MemoryWrite |";
     if ( value & AccessFlagBits::eTransformFeedbackWriteEXT )
-      result += "TransformFeedbackWriteEXT | ";
+      result += " TransformFeedbackWriteEXT |";
     if ( value & AccessFlagBits::eTransformFeedbackCounterReadEXT )
-      result += "TransformFeedbackCounterReadEXT | ";
+      result += " TransformFeedbackCounterReadEXT |";
     if ( value & AccessFlagBits::eTransformFeedbackCounterWriteEXT )
-      result += "TransformFeedbackCounterWriteEXT | ";
+      result += " TransformFeedbackCounterWriteEXT |";
     if ( value & AccessFlagBits::eConditionalRenderingReadEXT )
-      result += "ConditionalRenderingReadEXT | ";
+      result += " ConditionalRenderingReadEXT |";
     if ( value & AccessFlagBits::eColorAttachmentReadNoncoherentEXT )
-      result += "ColorAttachmentReadNoncoherentEXT | ";
+      result += " ColorAttachmentReadNoncoherentEXT |";
     if ( value & AccessFlagBits::eAccelerationStructureReadKHR )
-      result += "AccelerationStructureReadKHR | ";
+      result += " AccelerationStructureReadKHR |";
     if ( value & AccessFlagBits::eAccelerationStructureWriteKHR )
-      result += "AccelerationStructureWriteKHR | ";
+      result += " AccelerationStructureWriteKHR |";
     if ( value & AccessFlagBits::eFragmentDensityMapReadEXT )
-      result += "FragmentDensityMapReadEXT | ";
+      result += " FragmentDensityMapReadEXT |";
     if ( value & AccessFlagBits::eFragmentShadingRateAttachmentReadKHR )
-      result += "FragmentShadingRateAttachmentReadKHR | ";
+      result += " FragmentShadingRateAttachmentReadKHR |";
     if ( value & AccessFlagBits::eCommandPreprocessReadNV )
-      result += "CommandPreprocessReadNV | ";
+      result += " CommandPreprocessReadNV |";
     if ( value & AccessFlagBits::eCommandPreprocessWriteNV )
-      result += "CommandPreprocessWriteNV | ";
+      result += " CommandPreprocessWriteNV |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "None";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( AttachmentDescriptionFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & AttachmentDescriptionFlagBits::eMayAlias )
-      result += "MayAlias | ";
+      result += " MayAlias |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( DependencyFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & DependencyFlagBits::eByRegion )
-      result += "ByRegion | ";
+      result += " ByRegion |";
     if ( value & DependencyFlagBits::eDeviceGroup )
-      result += "DeviceGroup | ";
+      result += " DeviceGroup |";
     if ( value & DependencyFlagBits::eViewLocal )
-      result += "ViewLocal | ";
+      result += " ViewLocal |";
     if ( value & DependencyFlagBits::eFeedbackLoopEXT )
-      result += "FeedbackLoopEXT | ";
+      result += " FeedbackLoopEXT |";
     if ( value & DependencyFlagBits::eQueueFamilyOwnershipTransferUseAllStagesKHR )
-      result += "QueueFamilyOwnershipTransferUseAllStagesKHR | ";
+      result += " QueueFamilyOwnershipTransferUseAllStagesKHR |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( FramebufferCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & FramebufferCreateFlagBits::eImageless )
-      result += "Imageless | ";
+      result += " Imageless |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( RenderPassCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & RenderPassCreateFlagBits::eTransformQCOM )
-      result += "TransformQCOM | ";
+      result += " TransformQCOM |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( SubpassDescriptionFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & SubpassDescriptionFlagBits::ePerViewAttributesNVX )
-      result += "PerViewAttributesNVX | ";
+      result += " PerViewAttributesNVX |";
     if ( value & SubpassDescriptionFlagBits::ePerViewPositionXOnlyNVX )
-      result += "PerViewPositionXOnlyNVX | ";
+      result += " PerViewPositionXOnlyNVX |";
     if ( value & SubpassDescriptionFlagBits::eFragmentRegionQCOM )
-      result += "FragmentRegionQCOM | ";
+      result += " FragmentRegionQCOM |";
     if ( value & SubpassDescriptionFlagBits::eShaderResolveQCOM )
-      result += "ShaderResolveQCOM | ";
+      result += " ShaderResolveQCOM |";
     if ( value & SubpassDescriptionFlagBits::eRasterizationOrderAttachmentColorAccessEXT )
-      result += "RasterizationOrderAttachmentColorAccessEXT | ";
+      result += " RasterizationOrderAttachmentColorAccessEXT |";
     if ( value & SubpassDescriptionFlagBits::eRasterizationOrderAttachmentDepthAccessEXT )
-      result += "RasterizationOrderAttachmentDepthAccessEXT | ";
+      result += " RasterizationOrderAttachmentDepthAccessEXT |";
     if ( value & SubpassDescriptionFlagBits::eRasterizationOrderAttachmentStencilAccessEXT )
-      result += "RasterizationOrderAttachmentStencilAccessEXT | ";
+      result += " RasterizationOrderAttachmentStencilAccessEXT |";
     if ( value & SubpassDescriptionFlagBits::eEnableLegacyDitheringEXT )
-      result += "EnableLegacyDitheringEXT | ";
+      result += " EnableLegacyDitheringEXT |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( CommandPoolCreateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & CommandPoolCreateFlagBits::eTransient )
-      result += "Transient | ";
+      result += " Transient |";
     if ( value & CommandPoolCreateFlagBits::eResetCommandBuffer )
-      result += "ResetCommandBuffer | ";
+      result += " ResetCommandBuffer |";
     if ( value & CommandPoolCreateFlagBits::eProtected )
-      result += "Protected | ";
+      result += " Protected |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( CommandPoolResetFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & CommandPoolResetFlagBits::eReleaseResources )
-      result += "ReleaseResources | ";
+      result += " ReleaseResources |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( CommandBufferResetFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & CommandBufferResetFlagBits::eReleaseResources )
-      result += "ReleaseResources | ";
+      result += " ReleaseResources |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( CommandBufferUsageFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & CommandBufferUsageFlagBits::eOneTimeSubmit )
-      result += "OneTimeSubmit | ";
+      result += " OneTimeSubmit |";
     if ( value & CommandBufferUsageFlagBits::eRenderPassContinue )
-      result += "RenderPassContinue | ";
+      result += " RenderPassContinue |";
     if ( value & CommandBufferUsageFlagBits::eSimultaneousUse )
-      result += "SimultaneousUse | ";
+      result += " SimultaneousUse |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( QueryControlFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & QueryControlFlagBits::ePrecise )
-      result += "Precise | ";
+      result += " Precise |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( StencilFaceFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & StencilFaceFlagBits::eFront )
-      result += "Front | ";
+      result += " Front |";
     if ( value & StencilFaceFlagBits::eBack )
-      result += "Back | ";
+      result += " Back |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_VERSION_1_1 ===
 
   VULKAN_HPP_INLINE std::string to_string( SubgroupFeatureFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & SubgroupFeatureFlagBits::eBasic )
-      result += "Basic | ";
+      result += " Basic |";
     if ( value & SubgroupFeatureFlagBits::eVote )
-      result += "Vote | ";
+      result += " Vote |";
     if ( value & SubgroupFeatureFlagBits::eArithmetic )
-      result += "Arithmetic | ";
+      result += " Arithmetic |";
     if ( value & SubgroupFeatureFlagBits::eBallot )
-      result += "Ballot | ";
+      result += " Ballot |";
     if ( value & SubgroupFeatureFlagBits::eShuffle )
-      result += "Shuffle | ";
+      result += " Shuffle |";
     if ( value & SubgroupFeatureFlagBits::eShuffleRelative )
-      result += "ShuffleRelative | ";
+      result += " ShuffleRelative |";
     if ( value & SubgroupFeatureFlagBits::eClustered )
-      result += "Clustered | ";
+      result += " Clustered |";
     if ( value & SubgroupFeatureFlagBits::eQuad )
-      result += "Quad | ";
+      result += " Quad |";
     if ( value & SubgroupFeatureFlagBits::eRotate )
-      result += "Rotate | ";
+      result += " Rotate |";
     if ( value & SubgroupFeatureFlagBits::eRotateClustered )
-      result += "RotateClustered | ";
+      result += " RotateClustered |";
     if ( value & SubgroupFeatureFlagBits::ePartitionedNV )
-      result += "PartitionedNV | ";
+      result += " PartitionedNV |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( PeerMemoryFeatureFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & PeerMemoryFeatureFlagBits::eCopySrc )
-      result += "CopySrc | ";
+      result += " CopySrc |";
     if ( value & PeerMemoryFeatureFlagBits::eCopyDst )
-      result += "CopyDst | ";
+      result += " CopyDst |";
     if ( value & PeerMemoryFeatureFlagBits::eGenericSrc )
-      result += "GenericSrc | ";
+      result += " GenericSrc |";
     if ( value & PeerMemoryFeatureFlagBits::eGenericDst )
-      result += "GenericDst | ";
+      result += " GenericDst |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( MemoryAllocateFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & MemoryAllocateFlagBits::eDeviceMask )
-      result += "DeviceMask | ";
+      result += " DeviceMask |";
     if ( value & MemoryAllocateFlagBits::eDeviceAddress )
-      result += "DeviceAddress | ";
+      result += " DeviceAddress |";
     if ( value & MemoryAllocateFlagBits::eDeviceAddressCaptureReplay )
-      result += "DeviceAddressCaptureReplay | ";
+      result += " DeviceAddressCaptureReplay |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( CommandPoolTrimFlags )
@@ -1305,260 +1353,273 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( ExternalMemoryHandleTypeFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ExternalMemoryHandleTypeFlagBits::eOpaqueFd )
-      result += "OpaqueFd | ";
+      result += " OpaqueFd |";
     if ( value & ExternalMemoryHandleTypeFlagBits::eOpaqueWin32 )
-      result += "OpaqueWin32 | ";
+      result += " OpaqueWin32 |";
     if ( value & ExternalMemoryHandleTypeFlagBits::eOpaqueWin32Kmt )
-      result += "OpaqueWin32Kmt | ";
+      result += " OpaqueWin32Kmt |";
     if ( value & ExternalMemoryHandleTypeFlagBits::eD3D11Texture )
-      result += "D3D11Texture | ";
+      result += " D3D11Texture |";
     if ( value & ExternalMemoryHandleTypeFlagBits::eD3D11TextureKmt )
-      result += "D3D11TextureKmt | ";
+      result += " D3D11TextureKmt |";
     if ( value & ExternalMemoryHandleTypeFlagBits::eD3D12Heap )
-      result += "D3D12Heap | ";
+      result += " D3D12Heap |";
     if ( value & ExternalMemoryHandleTypeFlagBits::eD3D12Resource )
-      result += "D3D12Resource | ";
+      result += " D3D12Resource |";
     if ( value & ExternalMemoryHandleTypeFlagBits::eDmaBufEXT )
-      result += "DmaBufEXT | ";
+      result += " DmaBufEXT |";
 #if defined( VK_USE_PLATFORM_ANDROID_KHR )
     if ( value & ExternalMemoryHandleTypeFlagBits::eAndroidHardwareBufferANDROID )
-      result += "AndroidHardwareBufferANDROID | ";
+      result += " AndroidHardwareBufferANDROID |";
 #endif /*VK_USE_PLATFORM_ANDROID_KHR*/
     if ( value & ExternalMemoryHandleTypeFlagBits::eHostAllocationEXT )
-      result += "HostAllocationEXT | ";
+      result += " HostAllocationEXT |";
     if ( value & ExternalMemoryHandleTypeFlagBits::eHostMappedForeignMemoryEXT )
-      result += "HostMappedForeignMemoryEXT | ";
+      result += " HostMappedForeignMemoryEXT |";
 #if defined( VK_USE_PLATFORM_FUCHSIA )
     if ( value & ExternalMemoryHandleTypeFlagBits::eZirconVmoFUCHSIA )
-      result += "ZirconVmoFUCHSIA | ";
+      result += " ZirconVmoFUCHSIA |";
 #endif /*VK_USE_PLATFORM_FUCHSIA*/
     if ( value & ExternalMemoryHandleTypeFlagBits::eRdmaAddressNV )
-      result += "RdmaAddressNV | ";
+      result += " RdmaAddressNV |";
 #if defined( VK_USE_PLATFORM_SCREEN_QNX )
     if ( value & ExternalMemoryHandleTypeFlagBits::eScreenBufferQNX )
-      result += "ScreenBufferQNX | ";
+      result += " ScreenBufferQNX |";
 #endif /*VK_USE_PLATFORM_SCREEN_QNX*/
 #if defined( VK_USE_PLATFORM_METAL_EXT )
     if ( value & ExternalMemoryHandleTypeFlagBits::eMtlbufferEXT )
-      result += "MtlbufferEXT | ";
+      result += " MtlbufferEXT |";
     if ( value & ExternalMemoryHandleTypeFlagBits::eMtltextureEXT )
-      result += "MtltextureEXT | ";
+      result += " MtltextureEXT |";
     if ( value & ExternalMemoryHandleTypeFlagBits::eMtlheapEXT )
-      result += "MtlheapEXT | ";
+      result += " MtlheapEXT |";
 #endif /*VK_USE_PLATFORM_METAL_EXT*/
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( ExternalMemoryFeatureFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ExternalMemoryFeatureFlagBits::eDedicatedOnly )
-      result += "DedicatedOnly | ";
+      result += " DedicatedOnly |";
     if ( value & ExternalMemoryFeatureFlagBits::eExportable )
-      result += "Exportable | ";
+      result += " Exportable |";
     if ( value & ExternalMemoryFeatureFlagBits::eImportable )
-      result += "Importable | ";
+      result += " Importable |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( ExternalFenceHandleTypeFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ExternalFenceHandleTypeFlagBits::eOpaqueFd )
-      result += "OpaqueFd | ";
+      result += " OpaqueFd |";
     if ( value & ExternalFenceHandleTypeFlagBits::eOpaqueWin32 )
-      result += "OpaqueWin32 | ";
+      result += " OpaqueWin32 |";
     if ( value & ExternalFenceHandleTypeFlagBits::eOpaqueWin32Kmt )
-      result += "OpaqueWin32Kmt | ";
+      result += " OpaqueWin32Kmt |";
     if ( value & ExternalFenceHandleTypeFlagBits::eSyncFd )
-      result += "SyncFd | ";
+      result += " SyncFd |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( ExternalFenceFeatureFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ExternalFenceFeatureFlagBits::eExportable )
-      result += "Exportable | ";
+      result += " Exportable |";
     if ( value & ExternalFenceFeatureFlagBits::eImportable )
-      result += "Importable | ";
+      result += " Importable |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( FenceImportFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & FenceImportFlagBits::eTemporary )
-      result += "Temporary | ";
+      result += " Temporary |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( SemaphoreImportFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & SemaphoreImportFlagBits::eTemporary )
-      result += "Temporary | ";
+      result += " Temporary |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( ExternalSemaphoreHandleTypeFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ExternalSemaphoreHandleTypeFlagBits::eOpaqueFd )
-      result += "OpaqueFd | ";
+      result += " OpaqueFd |";
     if ( value & ExternalSemaphoreHandleTypeFlagBits::eOpaqueWin32 )
-      result += "OpaqueWin32 | ";
+      result += " OpaqueWin32 |";
     if ( value & ExternalSemaphoreHandleTypeFlagBits::eOpaqueWin32Kmt )
-      result += "OpaqueWin32Kmt | ";
+      result += " OpaqueWin32Kmt |";
     if ( value & ExternalSemaphoreHandleTypeFlagBits::eD3D12Fence )
-      result += "D3D12Fence | ";
+      result += " D3D12Fence |";
     if ( value & ExternalSemaphoreHandleTypeFlagBits::eSyncFd )
-      result += "SyncFd | ";
+      result += " SyncFd |";
 #if defined( VK_USE_PLATFORM_FUCHSIA )
     if ( value & ExternalSemaphoreHandleTypeFlagBits::eZirconEventFUCHSIA )
-      result += "ZirconEventFUCHSIA | ";
+      result += " ZirconEventFUCHSIA |";
 #endif /*VK_USE_PLATFORM_FUCHSIA*/
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( ExternalSemaphoreFeatureFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ExternalSemaphoreFeatureFlagBits::eExportable )
-      result += "Exportable | ";
+      result += " Exportable |";
     if ( value & ExternalSemaphoreFeatureFlagBits::eImportable )
-      result += "Importable | ";
+      result += " Importable |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_VERSION_1_2 ===
 
   VULKAN_HPP_INLINE std::string to_string( DescriptorBindingFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & DescriptorBindingFlagBits::eUpdateAfterBind )
-      result += "UpdateAfterBind | ";
+      result += " UpdateAfterBind |";
     if ( value & DescriptorBindingFlagBits::eUpdateUnusedWhilePending )
-      result += "UpdateUnusedWhilePending | ";
+      result += " UpdateUnusedWhilePending |";
     if ( value & DescriptorBindingFlagBits::ePartiallyBound )
-      result += "PartiallyBound | ";
+      result += " PartiallyBound |";
     if ( value & DescriptorBindingFlagBits::eVariableDescriptorCount )
-      result += "VariableDescriptorCount | ";
+      result += " VariableDescriptorCount |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( ResolveModeFlags value )
   {
-    if ( !value )
-      return "None";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ResolveModeFlagBits::eSampleZero )
-      result += "SampleZero | ";
+      result += " SampleZero |";
     if ( value & ResolveModeFlagBits::eAverage )
-      result += "Average | ";
+      result += " Average |";
     if ( value & ResolveModeFlagBits::eMin )
-      result += "Min | ";
+      result += " Min |";
     if ( value & ResolveModeFlagBits::eMax )
-      result += "Max | ";
+      result += " Max |";
 #if defined( VK_USE_PLATFORM_ANDROID_KHR )
     if ( value & ResolveModeFlagBits::eExternalFormatDownsampleANDROID )
-      result += "ExternalFormatDownsampleANDROID | ";
+      result += " ExternalFormatDownsampleANDROID |";
 #endif /*VK_USE_PLATFORM_ANDROID_KHR*/
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "None";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( SemaphoreWaitFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & SemaphoreWaitFlagBits::eAny )
-      result += "Any | ";
+      result += " Any |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_VERSION_1_3 ===
 
   VULKAN_HPP_INLINE std::string to_string( PipelineCreationFeedbackFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & PipelineCreationFeedbackFlagBits::eValid )
-      result += "Valid | ";
+      result += " Valid |";
     if ( value & PipelineCreationFeedbackFlagBits::eApplicationPipelineCacheHit )
-      result += "ApplicationPipelineCacheHit | ";
+      result += " ApplicationPipelineCacheHit |";
     if ( value & PipelineCreationFeedbackFlagBits::eBasePipelineAcceleration )
-      result += "BasePipelineAcceleration | ";
+      result += " BasePipelineAcceleration |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( ToolPurposeFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ToolPurposeFlagBits::eValidation )
-      result += "Validation | ";
+      result += " Validation |";
     if ( value & ToolPurposeFlagBits::eProfiling )
-      result += "Profiling | ";
+      result += " Profiling |";
     if ( value & ToolPurposeFlagBits::eTracing )
-      result += "Tracing | ";
+      result += " Tracing |";
     if ( value & ToolPurposeFlagBits::eAdditionalFeatures )
-      result += "AdditionalFeatures | ";
+      result += " AdditionalFeatures |";
     if ( value & ToolPurposeFlagBits::eModifyingFeatures )
-      result += "ModifyingFeatures | ";
+      result += " ModifyingFeatures |";
     if ( value & ToolPurposeFlagBits::eDebugReportingEXT )
-      result += "DebugReportingEXT | ";
+      result += " DebugReportingEXT |";
     if ( value & ToolPurposeFlagBits::eDebugMarkersEXT )
-      result += "DebugMarkersEXT | ";
+      result += " DebugMarkersEXT |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( PrivateDataSlotCreateFlags )
@@ -1568,560 +1629,572 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( PipelineStageFlags2 value )
   {
-    if ( !value )
-      return "None";
-
-    std::string result;
+    std::string result = "{";
     if ( value & PipelineStageFlagBits2::eTopOfPipe )
-      result += "TopOfPipe | ";
+      result += " TopOfPipe |";
     if ( value & PipelineStageFlagBits2::eDrawIndirect )
-      result += "DrawIndirect | ";
+      result += " DrawIndirect |";
     if ( value & PipelineStageFlagBits2::eVertexInput )
-      result += "VertexInput | ";
+      result += " VertexInput |";
     if ( value & PipelineStageFlagBits2::eVertexShader )
-      result += "VertexShader | ";
+      result += " VertexShader |";
     if ( value & PipelineStageFlagBits2::eTessellationControlShader )
-      result += "TessellationControlShader | ";
+      result += " TessellationControlShader |";
     if ( value & PipelineStageFlagBits2::eTessellationEvaluationShader )
-      result += "TessellationEvaluationShader | ";
+      result += " TessellationEvaluationShader |";
     if ( value & PipelineStageFlagBits2::eGeometryShader )
-      result += "GeometryShader | ";
+      result += " GeometryShader |";
     if ( value & PipelineStageFlagBits2::eFragmentShader )
-      result += "FragmentShader | ";
+      result += " FragmentShader |";
     if ( value & PipelineStageFlagBits2::eEarlyFragmentTests )
-      result += "EarlyFragmentTests | ";
+      result += " EarlyFragmentTests |";
     if ( value & PipelineStageFlagBits2::eLateFragmentTests )
-      result += "LateFragmentTests | ";
+      result += " LateFragmentTests |";
     if ( value & PipelineStageFlagBits2::eColorAttachmentOutput )
-      result += "ColorAttachmentOutput | ";
+      result += " ColorAttachmentOutput |";
     if ( value & PipelineStageFlagBits2::eComputeShader )
-      result += "ComputeShader | ";
+      result += " ComputeShader |";
     if ( value & PipelineStageFlagBits2::eAllTransfer )
-      result += "AllTransfer | ";
+      result += " AllTransfer |";
     if ( value & PipelineStageFlagBits2::eBottomOfPipe )
-      result += "BottomOfPipe | ";
+      result += " BottomOfPipe |";
     if ( value & PipelineStageFlagBits2::eHost )
-      result += "Host | ";
+      result += " Host |";
     if ( value & PipelineStageFlagBits2::eAllGraphics )
-      result += "AllGraphics | ";
+      result += " AllGraphics |";
     if ( value & PipelineStageFlagBits2::eAllCommands )
-      result += "AllCommands | ";
+      result += " AllCommands |";
     if ( value & PipelineStageFlagBits2::eCopy )
-      result += "Copy | ";
+      result += " Copy |";
     if ( value & PipelineStageFlagBits2::eResolve )
-      result += "Resolve | ";
+      result += " Resolve |";
     if ( value & PipelineStageFlagBits2::eBlit )
-      result += "Blit | ";
+      result += " Blit |";
     if ( value & PipelineStageFlagBits2::eClear )
-      result += "Clear | ";
+      result += " Clear |";
     if ( value & PipelineStageFlagBits2::eIndexInput )
-      result += "IndexInput | ";
+      result += " IndexInput |";
     if ( value & PipelineStageFlagBits2::eVertexAttributeInput )
-      result += "VertexAttributeInput | ";
+      result += " VertexAttributeInput |";
     if ( value & PipelineStageFlagBits2::ePreRasterizationShaders )
-      result += "PreRasterizationShaders | ";
+      result += " PreRasterizationShaders |";
     if ( value & PipelineStageFlagBits2::eVideoDecodeKHR )
-      result += "VideoDecodeKHR | ";
+      result += " VideoDecodeKHR |";
     if ( value & PipelineStageFlagBits2::eVideoEncodeKHR )
-      result += "VideoEncodeKHR | ";
+      result += " VideoEncodeKHR |";
     if ( value & PipelineStageFlagBits2::eTransformFeedbackEXT )
-      result += "TransformFeedbackEXT | ";
+      result += " TransformFeedbackEXT |";
     if ( value & PipelineStageFlagBits2::eConditionalRenderingEXT )
-      result += "ConditionalRenderingEXT | ";
+      result += " ConditionalRenderingEXT |";
     if ( value & PipelineStageFlagBits2::eCommandPreprocessNV )
-      result += "CommandPreprocessNV | ";
+      result += " CommandPreprocessNV |";
     if ( value & PipelineStageFlagBits2::eFragmentShadingRateAttachmentKHR )
-      result += "FragmentShadingRateAttachmentKHR | ";
+      result += " FragmentShadingRateAttachmentKHR |";
     if ( value & PipelineStageFlagBits2::eAccelerationStructureBuildKHR )
-      result += "AccelerationStructureBuildKHR | ";
+      result += " AccelerationStructureBuildKHR |";
     if ( value & PipelineStageFlagBits2::eRayTracingShaderKHR )
-      result += "RayTracingShaderKHR | ";
+      result += " RayTracingShaderKHR |";
     if ( value & PipelineStageFlagBits2::eFragmentDensityProcessEXT )
-      result += "FragmentDensityProcessEXT | ";
+      result += " FragmentDensityProcessEXT |";
     if ( value & PipelineStageFlagBits2::eTaskShaderEXT )
-      result += "TaskShaderEXT | ";
+      result += " TaskShaderEXT |";
     if ( value & PipelineStageFlagBits2::eMeshShaderEXT )
-      result += "MeshShaderEXT | ";
+      result += " MeshShaderEXT |";
     if ( value & PipelineStageFlagBits2::eSubpassShaderHUAWEI )
-      result += "SubpassShaderHUAWEI | ";
+      result += " SubpassShaderHUAWEI |";
     if ( value & PipelineStageFlagBits2::eInvocationMaskHUAWEI )
-      result += "InvocationMaskHUAWEI | ";
+      result += " InvocationMaskHUAWEI |";
     if ( value & PipelineStageFlagBits2::eAccelerationStructureCopyKHR )
-      result += "AccelerationStructureCopyKHR | ";
+      result += " AccelerationStructureCopyKHR |";
     if ( value & PipelineStageFlagBits2::eMicromapBuildEXT )
-      result += "MicromapBuildEXT | ";
+      result += " MicromapBuildEXT |";
     if ( value & PipelineStageFlagBits2::eClusterCullingShaderHUAWEI )
-      result += "ClusterCullingShaderHUAWEI | ";
+      result += " ClusterCullingShaderHUAWEI |";
     if ( value & PipelineStageFlagBits2::eOpticalFlowNV )
-      result += "OpticalFlowNV | ";
+      result += " OpticalFlowNV |";
     if ( value & PipelineStageFlagBits2::eConvertCooperativeVectorMatrixNV )
-      result += "ConvertCooperativeVectorMatrixNV | ";
+      result += " ConvertCooperativeVectorMatrixNV |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "None";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( AccessFlags2 value )
   {
-    if ( !value )
-      return "None";
-
-    std::string result;
+    std::string result = "{";
     if ( value & AccessFlagBits2::eIndirectCommandRead )
-      result += "IndirectCommandRead | ";
+      result += " IndirectCommandRead |";
     if ( value & AccessFlagBits2::eIndexRead )
-      result += "IndexRead | ";
+      result += " IndexRead |";
     if ( value & AccessFlagBits2::eVertexAttributeRead )
-      result += "VertexAttributeRead | ";
+      result += " VertexAttributeRead |";
     if ( value & AccessFlagBits2::eUniformRead )
-      result += "UniformRead | ";
+      result += " UniformRead |";
     if ( value & AccessFlagBits2::eInputAttachmentRead )
-      result += "InputAttachmentRead | ";
+      result += " InputAttachmentRead |";
     if ( value & AccessFlagBits2::eShaderRead )
-      result += "ShaderRead | ";
+      result += " ShaderRead |";
     if ( value & AccessFlagBits2::eShaderWrite )
-      result += "ShaderWrite | ";
+      result += " ShaderWrite |";
     if ( value & AccessFlagBits2::eColorAttachmentRead )
-      result += "ColorAttachmentRead | ";
+      result += " ColorAttachmentRead |";
     if ( value & AccessFlagBits2::eColorAttachmentWrite )
-      result += "ColorAttachmentWrite | ";
+      result += " ColorAttachmentWrite |";
     if ( value & AccessFlagBits2::eDepthStencilAttachmentRead )
-      result += "DepthStencilAttachmentRead | ";
+      result += " DepthStencilAttachmentRead |";
     if ( value & AccessFlagBits2::eDepthStencilAttachmentWrite )
-      result += "DepthStencilAttachmentWrite | ";
+      result += " DepthStencilAttachmentWrite |";
     if ( value & AccessFlagBits2::eTransferRead )
-      result += "TransferRead | ";
+      result += " TransferRead |";
     if ( value & AccessFlagBits2::eTransferWrite )
-      result += "TransferWrite | ";
+      result += " TransferWrite |";
     if ( value & AccessFlagBits2::eHostRead )
-      result += "HostRead | ";
+      result += " HostRead |";
     if ( value & AccessFlagBits2::eHostWrite )
-      result += "HostWrite | ";
+      result += " HostWrite |";
     if ( value & AccessFlagBits2::eMemoryRead )
-      result += "MemoryRead | ";
+      result += " MemoryRead |";
     if ( value & AccessFlagBits2::eMemoryWrite )
-      result += "MemoryWrite | ";
+      result += " MemoryWrite |";
     if ( value & AccessFlagBits2::eShaderSampledRead )
-      result += "ShaderSampledRead | ";
+      result += " ShaderSampledRead |";
     if ( value & AccessFlagBits2::eShaderStorageRead )
-      result += "ShaderStorageRead | ";
+      result += " ShaderStorageRead |";
     if ( value & AccessFlagBits2::eShaderStorageWrite )
-      result += "ShaderStorageWrite | ";
+      result += " ShaderStorageWrite |";
     if ( value & AccessFlagBits2::eVideoDecodeReadKHR )
-      result += "VideoDecodeReadKHR | ";
+      result += " VideoDecodeReadKHR |";
     if ( value & AccessFlagBits2::eVideoDecodeWriteKHR )
-      result += "VideoDecodeWriteKHR | ";
+      result += " VideoDecodeWriteKHR |";
     if ( value & AccessFlagBits2::eVideoEncodeReadKHR )
-      result += "VideoEncodeReadKHR | ";
+      result += " VideoEncodeReadKHR |";
     if ( value & AccessFlagBits2::eVideoEncodeWriteKHR )
-      result += "VideoEncodeWriteKHR | ";
+      result += " VideoEncodeWriteKHR |";
     if ( value & AccessFlagBits2::eTransformFeedbackWriteEXT )
-      result += "TransformFeedbackWriteEXT | ";
+      result += " TransformFeedbackWriteEXT |";
     if ( value & AccessFlagBits2::eTransformFeedbackCounterReadEXT )
-      result += "TransformFeedbackCounterReadEXT | ";
+      result += " TransformFeedbackCounterReadEXT |";
     if ( value & AccessFlagBits2::eTransformFeedbackCounterWriteEXT )
-      result += "TransformFeedbackCounterWriteEXT | ";
+      result += " TransformFeedbackCounterWriteEXT |";
     if ( value & AccessFlagBits2::eConditionalRenderingReadEXT )
-      result += "ConditionalRenderingReadEXT | ";
+      result += " ConditionalRenderingReadEXT |";
     if ( value & AccessFlagBits2::eCommandPreprocessReadNV )
-      result += "CommandPreprocessReadNV | ";
+      result += " CommandPreprocessReadNV |";
     if ( value & AccessFlagBits2::eCommandPreprocessWriteNV )
-      result += "CommandPreprocessWriteNV | ";
+      result += " CommandPreprocessWriteNV |";
     if ( value & AccessFlagBits2::eFragmentShadingRateAttachmentReadKHR )
-      result += "FragmentShadingRateAttachmentReadKHR | ";
+      result += " FragmentShadingRateAttachmentReadKHR |";
     if ( value & AccessFlagBits2::eAccelerationStructureReadKHR )
-      result += "AccelerationStructureReadKHR | ";
+      result += " AccelerationStructureReadKHR |";
     if ( value & AccessFlagBits2::eAccelerationStructureWriteKHR )
-      result += "AccelerationStructureWriteKHR | ";
+      result += " AccelerationStructureWriteKHR |";
     if ( value & AccessFlagBits2::eFragmentDensityMapReadEXT )
-      result += "FragmentDensityMapReadEXT | ";
+      result += " FragmentDensityMapReadEXT |";
     if ( value & AccessFlagBits2::eColorAttachmentReadNoncoherentEXT )
-      result += "ColorAttachmentReadNoncoherentEXT | ";
+      result += " ColorAttachmentReadNoncoherentEXT |";
     if ( value & AccessFlagBits2::eDescriptorBufferReadEXT )
-      result += "DescriptorBufferReadEXT | ";
+      result += " DescriptorBufferReadEXT |";
     if ( value & AccessFlagBits2::eInvocationMaskReadHUAWEI )
-      result += "InvocationMaskReadHUAWEI | ";
+      result += " InvocationMaskReadHUAWEI |";
     if ( value & AccessFlagBits2::eShaderBindingTableReadKHR )
-      result += "ShaderBindingTableReadKHR | ";
+      result += " ShaderBindingTableReadKHR |";
     if ( value & AccessFlagBits2::eMicromapReadEXT )
-      result += "MicromapReadEXT | ";
+      result += " MicromapReadEXT |";
     if ( value & AccessFlagBits2::eMicromapWriteEXT )
-      result += "MicromapWriteEXT | ";
+      result += " MicromapWriteEXT |";
     if ( value & AccessFlagBits2::eOpticalFlowReadNV )
-      result += "OpticalFlowReadNV | ";
+      result += " OpticalFlowReadNV |";
     if ( value & AccessFlagBits2::eOpticalFlowWriteNV )
-      result += "OpticalFlowWriteNV | ";
+      result += " OpticalFlowWriteNV |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "None";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( SubmitFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & SubmitFlagBits::eProtected )
-      result += "Protected | ";
+      result += " Protected |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( RenderingFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & RenderingFlagBits::eContentsSecondaryCommandBuffers )
-      result += "ContentsSecondaryCommandBuffers | ";
+      result += " ContentsSecondaryCommandBuffers |";
     if ( value & RenderingFlagBits::eSuspending )
-      result += "Suspending | ";
+      result += " Suspending |";
     if ( value & RenderingFlagBits::eResuming )
-      result += "Resuming | ";
+      result += " Resuming |";
     if ( value & RenderingFlagBits::eEnableLegacyDitheringEXT )
-      result += "EnableLegacyDitheringEXT | ";
+      result += " EnableLegacyDitheringEXT |";
     if ( value & RenderingFlagBits::eContentsInlineKHR )
-      result += "ContentsInlineKHR | ";
+      result += " ContentsInlineKHR |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( FormatFeatureFlags2 value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & FormatFeatureFlagBits2::eSampledImage )
-      result += "SampledImage | ";
+      result += " SampledImage |";
     if ( value & FormatFeatureFlagBits2::eStorageImage )
-      result += "StorageImage | ";
+      result += " StorageImage |";
     if ( value & FormatFeatureFlagBits2::eStorageImageAtomic )
-      result += "StorageImageAtomic | ";
+      result += " StorageImageAtomic |";
     if ( value & FormatFeatureFlagBits2::eUniformTexelBuffer )
-      result += "UniformTexelBuffer | ";
+      result += " UniformTexelBuffer |";
     if ( value & FormatFeatureFlagBits2::eStorageTexelBuffer )
-      result += "StorageTexelBuffer | ";
+      result += " StorageTexelBuffer |";
     if ( value & FormatFeatureFlagBits2::eStorageTexelBufferAtomic )
-      result += "StorageTexelBufferAtomic | ";
+      result += " StorageTexelBufferAtomic |";
     if ( value & FormatFeatureFlagBits2::eVertexBuffer )
-      result += "VertexBuffer | ";
+      result += " VertexBuffer |";
     if ( value & FormatFeatureFlagBits2::eColorAttachment )
-      result += "ColorAttachment | ";
+      result += " ColorAttachment |";
     if ( value & FormatFeatureFlagBits2::eColorAttachmentBlend )
-      result += "ColorAttachmentBlend | ";
+      result += " ColorAttachmentBlend |";
     if ( value & FormatFeatureFlagBits2::eDepthStencilAttachment )
-      result += "DepthStencilAttachment | ";
+      result += " DepthStencilAttachment |";
     if ( value & FormatFeatureFlagBits2::eBlitSrc )
-      result += "BlitSrc | ";
+      result += " BlitSrc |";
     if ( value & FormatFeatureFlagBits2::eBlitDst )
-      result += "BlitDst | ";
+      result += " BlitDst |";
     if ( value & FormatFeatureFlagBits2::eSampledImageFilterLinear )
-      result += "SampledImageFilterLinear | ";
+      result += " SampledImageFilterLinear |";
     if ( value & FormatFeatureFlagBits2::eTransferSrc )
-      result += "TransferSrc | ";
+      result += " TransferSrc |";
     if ( value & FormatFeatureFlagBits2::eTransferDst )
-      result += "TransferDst | ";
+      result += " TransferDst |";
     if ( value & FormatFeatureFlagBits2::eSampledImageFilterMinmax )
-      result += "SampledImageFilterMinmax | ";
+      result += " SampledImageFilterMinmax |";
     if ( value & FormatFeatureFlagBits2::eMidpointChromaSamples )
-      result += "MidpointChromaSamples | ";
+      result += " MidpointChromaSamples |";
     if ( value & FormatFeatureFlagBits2::eSampledImageYcbcrConversionLinearFilter )
-      result += "SampledImageYcbcrConversionLinearFilter | ";
+      result += " SampledImageYcbcrConversionLinearFilter |";
     if ( value & FormatFeatureFlagBits2::eSampledImageYcbcrConversionSeparateReconstructionFilter )
-      result += "SampledImageYcbcrConversionSeparateReconstructionFilter | ";
+      result += " SampledImageYcbcrConversionSeparateReconstructionFilter |";
     if ( value & FormatFeatureFlagBits2::eSampledImageYcbcrConversionChromaReconstructionExplicit )
-      result += "SampledImageYcbcrConversionChromaReconstructionExplicit | ";
+      result += " SampledImageYcbcrConversionChromaReconstructionExplicit |";
     if ( value & FormatFeatureFlagBits2::eSampledImageYcbcrConversionChromaReconstructionExplicitForceable )
-      result += "SampledImageYcbcrConversionChromaReconstructionExplicitForceable | ";
+      result += " SampledImageYcbcrConversionChromaReconstructionExplicitForceable |";
     if ( value & FormatFeatureFlagBits2::eDisjoint )
-      result += "Disjoint | ";
+      result += " Disjoint |";
     if ( value & FormatFeatureFlagBits2::eCositedChromaSamples )
-      result += "CositedChromaSamples | ";
+      result += " CositedChromaSamples |";
     if ( value & FormatFeatureFlagBits2::eStorageReadWithoutFormat )
-      result += "StorageReadWithoutFormat | ";
+      result += " StorageReadWithoutFormat |";
     if ( value & FormatFeatureFlagBits2::eStorageWriteWithoutFormat )
-      result += "StorageWriteWithoutFormat | ";
+      result += " StorageWriteWithoutFormat |";
     if ( value & FormatFeatureFlagBits2::eSampledImageDepthComparison )
-      result += "SampledImageDepthComparison | ";
+      result += " SampledImageDepthComparison |";
     if ( value & FormatFeatureFlagBits2::eSampledImageFilterCubic )
-      result += "SampledImageFilterCubic | ";
+      result += " SampledImageFilterCubic |";
     if ( value & FormatFeatureFlagBits2::eHostImageTransfer )
-      result += "HostImageTransfer | ";
+      result += " HostImageTransfer |";
     if ( value & FormatFeatureFlagBits2::eVideoDecodeOutputKHR )
-      result += "VideoDecodeOutputKHR | ";
+      result += " VideoDecodeOutputKHR |";
     if ( value & FormatFeatureFlagBits2::eVideoDecodeDpbKHR )
-      result += "VideoDecodeDpbKHR | ";
+      result += " VideoDecodeDpbKHR |";
     if ( value & FormatFeatureFlagBits2::eAccelerationStructureVertexBufferKHR )
-      result += "AccelerationStructureVertexBufferKHR | ";
+      result += " AccelerationStructureVertexBufferKHR |";
     if ( value & FormatFeatureFlagBits2::eFragmentDensityMapEXT )
-      result += "FragmentDensityMapEXT | ";
+      result += " FragmentDensityMapEXT |";
     if ( value & FormatFeatureFlagBits2::eFragmentShadingRateAttachmentKHR )
-      result += "FragmentShadingRateAttachmentKHR | ";
+      result += " FragmentShadingRateAttachmentKHR |";
     if ( value & FormatFeatureFlagBits2::eVideoEncodeInputKHR )
-      result += "VideoEncodeInputKHR | ";
+      result += " VideoEncodeInputKHR |";
     if ( value & FormatFeatureFlagBits2::eVideoEncodeDpbKHR )
-      result += "VideoEncodeDpbKHR | ";
+      result += " VideoEncodeDpbKHR |";
     if ( value & FormatFeatureFlagBits2::eAccelerationStructureRadiusBufferNV )
-      result += "AccelerationStructureRadiusBufferNV | ";
+      result += " AccelerationStructureRadiusBufferNV |";
     if ( value & FormatFeatureFlagBits2::eLinearColorAttachmentNV )
-      result += "LinearColorAttachmentNV | ";
+      result += " LinearColorAttachmentNV |";
     if ( value & FormatFeatureFlagBits2::eWeightImageQCOM )
-      result += "WeightImageQCOM | ";
+      result += " WeightImageQCOM |";
     if ( value & FormatFeatureFlagBits2::eWeightSampledImageQCOM )
-      result += "WeightSampledImageQCOM | ";
+      result += " WeightSampledImageQCOM |";
     if ( value & FormatFeatureFlagBits2::eBlockMatchingQCOM )
-      result += "BlockMatchingQCOM | ";
+      result += " BlockMatchingQCOM |";
     if ( value & FormatFeatureFlagBits2::eBoxFilterSampledQCOM )
-      result += "BoxFilterSampledQCOM | ";
+      result += " BoxFilterSampledQCOM |";
     if ( value & FormatFeatureFlagBits2::eOpticalFlowImageNV )
-      result += "OpticalFlowImageNV | ";
+      result += " OpticalFlowImageNV |";
     if ( value & FormatFeatureFlagBits2::eOpticalFlowVectorNV )
-      result += "OpticalFlowVectorNV | ";
+      result += " OpticalFlowVectorNV |";
     if ( value & FormatFeatureFlagBits2::eOpticalFlowCostNV )
-      result += "OpticalFlowCostNV | ";
+      result += " OpticalFlowCostNV |";
     if ( value & FormatFeatureFlagBits2::eVideoEncodeQuantizationDeltaMapKHR )
-      result += "VideoEncodeQuantizationDeltaMapKHR | ";
+      result += " VideoEncodeQuantizationDeltaMapKHR |";
     if ( value & FormatFeatureFlagBits2::eVideoEncodeEmphasisMapKHR )
-      result += "VideoEncodeEmphasisMapKHR | ";
+      result += " VideoEncodeEmphasisMapKHR |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_VERSION_1_4 ===
 
   VULKAN_HPP_INLINE std::string to_string( MemoryUnmapFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & MemoryUnmapFlagBits::eReserveEXT )
-      result += "ReserveEXT | ";
+      result += " ReserveEXT |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( PipelineCreateFlags2 value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & PipelineCreateFlagBits2::eDisableOptimization )
-      result += "DisableOptimization | ";
+      result += " DisableOptimization |";
     if ( value & PipelineCreateFlagBits2::eAllowDerivatives )
-      result += "AllowDerivatives | ";
+      result += " AllowDerivatives |";
     if ( value & PipelineCreateFlagBits2::eDerivative )
-      result += "Derivative | ";
+      result += " Derivative |";
     if ( value & PipelineCreateFlagBits2::eViewIndexFromDeviceIndex )
-      result += "ViewIndexFromDeviceIndex | ";
+      result += " ViewIndexFromDeviceIndex |";
     if ( value & PipelineCreateFlagBits2::eDispatchBase )
-      result += "DispatchBase | ";
+      result += " DispatchBase |";
     if ( value & PipelineCreateFlagBits2::eFailOnPipelineCompileRequired )
-      result += "FailOnPipelineCompileRequired | ";
+      result += " FailOnPipelineCompileRequired |";
     if ( value & PipelineCreateFlagBits2::eEarlyReturnOnFailure )
-      result += "EarlyReturnOnFailure | ";
+      result += " EarlyReturnOnFailure |";
     if ( value & PipelineCreateFlagBits2::eNoProtectedAccess )
-      result += "NoProtectedAccess | ";
+      result += " NoProtectedAccess |";
     if ( value & PipelineCreateFlagBits2::eProtectedAccessOnly )
-      result += "ProtectedAccessOnly | ";
+      result += " ProtectedAccessOnly |";
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
     if ( value & PipelineCreateFlagBits2::eExecutionGraphAMDX )
-      result += "ExecutionGraphAMDX | ";
+      result += " ExecutionGraphAMDX |";
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
     if ( value & PipelineCreateFlagBits2::eRayTracingAllowSpheresAndLinearSweptSpheresNV )
-      result += "RayTracingAllowSpheresAndLinearSweptSpheresNV | ";
+      result += " RayTracingAllowSpheresAndLinearSweptSpheresNV |";
     if ( value & PipelineCreateFlagBits2::eEnableLegacyDitheringEXT )
-      result += "EnableLegacyDitheringEXT | ";
+      result += " EnableLegacyDitheringEXT |";
     if ( value & PipelineCreateFlagBits2::eDeferCompileNV )
-      result += "DeferCompileNV | ";
+      result += " DeferCompileNV |";
     if ( value & PipelineCreateFlagBits2::eCaptureStatisticsKHR )
-      result += "CaptureStatisticsKHR | ";
+      result += " CaptureStatisticsKHR |";
     if ( value & PipelineCreateFlagBits2::eCaptureInternalRepresentationsKHR )
-      result += "CaptureInternalRepresentationsKHR | ";
+      result += " CaptureInternalRepresentationsKHR |";
     if ( value & PipelineCreateFlagBits2::eLinkTimeOptimizationEXT )
-      result += "LinkTimeOptimizationEXT | ";
+      result += " LinkTimeOptimizationEXT |";
     if ( value & PipelineCreateFlagBits2::eRetainLinkTimeOptimizationInfoEXT )
-      result += "RetainLinkTimeOptimizationInfoEXT | ";
+      result += " RetainLinkTimeOptimizationInfoEXT |";
     if ( value & PipelineCreateFlagBits2::eLibraryKHR )
-      result += "LibraryKHR | ";
+      result += " LibraryKHR |";
     if ( value & PipelineCreateFlagBits2::eRayTracingSkipTrianglesKHR )
-      result += "RayTracingSkipTrianglesKHR | ";
+      result += " RayTracingSkipTrianglesKHR |";
     if ( value & PipelineCreateFlagBits2::eRayTracingSkipAabbsKHR )
-      result += "RayTracingSkipAabbsKHR | ";
+      result += " RayTracingSkipAabbsKHR |";
     if ( value & PipelineCreateFlagBits2::eRayTracingNoNullAnyHitShadersKHR )
-      result += "RayTracingNoNullAnyHitShadersKHR | ";
+      result += " RayTracingNoNullAnyHitShadersKHR |";
     if ( value & PipelineCreateFlagBits2::eRayTracingNoNullClosestHitShadersKHR )
-      result += "RayTracingNoNullClosestHitShadersKHR | ";
+      result += " RayTracingNoNullClosestHitShadersKHR |";
     if ( value & PipelineCreateFlagBits2::eRayTracingNoNullMissShadersKHR )
-      result += "RayTracingNoNullMissShadersKHR | ";
+      result += " RayTracingNoNullMissShadersKHR |";
     if ( value & PipelineCreateFlagBits2::eRayTracingNoNullIntersectionShadersKHR )
-      result += "RayTracingNoNullIntersectionShadersKHR | ";
+      result += " RayTracingNoNullIntersectionShadersKHR |";
     if ( value & PipelineCreateFlagBits2::eRayTracingShaderGroupHandleCaptureReplayKHR )
-      result += "RayTracingShaderGroupHandleCaptureReplayKHR | ";
+      result += " RayTracingShaderGroupHandleCaptureReplayKHR |";
     if ( value & PipelineCreateFlagBits2::eIndirectBindableNV )
-      result += "IndirectBindableNV | ";
+      result += " IndirectBindableNV |";
     if ( value & PipelineCreateFlagBits2::eRayTracingAllowMotionNV )
-      result += "RayTracingAllowMotionNV | ";
+      result += " RayTracingAllowMotionNV |";
     if ( value & PipelineCreateFlagBits2::eRenderingFragmentShadingRateAttachmentKHR )
-      result += "RenderingFragmentShadingRateAttachmentKHR | ";
+      result += " RenderingFragmentShadingRateAttachmentKHR |";
     if ( value & PipelineCreateFlagBits2::eRenderingFragmentDensityMapAttachmentEXT )
-      result += "RenderingFragmentDensityMapAttachmentEXT | ";
+      result += " RenderingFragmentDensityMapAttachmentEXT |";
     if ( value & PipelineCreateFlagBits2::eRayTracingOpacityMicromapEXT )
-      result += "RayTracingOpacityMicromapEXT | ";
+      result += " RayTracingOpacityMicromapEXT |";
     if ( value & PipelineCreateFlagBits2::eColorAttachmentFeedbackLoopEXT )
-      result += "ColorAttachmentFeedbackLoopEXT | ";
+      result += " ColorAttachmentFeedbackLoopEXT |";
     if ( value & PipelineCreateFlagBits2::eDepthStencilAttachmentFeedbackLoopEXT )
-      result += "DepthStencilAttachmentFeedbackLoopEXT | ";
+      result += " DepthStencilAttachmentFeedbackLoopEXT |";
     if ( value & PipelineCreateFlagBits2::eRayTracingDisplacementMicromapNV )
-      result += "RayTracingDisplacementMicromapNV | ";
+      result += " RayTracingDisplacementMicromapNV |";
     if ( value & PipelineCreateFlagBits2::eDescriptorBufferEXT )
-      result += "DescriptorBufferEXT | ";
+      result += " DescriptorBufferEXT |";
     if ( value & PipelineCreateFlagBits2::eDisallowOpacityMicromapARM )
-      result += "DisallowOpacityMicromapARM | ";
+      result += " DisallowOpacityMicromapARM |";
     if ( value & PipelineCreateFlagBits2::eCaptureDataKHR )
-      result += "CaptureDataKHR | ";
+      result += " CaptureDataKHR |";
     if ( value & PipelineCreateFlagBits2::eIndirectBindableEXT )
-      result += "IndirectBindableEXT | ";
+      result += " IndirectBindableEXT |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( BufferUsageFlags2 value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & BufferUsageFlagBits2::eTransferSrc )
-      result += "TransferSrc | ";
+      result += " TransferSrc |";
     if ( value & BufferUsageFlagBits2::eTransferDst )
-      result += "TransferDst | ";
+      result += " TransferDst |";
     if ( value & BufferUsageFlagBits2::eUniformTexelBuffer )
-      result += "UniformTexelBuffer | ";
+      result += " UniformTexelBuffer |";
     if ( value & BufferUsageFlagBits2::eStorageTexelBuffer )
-      result += "StorageTexelBuffer | ";
+      result += " StorageTexelBuffer |";
     if ( value & BufferUsageFlagBits2::eUniformBuffer )
-      result += "UniformBuffer | ";
+      result += " UniformBuffer |";
     if ( value & BufferUsageFlagBits2::eStorageBuffer )
-      result += "StorageBuffer | ";
+      result += " StorageBuffer |";
     if ( value & BufferUsageFlagBits2::eIndexBuffer )
-      result += "IndexBuffer | ";
+      result += " IndexBuffer |";
     if ( value & BufferUsageFlagBits2::eVertexBuffer )
-      result += "VertexBuffer | ";
+      result += " VertexBuffer |";
     if ( value & BufferUsageFlagBits2::eIndirectBuffer )
-      result += "IndirectBuffer | ";
+      result += " IndirectBuffer |";
     if ( value & BufferUsageFlagBits2::eShaderDeviceAddress )
-      result += "ShaderDeviceAddress | ";
+      result += " ShaderDeviceAddress |";
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
     if ( value & BufferUsageFlagBits2::eExecutionGraphScratchAMDX )
-      result += "ExecutionGraphScratchAMDX | ";
+      result += " ExecutionGraphScratchAMDX |";
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
     if ( value & BufferUsageFlagBits2::eConditionalRenderingEXT )
-      result += "ConditionalRenderingEXT | ";
+      result += " ConditionalRenderingEXT |";
     if ( value & BufferUsageFlagBits2::eShaderBindingTableKHR )
-      result += "ShaderBindingTableKHR | ";
+      result += " ShaderBindingTableKHR |";
     if ( value & BufferUsageFlagBits2::eTransformFeedbackBufferEXT )
-      result += "TransformFeedbackBufferEXT | ";
+      result += " TransformFeedbackBufferEXT |";
     if ( value & BufferUsageFlagBits2::eTransformFeedbackCounterBufferEXT )
-      result += "TransformFeedbackCounterBufferEXT | ";
+      result += " TransformFeedbackCounterBufferEXT |";
     if ( value & BufferUsageFlagBits2::eVideoDecodeSrcKHR )
-      result += "VideoDecodeSrcKHR | ";
+      result += " VideoDecodeSrcKHR |";
     if ( value & BufferUsageFlagBits2::eVideoDecodeDstKHR )
-      result += "VideoDecodeDstKHR | ";
+      result += " VideoDecodeDstKHR |";
     if ( value & BufferUsageFlagBits2::eVideoEncodeDstKHR )
-      result += "VideoEncodeDstKHR | ";
+      result += " VideoEncodeDstKHR |";
     if ( value & BufferUsageFlagBits2::eVideoEncodeSrcKHR )
-      result += "VideoEncodeSrcKHR | ";
+      result += " VideoEncodeSrcKHR |";
     if ( value & BufferUsageFlagBits2::eAccelerationStructureBuildInputReadOnlyKHR )
-      result += "AccelerationStructureBuildInputReadOnlyKHR | ";
+      result += " AccelerationStructureBuildInputReadOnlyKHR |";
     if ( value & BufferUsageFlagBits2::eAccelerationStructureStorageKHR )
-      result += "AccelerationStructureStorageKHR | ";
+      result += " AccelerationStructureStorageKHR |";
     if ( value & BufferUsageFlagBits2::eSamplerDescriptorBufferEXT )
-      result += "SamplerDescriptorBufferEXT | ";
+      result += " SamplerDescriptorBufferEXT |";
     if ( value & BufferUsageFlagBits2::eResourceDescriptorBufferEXT )
-      result += "ResourceDescriptorBufferEXT | ";
+      result += " ResourceDescriptorBufferEXT |";
     if ( value & BufferUsageFlagBits2::ePushDescriptorsDescriptorBufferEXT )
-      result += "PushDescriptorsDescriptorBufferEXT | ";
+      result += " PushDescriptorsDescriptorBufferEXT |";
     if ( value & BufferUsageFlagBits2::eMicromapBuildInputReadOnlyEXT )
-      result += "MicromapBuildInputReadOnlyEXT | ";
+      result += " MicromapBuildInputReadOnlyEXT |";
     if ( value & BufferUsageFlagBits2::eMicromapStorageEXT )
-      result += "MicromapStorageEXT | ";
+      result += " MicromapStorageEXT |";
     if ( value & BufferUsageFlagBits2::ePreprocessBufferEXT )
-      result += "PreprocessBufferEXT | ";
+      result += " PreprocessBufferEXT |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( HostImageCopyFlags value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & HostImageCopyFlagBits::eMemcpy )
-      result += "Memcpy | ";
+      result += " Memcpy |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_KHR_surface ===
 
   VULKAN_HPP_INLINE std::string to_string( CompositeAlphaFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & CompositeAlphaFlagBitsKHR::eOpaque )
-      result += "Opaque | ";
+      result += " Opaque |";
     if ( value & CompositeAlphaFlagBitsKHR::ePreMultiplied )
-      result += "PreMultiplied | ";
+      result += " PreMultiplied |";
     if ( value & CompositeAlphaFlagBitsKHR::ePostMultiplied )
-      result += "PostMultiplied | ";
+      result += " PostMultiplied |";
     if ( value & CompositeAlphaFlagBitsKHR::eInherit )
-      result += "Inherit | ";
+      result += " Inherit |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_KHR_swapchain ===
 
   VULKAN_HPP_INLINE std::string to_string( SwapchainCreateFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & SwapchainCreateFlagBitsKHR::eSplitInstanceBindRegions )
-      result += "SplitInstanceBindRegions | ";
+      result += " SplitInstanceBindRegions |";
     if ( value & SwapchainCreateFlagBitsKHR::eProtected )
-      result += "Protected | ";
+      result += " Protected |";
     if ( value & SwapchainCreateFlagBitsKHR::eMutableFormat )
-      result += "MutableFormat | ";
+      result += " MutableFormat |";
     if ( value & SwapchainCreateFlagBitsKHR::eDeferredMemoryAllocationEXT )
-      result += "DeferredMemoryAllocationEXT | ";
+      result += " DeferredMemoryAllocationEXT |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( DeviceGroupPresentModeFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & DeviceGroupPresentModeFlagBitsKHR::eLocal )
-      result += "Local | ";
+      result += " Local |";
     if ( value & DeviceGroupPresentModeFlagBitsKHR::eRemote )
-      result += "Remote | ";
+      result += " Remote |";
     if ( value & DeviceGroupPresentModeFlagBitsKHR::eSum )
-      result += "Sum | ";
+      result += " Sum |";
     if ( value & DeviceGroupPresentModeFlagBitsKHR::eLocalMultiDevice )
-      result += "LocalMultiDevice | ";
+      result += " LocalMultiDevice |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_KHR_display ===
@@ -2133,20 +2206,21 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( DisplayPlaneAlphaFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & DisplayPlaneAlphaFlagBitsKHR::eOpaque )
-      result += "Opaque | ";
+      result += " Opaque |";
     if ( value & DisplayPlaneAlphaFlagBitsKHR::eGlobal )
-      result += "Global | ";
+      result += " Global |";
     if ( value & DisplayPlaneAlphaFlagBitsKHR::ePerPixel )
-      result += "PerPixel | ";
+      result += " PerPixel |";
     if ( value & DisplayPlaneAlphaFlagBitsKHR::ePerPixelPremultiplied )
-      result += "PerPixelPremultiplied | ";
+      result += " PerPixelPremultiplied |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( DisplaySurfaceCreateFlagsKHR )
@@ -2156,30 +2230,31 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( SurfaceTransformFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & SurfaceTransformFlagBitsKHR::eIdentity )
-      result += "Identity | ";
+      result += " Identity |";
     if ( value & SurfaceTransformFlagBitsKHR::eRotate90 )
-      result += "Rotate90 | ";
+      result += " Rotate90 |";
     if ( value & SurfaceTransformFlagBitsKHR::eRotate180 )
-      result += "Rotate180 | ";
+      result += " Rotate180 |";
     if ( value & SurfaceTransformFlagBitsKHR::eRotate270 )
-      result += "Rotate270 | ";
+      result += " Rotate270 |";
     if ( value & SurfaceTransformFlagBitsKHR::eHorizontalMirror )
-      result += "HorizontalMirror | ";
+      result += " HorizontalMirror |";
     if ( value & SurfaceTransformFlagBitsKHR::eHorizontalMirrorRotate90 )
-      result += "HorizontalMirrorRotate90 | ";
+      result += " HorizontalMirrorRotate90 |";
     if ( value & SurfaceTransformFlagBitsKHR::eHorizontalMirrorRotate180 )
-      result += "HorizontalMirrorRotate180 | ";
+      result += " HorizontalMirrorRotate180 |";
     if ( value & SurfaceTransformFlagBitsKHR::eHorizontalMirrorRotate270 )
-      result += "HorizontalMirrorRotate270 | ";
+      result += " HorizontalMirrorRotate270 |";
     if ( value & SurfaceTransformFlagBitsKHR::eInherit )
-      result += "Inherit | ";
+      result += " Inherit |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
 #if defined( VK_USE_PLATFORM_XLIB_KHR )
@@ -2231,128 +2306,135 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( DebugReportFlagsEXT value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & DebugReportFlagBitsEXT::eInformation )
-      result += "Information | ";
+      result += " Information |";
     if ( value & DebugReportFlagBitsEXT::eWarning )
-      result += "Warning | ";
+      result += " Warning |";
     if ( value & DebugReportFlagBitsEXT::ePerformanceWarning )
-      result += "PerformanceWarning | ";
+      result += " PerformanceWarning |";
     if ( value & DebugReportFlagBitsEXT::eError )
-      result += "Error | ";
+      result += " Error |";
     if ( value & DebugReportFlagBitsEXT::eDebug )
-      result += "Debug | ";
+      result += " Debug |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_KHR_video_queue ===
 
   VULKAN_HPP_INLINE std::string to_string( VideoCodecOperationFlagsKHR value )
   {
-    if ( !value )
-      return "None";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoCodecOperationFlagBitsKHR::eEncodeH264 )
-      result += "EncodeH264 | ";
+      result += " EncodeH264 |";
     if ( value & VideoCodecOperationFlagBitsKHR::eEncodeH265 )
-      result += "EncodeH265 | ";
+      result += " EncodeH265 |";
     if ( value & VideoCodecOperationFlagBitsKHR::eDecodeH264 )
-      result += "DecodeH264 | ";
+      result += " DecodeH264 |";
     if ( value & VideoCodecOperationFlagBitsKHR::eDecodeH265 )
-      result += "DecodeH265 | ";
+      result += " DecodeH265 |";
     if ( value & VideoCodecOperationFlagBitsKHR::eDecodeAv1 )
-      result += "DecodeAv1 | ";
+      result += " DecodeAv1 |";
     if ( value & VideoCodecOperationFlagBitsKHR::eEncodeAv1 )
-      result += "EncodeAv1 | ";
+      result += " EncodeAv1 |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "None";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoChromaSubsamplingFlagsKHR value )
   {
-    if ( !value )
-      return "Invalid";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoChromaSubsamplingFlagBitsKHR::eMonochrome )
-      result += "Monochrome | ";
+      result += " Monochrome |";
     if ( value & VideoChromaSubsamplingFlagBitsKHR::e420 )
-      result += "420 | ";
+      result += " 420 |";
     if ( value & VideoChromaSubsamplingFlagBitsKHR::e422 )
-      result += "422 | ";
+      result += " 422 |";
     if ( value & VideoChromaSubsamplingFlagBitsKHR::e444 )
-      result += "444 | ";
+      result += " 444 |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "Invalid";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoComponentBitDepthFlagsKHR value )
   {
-    if ( !value )
-      return "Invalid";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoComponentBitDepthFlagBitsKHR::e8 )
-      result += "8 | ";
+      result += " 8 |";
     if ( value & VideoComponentBitDepthFlagBitsKHR::e10 )
-      result += "10 | ";
+      result += " 10 |";
     if ( value & VideoComponentBitDepthFlagBitsKHR::e12 )
-      result += "12 | ";
+      result += " 12 |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "Invalid";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoCapabilityFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoCapabilityFlagBitsKHR::eProtectedContent )
-      result += "ProtectedContent | ";
+      result += " ProtectedContent |";
     if ( value & VideoCapabilityFlagBitsKHR::eSeparateReferenceImages )
-      result += "SeparateReferenceImages | ";
+      result += " SeparateReferenceImages |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoSessionCreateFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoSessionCreateFlagBitsKHR::eProtectedContent )
-      result += "ProtectedContent | ";
+      result += " ProtectedContent |";
     if ( value & VideoSessionCreateFlagBitsKHR::eAllowEncodeParameterOptimizations )
-      result += "AllowEncodeParameterOptimizations | ";
+      result += " AllowEncodeParameterOptimizations |";
     if ( value & VideoSessionCreateFlagBitsKHR::eInlineQueries )
-      result += "InlineQueries | ";
+      result += " InlineQueries |";
     if ( value & VideoSessionCreateFlagBitsKHR::eAllowEncodeQuantizationDeltaMap )
-      result += "AllowEncodeQuantizationDeltaMap | ";
+      result += " AllowEncodeQuantizationDeltaMap |";
     if ( value & VideoSessionCreateFlagBitsKHR::eAllowEncodeEmphasisMap )
-      result += "AllowEncodeEmphasisMap | ";
+      result += " AllowEncodeEmphasisMap |";
     if ( value & VideoSessionCreateFlagBitsKHR::eInlineSessionParameters )
-      result += "InlineSessionParameters | ";
+      result += " InlineSessionParameters |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoSessionParametersCreateFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoSessionParametersCreateFlagBitsKHR::eQuantizationMapCompatible )
-      result += "QuantizationMapCompatible | ";
+      result += " QuantizationMapCompatible |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoBeginCodingFlagsKHR )
@@ -2367,50 +2449,53 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( VideoCodingControlFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoCodingControlFlagBitsKHR::eReset )
-      result += "Reset | ";
+      result += " Reset |";
     if ( value & VideoCodingControlFlagBitsKHR::eEncodeRateControl )
-      result += "EncodeRateControl | ";
+      result += " EncodeRateControl |";
     if ( value & VideoCodingControlFlagBitsKHR::eEncodeQualityLevel )
-      result += "EncodeQualityLevel | ";
+      result += " EncodeQualityLevel |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_KHR_video_decode_queue ===
 
   VULKAN_HPP_INLINE std::string to_string( VideoDecodeCapabilityFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoDecodeCapabilityFlagBitsKHR::eDpbAndOutputCoincide )
-      result += "DpbAndOutputCoincide | ";
+      result += " DpbAndOutputCoincide |";
     if ( value & VideoDecodeCapabilityFlagBitsKHR::eDpbAndOutputDistinct )
-      result += "DpbAndOutputDistinct | ";
+      result += " DpbAndOutputDistinct |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoDecodeUsageFlagsKHR value )
   {
-    if ( !value )
-      return "Default";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoDecodeUsageFlagBitsKHR::eTranscoding )
-      result += "Transcoding | ";
+      result += " Transcoding |";
     if ( value & VideoDecodeUsageFlagBitsKHR::eOffline )
-      result += "Offline | ";
+      result += " Offline |";
     if ( value & VideoDecodeUsageFlagBitsKHR::eStreaming )
-      result += "Streaming | ";
+      result += " Streaming |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "Default";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoDecodeFlagsKHR )
@@ -2429,258 +2514,267 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH264CapabilityFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoEncodeH264CapabilityFlagBitsKHR::eHrdCompliance )
-      result += "HrdCompliance | ";
+      result += " HrdCompliance |";
     if ( value & VideoEncodeH264CapabilityFlagBitsKHR::ePredictionWeightTableGenerated )
-      result += "PredictionWeightTableGenerated | ";
+      result += " PredictionWeightTableGenerated |";
     if ( value & VideoEncodeH264CapabilityFlagBitsKHR::eRowUnalignedSlice )
-      result += "RowUnalignedSlice | ";
+      result += " RowUnalignedSlice |";
     if ( value & VideoEncodeH264CapabilityFlagBitsKHR::eDifferentSliceType )
-      result += "DifferentSliceType | ";
+      result += " DifferentSliceType |";
     if ( value & VideoEncodeH264CapabilityFlagBitsKHR::eBFrameInL0List )
-      result += "BFrameInL0List | ";
+      result += " BFrameInL0List |";
     if ( value & VideoEncodeH264CapabilityFlagBitsKHR::eBFrameInL1List )
-      result += "BFrameInL1List | ";
+      result += " BFrameInL1List |";
     if ( value & VideoEncodeH264CapabilityFlagBitsKHR::ePerPictureTypeMinMaxQp )
-      result += "PerPictureTypeMinMaxQp | ";
+      result += " PerPictureTypeMinMaxQp |";
     if ( value & VideoEncodeH264CapabilityFlagBitsKHR::ePerSliceConstantQp )
-      result += "PerSliceConstantQp | ";
+      result += " PerSliceConstantQp |";
     if ( value & VideoEncodeH264CapabilityFlagBitsKHR::eGeneratePrefixNalu )
-      result += "GeneratePrefixNalu | ";
+      result += " GeneratePrefixNalu |";
     if ( value & VideoEncodeH264CapabilityFlagBitsKHR::eMbQpDiffWraparound )
-      result += "MbQpDiffWraparound | ";
+      result += " MbQpDiffWraparound |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH264StdFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eSeparateColorPlaneFlagSet )
-      result += "SeparateColorPlaneFlagSet | ";
+      result += " SeparateColorPlaneFlagSet |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eQpprimeYZeroTransformBypassFlagSet )
-      result += "QpprimeYZeroTransformBypassFlagSet | ";
+      result += " QpprimeYZeroTransformBypassFlagSet |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eScalingMatrixPresentFlagSet )
-      result += "ScalingMatrixPresentFlagSet | ";
+      result += " ScalingMatrixPresentFlagSet |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eChromaQpIndexOffset )
-      result += "ChromaQpIndexOffset | ";
+      result += " ChromaQpIndexOffset |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eSecondChromaQpIndexOffset )
-      result += "SecondChromaQpIndexOffset | ";
+      result += " SecondChromaQpIndexOffset |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::ePicInitQpMinus26 )
-      result += "PicInitQpMinus26 | ";
+      result += " PicInitQpMinus26 |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eWeightedPredFlagSet )
-      result += "WeightedPredFlagSet | ";
+      result += " WeightedPredFlagSet |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eWeightedBipredIdcExplicit )
-      result += "WeightedBipredIdcExplicit | ";
+      result += " WeightedBipredIdcExplicit |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eWeightedBipredIdcImplicit )
-      result += "WeightedBipredIdcImplicit | ";
+      result += " WeightedBipredIdcImplicit |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eTransform8X8ModeFlagSet )
-      result += "Transform8X8ModeFlagSet | ";
+      result += " Transform8X8ModeFlagSet |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eDirectSpatialMvPredFlagUnset )
-      result += "DirectSpatialMvPredFlagUnset | ";
+      result += " DirectSpatialMvPredFlagUnset |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eEntropyCodingModeFlagUnset )
-      result += "EntropyCodingModeFlagUnset | ";
+      result += " EntropyCodingModeFlagUnset |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eEntropyCodingModeFlagSet )
-      result += "EntropyCodingModeFlagSet | ";
+      result += " EntropyCodingModeFlagSet |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eDirect8X8InferenceFlagUnset )
-      result += "Direct8X8InferenceFlagUnset | ";
+      result += " Direct8X8InferenceFlagUnset |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eConstrainedIntraPredFlagSet )
-      result += "ConstrainedIntraPredFlagSet | ";
+      result += " ConstrainedIntraPredFlagSet |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eDeblockingFilterDisabled )
-      result += "DeblockingFilterDisabled | ";
+      result += " DeblockingFilterDisabled |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eDeblockingFilterEnabled )
-      result += "DeblockingFilterEnabled | ";
+      result += " DeblockingFilterEnabled |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eDeblockingFilterPartial )
-      result += "DeblockingFilterPartial | ";
+      result += " DeblockingFilterPartial |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eSliceQpDelta )
-      result += "SliceQpDelta | ";
+      result += " SliceQpDelta |";
     if ( value & VideoEncodeH264StdFlagBitsKHR::eDifferentSliceQpDelta )
-      result += "DifferentSliceQpDelta | ";
+      result += " DifferentSliceQpDelta |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH264RateControlFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoEncodeH264RateControlFlagBitsKHR::eAttemptHrdCompliance )
-      result += "AttemptHrdCompliance | ";
+      result += " AttemptHrdCompliance |";
     if ( value & VideoEncodeH264RateControlFlagBitsKHR::eRegularGop )
-      result += "RegularGop | ";
+      result += " RegularGop |";
     if ( value & VideoEncodeH264RateControlFlagBitsKHR::eReferencePatternFlat )
-      result += "ReferencePatternFlat | ";
+      result += " ReferencePatternFlat |";
     if ( value & VideoEncodeH264RateControlFlagBitsKHR::eReferencePatternDyadic )
-      result += "ReferencePatternDyadic | ";
+      result += " ReferencePatternDyadic |";
     if ( value & VideoEncodeH264RateControlFlagBitsKHR::eTemporalLayerPatternDyadic )
-      result += "TemporalLayerPatternDyadic | ";
+      result += " TemporalLayerPatternDyadic |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_KHR_video_encode_h265 ===
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH265CapabilityFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoEncodeH265CapabilityFlagBitsKHR::eHrdCompliance )
-      result += "HrdCompliance | ";
+      result += " HrdCompliance |";
     if ( value & VideoEncodeH265CapabilityFlagBitsKHR::ePredictionWeightTableGenerated )
-      result += "PredictionWeightTableGenerated | ";
+      result += " PredictionWeightTableGenerated |";
     if ( value & VideoEncodeH265CapabilityFlagBitsKHR::eRowUnalignedSliceSegment )
-      result += "RowUnalignedSliceSegment | ";
+      result += " RowUnalignedSliceSegment |";
     if ( value & VideoEncodeH265CapabilityFlagBitsKHR::eDifferentSliceSegmentType )
-      result += "DifferentSliceSegmentType | ";
+      result += " DifferentSliceSegmentType |";
     if ( value & VideoEncodeH265CapabilityFlagBitsKHR::eBFrameInL0List )
-      result += "BFrameInL0List | ";
+      result += " BFrameInL0List |";
     if ( value & VideoEncodeH265CapabilityFlagBitsKHR::eBFrameInL1List )
-      result += "BFrameInL1List | ";
+      result += " BFrameInL1List |";
     if ( value & VideoEncodeH265CapabilityFlagBitsKHR::ePerPictureTypeMinMaxQp )
-      result += "PerPictureTypeMinMaxQp | ";
+      result += " PerPictureTypeMinMaxQp |";
     if ( value & VideoEncodeH265CapabilityFlagBitsKHR::ePerSliceSegmentConstantQp )
-      result += "PerSliceSegmentConstantQp | ";
+      result += " PerSliceSegmentConstantQp |";
     if ( value & VideoEncodeH265CapabilityFlagBitsKHR::eMultipleTilesPerSliceSegment )
-      result += "MultipleTilesPerSliceSegment | ";
+      result += " MultipleTilesPerSliceSegment |";
     if ( value & VideoEncodeH265CapabilityFlagBitsKHR::eMultipleSliceSegmentsPerTile )
-      result += "MultipleSliceSegmentsPerTile | ";
+      result += " MultipleSliceSegmentsPerTile |";
     if ( value & VideoEncodeH265CapabilityFlagBitsKHR::eCuQpDiffWraparound )
-      result += "CuQpDiffWraparound | ";
+      result += " CuQpDiffWraparound |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH265StdFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eSeparateColorPlaneFlagSet )
-      result += "SeparateColorPlaneFlagSet | ";
+      result += " SeparateColorPlaneFlagSet |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eSampleAdaptiveOffsetEnabledFlagSet )
-      result += "SampleAdaptiveOffsetEnabledFlagSet | ";
+      result += " SampleAdaptiveOffsetEnabledFlagSet |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eScalingListDataPresentFlagSet )
-      result += "ScalingListDataPresentFlagSet | ";
+      result += " ScalingListDataPresentFlagSet |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::ePcmEnabledFlagSet )
-      result += "PcmEnabledFlagSet | ";
+      result += " PcmEnabledFlagSet |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eSpsTemporalMvpEnabledFlagSet )
-      result += "SpsTemporalMvpEnabledFlagSet | ";
+      result += " SpsTemporalMvpEnabledFlagSet |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eInitQpMinus26 )
-      result += "InitQpMinus26 | ";
+      result += " InitQpMinus26 |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eWeightedPredFlagSet )
-      result += "WeightedPredFlagSet | ";
+      result += " WeightedPredFlagSet |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eWeightedBipredFlagSet )
-      result += "WeightedBipredFlagSet | ";
+      result += " WeightedBipredFlagSet |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eLog2ParallelMergeLevelMinus2 )
-      result += "Log2ParallelMergeLevelMinus2 | ";
+      result += " Log2ParallelMergeLevelMinus2 |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eSignDataHidingEnabledFlagSet )
-      result += "SignDataHidingEnabledFlagSet | ";
+      result += " SignDataHidingEnabledFlagSet |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eTransformSkipEnabledFlagSet )
-      result += "TransformSkipEnabledFlagSet | ";
+      result += " TransformSkipEnabledFlagSet |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eTransformSkipEnabledFlagUnset )
-      result += "TransformSkipEnabledFlagUnset | ";
+      result += " TransformSkipEnabledFlagUnset |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::ePpsSliceChromaQpOffsetsPresentFlagSet )
-      result += "PpsSliceChromaQpOffsetsPresentFlagSet | ";
+      result += " PpsSliceChromaQpOffsetsPresentFlagSet |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eTransquantBypassEnabledFlagSet )
-      result += "TransquantBypassEnabledFlagSet | ";
+      result += " TransquantBypassEnabledFlagSet |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eConstrainedIntraPredFlagSet )
-      result += "ConstrainedIntraPredFlagSet | ";
+      result += " ConstrainedIntraPredFlagSet |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eEntropyCodingSyncEnabledFlagSet )
-      result += "EntropyCodingSyncEnabledFlagSet | ";
+      result += " EntropyCodingSyncEnabledFlagSet |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eDeblockingFilterOverrideEnabledFlagSet )
-      result += "DeblockingFilterOverrideEnabledFlagSet | ";
+      result += " DeblockingFilterOverrideEnabledFlagSet |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eDependentSliceSegmentsEnabledFlagSet )
-      result += "DependentSliceSegmentsEnabledFlagSet | ";
+      result += " DependentSliceSegmentsEnabledFlagSet |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eDependentSliceSegmentFlagSet )
-      result += "DependentSliceSegmentFlagSet | ";
+      result += " DependentSliceSegmentFlagSet |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eSliceQpDelta )
-      result += "SliceQpDelta | ";
+      result += " SliceQpDelta |";
     if ( value & VideoEncodeH265StdFlagBitsKHR::eDifferentSliceQpDelta )
-      result += "DifferentSliceQpDelta | ";
+      result += " DifferentSliceQpDelta |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH265CtbSizeFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoEncodeH265CtbSizeFlagBitsKHR::e16 )
-      result += "16 | ";
+      result += " 16 |";
     if ( value & VideoEncodeH265CtbSizeFlagBitsKHR::e32 )
-      result += "32 | ";
+      result += " 32 |";
     if ( value & VideoEncodeH265CtbSizeFlagBitsKHR::e64 )
-      result += "64 | ";
+      result += " 64 |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH265TransformBlockSizeFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoEncodeH265TransformBlockSizeFlagBitsKHR::e4 )
-      result += "4 | ";
+      result += " 4 |";
     if ( value & VideoEncodeH265TransformBlockSizeFlagBitsKHR::e8 )
-      result += "8 | ";
+      result += " 8 |";
     if ( value & VideoEncodeH265TransformBlockSizeFlagBitsKHR::e16 )
-      result += "16 | ";
+      result += " 16 |";
     if ( value & VideoEncodeH265TransformBlockSizeFlagBitsKHR::e32 )
-      result += "32 | ";
+      result += " 32 |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeH265RateControlFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoEncodeH265RateControlFlagBitsKHR::eAttemptHrdCompliance )
-      result += "AttemptHrdCompliance | ";
+      result += " AttemptHrdCompliance |";
     if ( value & VideoEncodeH265RateControlFlagBitsKHR::eRegularGop )
-      result += "RegularGop | ";
+      result += " RegularGop |";
     if ( value & VideoEncodeH265RateControlFlagBitsKHR::eReferencePatternFlat )
-      result += "ReferencePatternFlat | ";
+      result += " ReferencePatternFlat |";
     if ( value & VideoEncodeH265RateControlFlagBitsKHR::eReferencePatternDyadic )
-      result += "ReferencePatternDyadic | ";
+      result += " ReferencePatternDyadic |";
     if ( value & VideoEncodeH265RateControlFlagBitsKHR::eTemporalSubLayerPatternDyadic )
-      result += "TemporalSubLayerPatternDyadic | ";
+      result += " TemporalSubLayerPatternDyadic |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_KHR_video_decode_h264 ===
 
   VULKAN_HPP_INLINE std::string to_string( VideoDecodeH264PictureLayoutFlagsKHR value )
   {
-    if ( !value )
-      return "Progressive";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoDecodeH264PictureLayoutFlagBitsKHR::eInterlacedInterleavedLines )
-      result += "InterlacedInterleavedLines | ";
+      result += " InterlacedInterleavedLines |";
     if ( value & VideoDecodeH264PictureLayoutFlagBitsKHR::eInterlacedSeparatePlanes )
-      result += "InterlacedSeparatePlanes | ";
+      result += " InterlacedSeparatePlanes |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "Progressive";
+    return result;
   }
 
 #if defined( VK_USE_PLATFORM_GGP )
@@ -2696,36 +2790,38 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( ExternalMemoryHandleTypeFlagsNV value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ExternalMemoryHandleTypeFlagBitsNV::eOpaqueWin32 )
-      result += "OpaqueWin32 | ";
+      result += " OpaqueWin32 |";
     if ( value & ExternalMemoryHandleTypeFlagBitsNV::eOpaqueWin32Kmt )
-      result += "OpaqueWin32Kmt | ";
+      result += " OpaqueWin32Kmt |";
     if ( value & ExternalMemoryHandleTypeFlagBitsNV::eD3D11Image )
-      result += "D3D11Image | ";
+      result += " D3D11Image |";
     if ( value & ExternalMemoryHandleTypeFlagBitsNV::eD3D11ImageKmt )
-      result += "D3D11ImageKmt | ";
+      result += " D3D11ImageKmt |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( ExternalMemoryFeatureFlagsNV value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ExternalMemoryFeatureFlagBitsNV::eDedicatedOnly )
-      result += "DedicatedOnly | ";
+      result += " DedicatedOnly |";
     if ( value & ExternalMemoryFeatureFlagBitsNV::eExportable )
-      result += "Exportable | ";
+      result += " Exportable |";
     if ( value & ExternalMemoryFeatureFlagBitsNV::eImportable )
-      result += "Importable | ";
+      result += " Importable |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
 #if defined( VK_USE_PLATFORM_VI_NN )
@@ -2741,28 +2837,30 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( ConditionalRenderingFlagsEXT value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ConditionalRenderingFlagBitsEXT::eInverted )
-      result += "Inverted | ";
+      result += " Inverted |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_EXT_display_surface_counter ===
 
   VULKAN_HPP_INLINE std::string to_string( SurfaceCounterFlagsEXT value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & SurfaceCounterFlagBitsEXT::eVblank )
-      result += "Vblank | ";
+      result += " Vblank |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_NV_viewport_swizzle ===
@@ -2797,16 +2895,17 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( PerformanceCounterDescriptionFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & PerformanceCounterDescriptionFlagBitsKHR::ePerformanceImpacting )
-      result += "PerformanceImpacting | ";
+      result += " PerformanceImpacting |";
     if ( value & PerformanceCounterDescriptionFlagBitsKHR::eConcurrentlyImpacted )
-      result += "ConcurrentlyImpacted | ";
+      result += " ConcurrentlyImpacted |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( AcquireProfilingLockFlagsKHR )
@@ -2836,38 +2935,40 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( DebugUtilsMessageSeverityFlagsEXT value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & DebugUtilsMessageSeverityFlagBitsEXT::eVerbose )
-      result += "Verbose | ";
+      result += " Verbose |";
     if ( value & DebugUtilsMessageSeverityFlagBitsEXT::eInfo )
-      result += "Info | ";
+      result += " Info |";
     if ( value & DebugUtilsMessageSeverityFlagBitsEXT::eWarning )
-      result += "Warning | ";
+      result += " Warning |";
     if ( value & DebugUtilsMessageSeverityFlagBitsEXT::eError )
-      result += "Error | ";
+      result += " Error |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( DebugUtilsMessageTypeFlagsEXT value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & DebugUtilsMessageTypeFlagBitsEXT::eGeneral )
-      result += "General | ";
+      result += " General |";
     if ( value & DebugUtilsMessageTypeFlagBitsEXT::eValidation )
-      result += "Validation | ";
+      result += " Validation |";
     if ( value & DebugUtilsMessageTypeFlagBitsEXT::ePerformance )
-      result += "Performance | ";
+      result += " Performance |";
     if ( value & DebugUtilsMessageTypeFlagBitsEXT::eDeviceAddressBinding )
-      result += "DeviceAddressBinding | ";
+      result += " DeviceAddressBinding |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( DebugUtilsMessengerCallbackDataFlagsEXT )
@@ -2891,88 +2992,92 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( GeometryFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & GeometryFlagBitsKHR::eOpaque )
-      result += "Opaque | ";
+      result += " Opaque |";
     if ( value & GeometryFlagBitsKHR::eNoDuplicateAnyHitInvocation )
-      result += "NoDuplicateAnyHitInvocation | ";
+      result += " NoDuplicateAnyHitInvocation |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( GeometryInstanceFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & GeometryInstanceFlagBitsKHR::eTriangleFacingCullDisable )
-      result += "TriangleFacingCullDisable | ";
+      result += " TriangleFacingCullDisable |";
     if ( value & GeometryInstanceFlagBitsKHR::eTriangleFlipFacing )
-      result += "TriangleFlipFacing | ";
+      result += " TriangleFlipFacing |";
     if ( value & GeometryInstanceFlagBitsKHR::eForceOpaque )
-      result += "ForceOpaque | ";
+      result += " ForceOpaque |";
     if ( value & GeometryInstanceFlagBitsKHR::eForceNoOpaque )
-      result += "ForceNoOpaque | ";
+      result += " ForceNoOpaque |";
     if ( value & GeometryInstanceFlagBitsKHR::eForceOpacityMicromap2StateEXT )
-      result += "ForceOpacityMicromap2StateEXT | ";
+      result += " ForceOpacityMicromap2StateEXT |";
     if ( value & GeometryInstanceFlagBitsKHR::eDisableOpacityMicromapsEXT )
-      result += "DisableOpacityMicromapsEXT | ";
+      result += " DisableOpacityMicromapsEXT |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( BuildAccelerationStructureFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & BuildAccelerationStructureFlagBitsKHR::eAllowUpdate )
-      result += "AllowUpdate | ";
+      result += " AllowUpdate |";
     if ( value & BuildAccelerationStructureFlagBitsKHR::eAllowCompaction )
-      result += "AllowCompaction | ";
+      result += " AllowCompaction |";
     if ( value & BuildAccelerationStructureFlagBitsKHR::ePreferFastTrace )
-      result += "PreferFastTrace | ";
+      result += " PreferFastTrace |";
     if ( value & BuildAccelerationStructureFlagBitsKHR::ePreferFastBuild )
-      result += "PreferFastBuild | ";
+      result += " PreferFastBuild |";
     if ( value & BuildAccelerationStructureFlagBitsKHR::eLowMemory )
-      result += "LowMemory | ";
+      result += " LowMemory |";
     if ( value & BuildAccelerationStructureFlagBitsKHR::eMotionNV )
-      result += "MotionNV | ";
+      result += " MotionNV |";
     if ( value & BuildAccelerationStructureFlagBitsKHR::eAllowOpacityMicromapUpdateEXT )
-      result += "AllowOpacityMicromapUpdateEXT | ";
+      result += " AllowOpacityMicromapUpdateEXT |";
     if ( value & BuildAccelerationStructureFlagBitsKHR::eAllowDisableOpacityMicromapsEXT )
-      result += "AllowDisableOpacityMicromapsEXT | ";
+      result += " AllowDisableOpacityMicromapsEXT |";
     if ( value & BuildAccelerationStructureFlagBitsKHR::eAllowOpacityMicromapDataUpdateEXT )
-      result += "AllowOpacityMicromapDataUpdateEXT | ";
+      result += " AllowOpacityMicromapDataUpdateEXT |";
 #if defined( VK_ENABLE_BETA_EXTENSIONS )
     if ( value & BuildAccelerationStructureFlagBitsKHR::eAllowDisplacementMicromapUpdateNV )
-      result += "AllowDisplacementMicromapUpdateNV | ";
+      result += " AllowDisplacementMicromapUpdateNV |";
 #endif /*VK_ENABLE_BETA_EXTENSIONS*/
     if ( value & BuildAccelerationStructureFlagBitsKHR::eAllowDataAccess )
-      result += "AllowDataAccess | ";
+      result += " AllowDataAccess |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( AccelerationStructureCreateFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & AccelerationStructureCreateFlagBitsKHR::eDeviceAddressCaptureReplay )
-      result += "DeviceAddressCaptureReplay | ";
+      result += " DeviceAddressCaptureReplay |";
     if ( value & AccelerationStructureCreateFlagBitsKHR::eDescriptorBufferCaptureReplayEXT )
-      result += "DescriptorBufferCaptureReplayEXT | ";
+      result += " DescriptorBufferCaptureReplayEXT |";
     if ( value & AccelerationStructureCreateFlagBitsKHR::eMotionNV )
-      result += "MotionNV | ";
+      result += " MotionNV |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_NV_framebuffer_mixed_samples ===
@@ -3039,64 +3144,68 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( PresentScalingFlagsEXT value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & PresentScalingFlagBitsEXT::eOneToOne )
-      result += "OneToOne | ";
+      result += " OneToOne |";
     if ( value & PresentScalingFlagBitsEXT::eAspectRatioStretch )
-      result += "AspectRatioStretch | ";
+      result += " AspectRatioStretch |";
     if ( value & PresentScalingFlagBitsEXT::eStretch )
-      result += "Stretch | ";
+      result += " Stretch |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( PresentGravityFlagsEXT value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & PresentGravityFlagBitsEXT::eMin )
-      result += "Min | ";
+      result += " Min |";
     if ( value & PresentGravityFlagBitsEXT::eMax )
-      result += "Max | ";
+      result += " Max |";
     if ( value & PresentGravityFlagBitsEXT::eCentered )
-      result += "Centered | ";
+      result += " Centered |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_NV_device_generated_commands ===
 
   VULKAN_HPP_INLINE std::string to_string( IndirectStateFlagsNV value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & IndirectStateFlagBitsNV::eFlagFrontface )
-      result += "FlagFrontface | ";
+      result += " FlagFrontface |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( IndirectCommandsLayoutUsageFlagsNV value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & IndirectCommandsLayoutUsageFlagBitsNV::eExplicitPreprocess )
-      result += "ExplicitPreprocess | ";
+      result += " ExplicitPreprocess |";
     if ( value & IndirectCommandsLayoutUsageFlagBitsNV::eIndexedSequences )
-      result += "IndexedSequences | ";
+      result += " IndexedSequences |";
     if ( value & IndirectCommandsLayoutUsageFlagBitsNV::eUnorderedSequences )
-      result += "UnorderedSequences | ";
+      result += " UnorderedSequences |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_EXT_device_memory_report ===
@@ -3110,84 +3219,89 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoEncodeFlagBitsKHR::eWithQuantizationDeltaMap )
-      result += "WithQuantizationDeltaMap | ";
+      result += " WithQuantizationDeltaMap |";
     if ( value & VideoEncodeFlagBitsKHR::eWithEmphasisMap )
-      result += "WithEmphasisMap | ";
+      result += " WithEmphasisMap |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeCapabilityFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoEncodeCapabilityFlagBitsKHR::ePrecedingExternallyEncodedBytes )
-      result += "PrecedingExternallyEncodedBytes | ";
+      result += " PrecedingExternallyEncodedBytes |";
     if ( value & VideoEncodeCapabilityFlagBitsKHR::eInsufficientBitstreamBufferRangeDetection )
-      result += "InsufficientBitstreamBufferRangeDetection | ";
+      result += " InsufficientBitstreamBufferRangeDetection |";
     if ( value & VideoEncodeCapabilityFlagBitsKHR::eQuantizationDeltaMap )
-      result += "QuantizationDeltaMap | ";
+      result += " QuantizationDeltaMap |";
     if ( value & VideoEncodeCapabilityFlagBitsKHR::eEmphasisMap )
-      result += "EmphasisMap | ";
+      result += " EmphasisMap |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeFeedbackFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoEncodeFeedbackFlagBitsKHR::eBitstreamBufferOffset )
-      result += "BitstreamBufferOffset | ";
+      result += " BitstreamBufferOffset |";
     if ( value & VideoEncodeFeedbackFlagBitsKHR::eBitstreamBytesWritten )
-      result += "BitstreamBytesWritten | ";
+      result += " BitstreamBytesWritten |";
     if ( value & VideoEncodeFeedbackFlagBitsKHR::eBitstreamHasOverrides )
-      result += "BitstreamHasOverrides | ";
+      result += " BitstreamHasOverrides |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeUsageFlagsKHR value )
   {
-    if ( !value )
-      return "Default";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoEncodeUsageFlagBitsKHR::eTranscoding )
-      result += "Transcoding | ";
+      result += " Transcoding |";
     if ( value & VideoEncodeUsageFlagBitsKHR::eStreaming )
-      result += "Streaming | ";
+      result += " Streaming |";
     if ( value & VideoEncodeUsageFlagBitsKHR::eRecording )
-      result += "Recording | ";
+      result += " Recording |";
     if ( value & VideoEncodeUsageFlagBitsKHR::eConferencing )
-      result += "Conferencing | ";
+      result += " Conferencing |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "Default";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeContentFlagsKHR value )
   {
-    if ( !value )
-      return "Default";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoEncodeContentFlagBitsKHR::eCamera )
-      result += "Camera | ";
+      result += " Camera |";
     if ( value & VideoEncodeContentFlagBitsKHR::eDesktop )
-      result += "Desktop | ";
+      result += " Desktop |";
     if ( value & VideoEncodeContentFlagBitsKHR::eRendered )
-      result += "Rendered | ";
+      result += " Rendered |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "Default";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeRateControlFlagsKHR )
@@ -3197,38 +3311,40 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeRateControlModeFlagsKHR value )
   {
-    if ( !value )
-      return "Default";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoEncodeRateControlModeFlagBitsKHR::eDisabled )
-      result += "Disabled | ";
+      result += " Disabled |";
     if ( value & VideoEncodeRateControlModeFlagBitsKHR::eCbr )
-      result += "Cbr | ";
+      result += " Cbr |";
     if ( value & VideoEncodeRateControlModeFlagBitsKHR::eVbr )
-      result += "Vbr | ";
+      result += " Vbr |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "Default";
+    return result;
   }
 
   //=== VK_NV_device_diagnostics_config ===
 
   VULKAN_HPP_INLINE std::string to_string( DeviceDiagnosticsConfigFlagsNV value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & DeviceDiagnosticsConfigFlagBitsNV::eEnableShaderDebugInfo )
-      result += "EnableShaderDebugInfo | ";
+      result += " EnableShaderDebugInfo |";
     if ( value & DeviceDiagnosticsConfigFlagBitsNV::eEnableResourceTracking )
-      result += "EnableResourceTracking | ";
+      result += " EnableResourceTracking |";
     if ( value & DeviceDiagnosticsConfigFlagBitsNV::eEnableAutomaticCheckpoints )
-      result += "EnableAutomaticCheckpoints | ";
+      result += " EnableAutomaticCheckpoints |";
     if ( value & DeviceDiagnosticsConfigFlagBitsNV::eEnableShaderErrorReporting )
-      result += "EnableShaderErrorReporting | ";
+      result += " EnableShaderErrorReporting |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
 #if defined( VK_USE_PLATFORM_METAL_EXT )
@@ -3236,24 +3352,25 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( ExportMetalObjectTypeFlagsEXT value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ExportMetalObjectTypeFlagBitsEXT::eMetalDevice )
-      result += "MetalDevice | ";
+      result += " MetalDevice |";
     if ( value & ExportMetalObjectTypeFlagBitsEXT::eMetalCommandQueue )
-      result += "MetalCommandQueue | ";
+      result += " MetalCommandQueue |";
     if ( value & ExportMetalObjectTypeFlagBitsEXT::eMetalBuffer )
-      result += "MetalBuffer | ";
+      result += " MetalBuffer |";
     if ( value & ExportMetalObjectTypeFlagBitsEXT::eMetalTexture )
-      result += "MetalTexture | ";
+      result += " MetalTexture |";
     if ( value & ExportMetalObjectTypeFlagBitsEXT::eMetalIosurface )
-      result += "MetalIosurface | ";
+      result += " MetalIosurface |";
     if ( value & ExportMetalObjectTypeFlagBitsEXT::eMetalSharedEvent )
-      result += "MetalSharedEvent | ";
+      result += " MetalSharedEvent |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 #endif /*VK_USE_PLATFORM_METAL_EXT*/
 
@@ -3261,20 +3378,21 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( GraphicsPipelineLibraryFlagsEXT value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & GraphicsPipelineLibraryFlagBitsEXT::eVertexInputInterface )
-      result += "VertexInputInterface | ";
+      result += " VertexInputInterface |";
     if ( value & GraphicsPipelineLibraryFlagBitsEXT::ePreRasterizationShaders )
-      result += "PreRasterizationShaders | ";
+      result += " PreRasterizationShaders |";
     if ( value & GraphicsPipelineLibraryFlagBitsEXT::eFragmentShader )
-      result += "FragmentShader | ";
+      result += " FragmentShader |";
     if ( value & GraphicsPipelineLibraryFlagBitsEXT::eFragmentOutputInterface )
-      result += "FragmentOutputInterface | ";
+      result += " FragmentOutputInterface |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_NV_ray_tracing_motion_blur ===
@@ -3293,76 +3411,78 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( ImageCompressionFlagsEXT value )
   {
-    if ( !value )
-      return "Default";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ImageCompressionFlagBitsEXT::eFixedRateDefault )
-      result += "FixedRateDefault | ";
+      result += " FixedRateDefault |";
     if ( value & ImageCompressionFlagBitsEXT::eFixedRateExplicit )
-      result += "FixedRateExplicit | ";
+      result += " FixedRateExplicit |";
     if ( value & ImageCompressionFlagBitsEXT::eDisabled )
-      result += "Disabled | ";
+      result += " Disabled |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "Default";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( ImageCompressionFixedRateFlagsEXT value )
   {
-    if ( !value )
-      return "None";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e1Bpc )
-      result += "1Bpc | ";
+      result += " 1Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e2Bpc )
-      result += "2Bpc | ";
+      result += " 2Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e3Bpc )
-      result += "3Bpc | ";
+      result += " 3Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e4Bpc )
-      result += "4Bpc | ";
+      result += " 4Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e5Bpc )
-      result += "5Bpc | ";
+      result += " 5Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e6Bpc )
-      result += "6Bpc | ";
+      result += " 6Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e7Bpc )
-      result += "7Bpc | ";
+      result += " 7Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e8Bpc )
-      result += "8Bpc | ";
+      result += " 8Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e9Bpc )
-      result += "9Bpc | ";
+      result += " 9Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e10Bpc )
-      result += "10Bpc | ";
+      result += " 10Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e11Bpc )
-      result += "11Bpc | ";
+      result += " 11Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e12Bpc )
-      result += "12Bpc | ";
+      result += " 12Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e13Bpc )
-      result += "13Bpc | ";
+      result += " 13Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e14Bpc )
-      result += "14Bpc | ";
+      result += " 14Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e15Bpc )
-      result += "15Bpc | ";
+      result += " 15Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e16Bpc )
-      result += "16Bpc | ";
+      result += " 16Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e17Bpc )
-      result += "17Bpc | ";
+      result += " 17Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e18Bpc )
-      result += "18Bpc | ";
+      result += " 18Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e19Bpc )
-      result += "19Bpc | ";
+      result += " 19Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e20Bpc )
-      result += "20Bpc | ";
+      result += " 20Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e21Bpc )
-      result += "21Bpc | ";
+      result += " 21Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e22Bpc )
-      result += "22Bpc | ";
+      result += " 22Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e23Bpc )
-      result += "23Bpc | ";
+      result += " 23Bpc |";
     if ( value & ImageCompressionFixedRateFlagBitsEXT::e24Bpc )
-      result += "24Bpc | ";
+      result += " 24Bpc |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "None";
+    return result;
   }
 
 #if defined( VK_USE_PLATFORM_DIRECTFB_EXT )
@@ -3378,14 +3498,15 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( DeviceAddressBindingFlagsEXT value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & DeviceAddressBindingFlagBitsEXT::eInternalObject )
-      result += "InternalObject | ";
+      result += " InternalObject |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
 #if defined( VK_USE_PLATFORM_FUCHSIA )
@@ -3398,22 +3519,23 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( ImageConstraintsInfoFlagsFUCHSIA value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ImageConstraintsInfoFlagBitsFUCHSIA::eCpuReadRarely )
-      result += "CpuReadRarely | ";
+      result += " CpuReadRarely |";
     if ( value & ImageConstraintsInfoFlagBitsFUCHSIA::eCpuReadOften )
-      result += "CpuReadOften | ";
+      result += " CpuReadOften |";
     if ( value & ImageConstraintsInfoFlagBitsFUCHSIA::eCpuWriteRarely )
-      result += "CpuWriteRarely | ";
+      result += " CpuWriteRarely |";
     if ( value & ImageConstraintsInfoFlagBitsFUCHSIA::eCpuWriteOften )
-      result += "CpuWriteOften | ";
+      result += " CpuWriteOften |";
     if ( value & ImageConstraintsInfoFlagBitsFUCHSIA::eProtectedOptional )
-      result += "ProtectedOptional | ";
+      result += " ProtectedOptional |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 #endif /*VK_USE_PLATFORM_FUCHSIA*/
 
@@ -3421,14 +3543,15 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( FrameBoundaryFlagsEXT value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & FrameBoundaryFlagBitsEXT::eFrameEnd )
-      result += "FrameEnd | ";
+      result += " FrameEnd |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
 #if defined( VK_USE_PLATFORM_SCREEN_QNX )
@@ -3444,58 +3567,62 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( BuildMicromapFlagsEXT value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & BuildMicromapFlagBitsEXT::ePreferFastTrace )
-      result += "PreferFastTrace | ";
+      result += " PreferFastTrace |";
     if ( value & BuildMicromapFlagBitsEXT::ePreferFastBuild )
-      result += "PreferFastBuild | ";
+      result += " PreferFastBuild |";
     if ( value & BuildMicromapFlagBitsEXT::eAllowCompaction )
-      result += "AllowCompaction | ";
+      result += " AllowCompaction |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( MicromapCreateFlagsEXT value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & MicromapCreateFlagBitsEXT::eDeviceAddressCaptureReplay )
-      result += "DeviceAddressCaptureReplay | ";
+      result += " DeviceAddressCaptureReplay |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_ARM_scheduling_controls ===
 
   VULKAN_HPP_INLINE std::string to_string( PhysicalDeviceSchedulingControlsFlagsARM value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & PhysicalDeviceSchedulingControlsFlagBitsARM::eShaderCoreCount )
-      result += "ShaderCoreCount | ";
+      result += " ShaderCoreCount |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_NV_memory_decompression ===
 
   VULKAN_HPP_INLINE std::string to_string( MemoryDecompressionMethodFlagsNV value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & MemoryDecompressionMethodFlagBitsNV::eGdeflate10 )
-      result += "Gdeflate10 | ";
+      result += " Gdeflate10 |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_LUNARG_direct_driver_loading ===
@@ -3509,304 +3636,321 @@ namespace VULKAN_HPP_NAMESPACE
 
   VULKAN_HPP_INLINE std::string to_string( OpticalFlowUsageFlagsNV value )
   {
-    if ( !value )
-      return "Unknown";
-
-    std::string result;
+    std::string result = "{";
     if ( value & OpticalFlowUsageFlagBitsNV::eInput )
-      result += "Input | ";
+      result += " Input |";
     if ( value & OpticalFlowUsageFlagBitsNV::eOutput )
-      result += "Output | ";
+      result += " Output |";
     if ( value & OpticalFlowUsageFlagBitsNV::eHint )
-      result += "Hint | ";
+      result += " Hint |";
     if ( value & OpticalFlowUsageFlagBitsNV::eCost )
-      result += "Cost | ";
+      result += " Cost |";
     if ( value & OpticalFlowUsageFlagBitsNV::eGlobalFlow )
-      result += "GlobalFlow | ";
+      result += " GlobalFlow |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "Unknown";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( OpticalFlowGridSizeFlagsNV value )
   {
-    if ( !value )
-      return "Unknown";
-
-    std::string result;
+    std::string result = "{";
     if ( value & OpticalFlowGridSizeFlagBitsNV::e1X1 )
-      result += "1X1 | ";
+      result += " 1X1 |";
     if ( value & OpticalFlowGridSizeFlagBitsNV::e2X2 )
-      result += "2X2 | ";
+      result += " 2X2 |";
     if ( value & OpticalFlowGridSizeFlagBitsNV::e4X4 )
-      result += "4X4 | ";
+      result += " 4X4 |";
     if ( value & OpticalFlowGridSizeFlagBitsNV::e8X8 )
-      result += "8X8 | ";
+      result += " 8X8 |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "Unknown";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( OpticalFlowSessionCreateFlagsNV value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & OpticalFlowSessionCreateFlagBitsNV::eEnableHint )
-      result += "EnableHint | ";
+      result += " EnableHint |";
     if ( value & OpticalFlowSessionCreateFlagBitsNV::eEnableCost )
-      result += "EnableCost | ";
+      result += " EnableCost |";
     if ( value & OpticalFlowSessionCreateFlagBitsNV::eEnableGlobalFlow )
-      result += "EnableGlobalFlow | ";
+      result += " EnableGlobalFlow |";
     if ( value & OpticalFlowSessionCreateFlagBitsNV::eAllowRegions )
-      result += "AllowRegions | ";
+      result += " AllowRegions |";
     if ( value & OpticalFlowSessionCreateFlagBitsNV::eBothDirections )
-      result += "BothDirections | ";
+      result += " BothDirections |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( OpticalFlowExecuteFlagsNV value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & OpticalFlowExecuteFlagBitsNV::eDisableTemporalHints )
-      result += "DisableTemporalHints | ";
+      result += " DisableTemporalHints |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_EXT_shader_object ===
 
   VULKAN_HPP_INLINE std::string to_string( ShaderCreateFlagsEXT value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ShaderCreateFlagBitsEXT::eLinkStage )
-      result += "LinkStage | ";
+      result += " LinkStage |";
     if ( value & ShaderCreateFlagBitsEXT::eAllowVaryingSubgroupSize )
-      result += "AllowVaryingSubgroupSize | ";
+      result += " AllowVaryingSubgroupSize |";
     if ( value & ShaderCreateFlagBitsEXT::eRequireFullSubgroups )
-      result += "RequireFullSubgroups | ";
+      result += " RequireFullSubgroups |";
     if ( value & ShaderCreateFlagBitsEXT::eNoTaskShader )
-      result += "NoTaskShader | ";
+      result += " NoTaskShader |";
     if ( value & ShaderCreateFlagBitsEXT::eDispatchBase )
-      result += "DispatchBase | ";
+      result += " DispatchBase |";
     if ( value & ShaderCreateFlagBitsEXT::eFragmentShadingRateAttachment )
-      result += "FragmentShadingRateAttachment | ";
+      result += " FragmentShadingRateAttachment |";
     if ( value & ShaderCreateFlagBitsEXT::eFragmentDensityMapAttachment )
-      result += "FragmentDensityMapAttachment | ";
+      result += " FragmentDensityMapAttachment |";
     if ( value & ShaderCreateFlagBitsEXT::eIndirectBindable )
-      result += "IndirectBindable | ";
+      result += " IndirectBindable |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_KHR_video_encode_av1 ===
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeAV1CapabilityFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoEncodeAV1CapabilityFlagBitsKHR::ePerRateControlGroupMinMaxQIndex )
-      result += "PerRateControlGroupMinMaxQIndex | ";
+      result += " PerRateControlGroupMinMaxQIndex |";
     if ( value & VideoEncodeAV1CapabilityFlagBitsKHR::eGenerateObuExtensionHeader )
-      result += "GenerateObuExtensionHeader | ";
+      result += " GenerateObuExtensionHeader |";
     if ( value & VideoEncodeAV1CapabilityFlagBitsKHR::ePrimaryReferenceCdfOnly )
-      result += "PrimaryReferenceCdfOnly | ";
+      result += " PrimaryReferenceCdfOnly |";
     if ( value & VideoEncodeAV1CapabilityFlagBitsKHR::eFrameSizeOverride )
-      result += "FrameSizeOverride | ";
+      result += " FrameSizeOverride |";
     if ( value & VideoEncodeAV1CapabilityFlagBitsKHR::eMotionVectorScaling )
-      result += "MotionVectorScaling | ";
+      result += " MotionVectorScaling |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeAV1StdFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoEncodeAV1StdFlagBitsKHR::eUniformTileSpacingFlagSet )
-      result += "UniformTileSpacingFlagSet | ";
+      result += " UniformTileSpacingFlagSet |";
     if ( value & VideoEncodeAV1StdFlagBitsKHR::eSkipModePresentUnset )
-      result += "SkipModePresentUnset | ";
+      result += " SkipModePresentUnset |";
     if ( value & VideoEncodeAV1StdFlagBitsKHR::ePrimaryRefFrame )
-      result += "PrimaryRefFrame | ";
+      result += " PrimaryRefFrame |";
     if ( value & VideoEncodeAV1StdFlagBitsKHR::eDeltaQ )
-      result += "DeltaQ | ";
+      result += " DeltaQ |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeAV1SuperblockSizeFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoEncodeAV1SuperblockSizeFlagBitsKHR::e64 )
-      result += "64 | ";
+      result += " 64 |";
     if ( value & VideoEncodeAV1SuperblockSizeFlagBitsKHR::e128 )
-      result += "128 | ";
+      result += " 128 |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( VideoEncodeAV1RateControlFlagsKHR value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & VideoEncodeAV1RateControlFlagBitsKHR::eRegularGop )
-      result += "RegularGop | ";
+      result += " RegularGop |";
     if ( value & VideoEncodeAV1RateControlFlagBitsKHR::eTemporalLayerPatternDyadic )
-      result += "TemporalLayerPatternDyadic | ";
+      result += " TemporalLayerPatternDyadic |";
     if ( value & VideoEncodeAV1RateControlFlagBitsKHR::eReferencePatternFlat )
-      result += "ReferencePatternFlat | ";
+      result += " ReferencePatternFlat |";
     if ( value & VideoEncodeAV1RateControlFlagBitsKHR::eReferencePatternDyadic )
-      result += "ReferencePatternDyadic | ";
+      result += " ReferencePatternDyadic |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_NV_cluster_acceleration_structure ===
 
   VULKAN_HPP_INLINE std::string to_string( ClusterAccelerationStructureClusterFlagsNV value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ClusterAccelerationStructureClusterFlagBitsNV::eAllowDisableOpacityMicromaps )
-      result += "AllowDisableOpacityMicromaps | ";
+      result += " AllowDisableOpacityMicromaps |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( ClusterAccelerationStructureGeometryFlagsNV value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ClusterAccelerationStructureGeometryFlagBitsNV::eCullDisable )
-      result += "CullDisable | ";
+      result += " CullDisable |";
     if ( value & ClusterAccelerationStructureGeometryFlagBitsNV::eNoDuplicateAnyhitInvocation )
-      result += "NoDuplicateAnyhitInvocation | ";
+      result += " NoDuplicateAnyhitInvocation |";
     if ( value & ClusterAccelerationStructureGeometryFlagBitsNV::eOpaque )
-      result += "Opaque | ";
+      result += " Opaque |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( ClusterAccelerationStructureAddressResolutionFlagsNV value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ClusterAccelerationStructureAddressResolutionFlagBitsNV::eIndirectedDstImplicitData )
-      result += "IndirectedDstImplicitData | ";
+      result += " IndirectedDstImplicitData |";
     if ( value & ClusterAccelerationStructureAddressResolutionFlagBitsNV::eIndirectedScratchData )
-      result += "IndirectedScratchData | ";
+      result += " IndirectedScratchData |";
     if ( value & ClusterAccelerationStructureAddressResolutionFlagBitsNV::eIndirectedDstAddressArray )
-      result += "IndirectedDstAddressArray | ";
+      result += " IndirectedDstAddressArray |";
     if ( value & ClusterAccelerationStructureAddressResolutionFlagBitsNV::eIndirectedDstSizesArray )
-      result += "IndirectedDstSizesArray | ";
+      result += " IndirectedDstSizesArray |";
     if ( value & ClusterAccelerationStructureAddressResolutionFlagBitsNV::eIndirectedSrcInfosArray )
-      result += "IndirectedSrcInfosArray | ";
+      result += " IndirectedSrcInfosArray |";
     if ( value & ClusterAccelerationStructureAddressResolutionFlagBitsNV::eIndirectedSrcInfosCount )
-      result += "IndirectedSrcInfosCount | ";
+      result += " IndirectedSrcInfosCount |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( ClusterAccelerationStructureIndexFormatFlagsNV value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & ClusterAccelerationStructureIndexFormatFlagBitsNV::e8 )
-      result += "8 | ";
+      result += " 8 |";
     if ( value & ClusterAccelerationStructureIndexFormatFlagBitsNV::e16 )
-      result += "16 | ";
+      result += " 16 |";
     if ( value & ClusterAccelerationStructureIndexFormatFlagBitsNV::e32 )
-      result += "32 | ";
+      result += " 32 |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_NV_partitioned_acceleration_structure ===
 
   VULKAN_HPP_INLINE std::string to_string( PartitionedAccelerationStructureInstanceFlagsNV value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & PartitionedAccelerationStructureInstanceFlagBitsNV::eFlagTriangleFacingCullDisable )
-      result += "FlagTriangleFacingCullDisable | ";
+      result += " FlagTriangleFacingCullDisable |";
     if ( value & PartitionedAccelerationStructureInstanceFlagBitsNV::eFlagTriangleFlipFacing )
-      result += "FlagTriangleFlipFacing | ";
+      result += " FlagTriangleFlipFacing |";
     if ( value & PartitionedAccelerationStructureInstanceFlagBitsNV::eFlagForceOpaque )
-      result += "FlagForceOpaque | ";
+      result += " FlagForceOpaque |";
     if ( value & PartitionedAccelerationStructureInstanceFlagBitsNV::eFlagForceNoOpaque )
-      result += "FlagForceNoOpaque | ";
+      result += " FlagForceNoOpaque |";
     if ( value & PartitionedAccelerationStructureInstanceFlagBitsNV::eFlagEnableExplicitBoundingBox )
-      result += "FlagEnableExplicitBoundingBox | ";
+      result += " FlagEnableExplicitBoundingBox |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_EXT_device_generated_commands ===
 
   VULKAN_HPP_INLINE std::string to_string( IndirectCommandsLayoutUsageFlagsEXT value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & IndirectCommandsLayoutUsageFlagBitsEXT::eExplicitPreprocess )
-      result += "ExplicitPreprocess | ";
+      result += " ExplicitPreprocess |";
     if ( value & IndirectCommandsLayoutUsageFlagBitsEXT::eUnorderedSequences )
-      result += "UnorderedSequences | ";
+      result += " UnorderedSequences |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   VULKAN_HPP_INLINE std::string to_string( IndirectCommandsInputModeFlagsEXT value )
   {
-    if ( !value )
-      return "{}";
-
-    std::string result;
+    std::string result = "{";
     if ( value & IndirectCommandsInputModeFlagBitsEXT::eVulkanIndexBuffer )
-      result += "VulkanIndexBuffer | ";
+      result += " VulkanIndexBuffer |";
     if ( value & IndirectCommandsInputModeFlagBitsEXT::eDxgiIndexBuffer )
-      result += "DxgiIndexBuffer | ";
+      result += " DxgiIndexBuffer |";
 
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "{}";
+    return result;
   }
 
   //=== VK_KHR_maintenance8 ===
 
   VULKAN_HPP_INLINE std::string to_string( AccessFlags3KHR value )
   {
-    if ( !value )
-      return "None";
+    std::string result = "{";
 
-    std::string result;
-
-    return "{ " + result.substr( 0, result.size() - 3 ) + " }";
+    if ( result.size() > 1 )
+      result.back() = '}';
+    else
+      result = "None";
+    return result;
   }
 
   //=======================


### PR DESCRIPTION
Currently, these functions are implemented rather inefficiently. Here's a random one to demonstrate:

```cpp
VULKAN_HPP_INLINE std::string to_string( CommandBufferUsageFlags value )
{
  if ( !value )
    return "{}";

  std::string result;
  if ( value & CommandBufferUsageFlagBits::eOneTimeSubmit )
    result += "OneTimeSubmit | ";
  if ( value & CommandBufferUsageFlagBits::eRenderPassContinue )
    result += "RenderPassContinue | ";
  if ( value & CommandBufferUsageFlagBits::eSimultaneousUse )
    result += "SimultaneousUse | ";

  return "{ " + result.substr( 0, result.size() - 3 ) + " }";
}
```

The `substr()` call incurs a copy of the string.
Then, because we _prepend_ `{`, all the string's contents need to be memmoved up in memory.
And overall we're not taking advantage of NRVO.

With a few tweaks, we can solve all those problems ([compare the assembly](https://godbolt.org/z/ohd78dov5)):

```cpp
VULKAN_HPP_INLINE std::string to_string( CommandBufferUsageFlags value )
{
  std::string result = "{ "; // ⭐ Instead of prepending {, initialize with it.
  if ( value & CommandBufferUsageFlagBits::eOneTimeSubmit )
    result += "OneTimeSubmit | ";
  if ( value & CommandBufferUsageFlagBits::eRenderPassContinue )
    result += "RenderPassContinue | ";
  if ( value & CommandBufferUsageFlagBits::eSimultaneousUse )
    result += "SimultaneousUse | ";

  if ( result.size() > 2 ) {
    result.resize(result.size() - 1);  // ⭐ No copy
    result.back() = '}';
  } else { 
    result = "{}";
  }
  return result; // ⭐ NRVO
}
```

I then found that avoiding the `resize()` call [generates even smaller code](https://godbolt.org/z/8GG5Wq7r9), so the final version looks like:

```cpp
VULKAN_HPP_INLINE std::string to_string( CommandBufferUsageFlags value )
{
  std::string result = "{";
  if ( value & CommandBufferUsageFlagBits::eOneTimeSubmit )
    result += " OneTimeSubmit |";
  if ( value & CommandBufferUsageFlagBits::eRenderPassContinue )
    result += " RenderPassContinue |";
  if ( value & CommandBufferUsageFlagBits::eSimultaneousUse )
    result += " SimultaneousUse |";

  if ( result.size() > 1 )
    result.back() = '}';
  else 
    result = "{}";
  return result;
}
```
