### PR TITLE
cppm: Temporarily remove extension dependency inspection as in #2094

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -5602,7 +5602,7 @@ std::string VulkanHppGenerator::generateCppModuleExtensionInspectionUsings() con
 )" };
 
   auto const extensionInspectionFunctions =
-    std::array{ "getDeviceExtensions",    "getInstanceExtensions", "getDeprecatedExtensions",  "getExtensionDepends",     "getExtensionDepends",
+    std::array{ "getDeviceExtensions",    "getInstanceExtensions", "getDeprecatedExtensions",  /*"getExtensionDepends",     "getExtensionDepends",*/
                 "getObsoletedExtensions", "getPromotedExtensions", "getExtensionDeprecatedBy", "getExtensionObsoletedBy", "getExtensionPromotedTo",
                 "isDeprecatedExtension",  "isDeviceExtension",     "isInstanceExtension",      "isObsoletedExtension",    "isPromotedExtension" };
 

--- a/vulkan/vulkan.cppm
+++ b/vulkan/vulkan.cppm
@@ -5197,7 +5197,6 @@ export namespace VULKAN_HPP_NAMESPACE
   //======================================
   using VULKAN_HPP_NAMESPACE::getDeprecatedExtensions;
   using VULKAN_HPP_NAMESPACE::getDeviceExtensions;
-  using VULKAN_HPP_NAMESPACE::getExtensionDepends;
   using VULKAN_HPP_NAMESPACE::getExtensionDeprecatedBy;
   using VULKAN_HPP_NAMESPACE::getExtensionObsoletedBy;
   using VULKAN_HPP_NAMESPACE::getExtensionPromotedTo;


### PR DESCRIPTION
`getExtensionDepends` was temporarily removed in #2094 and this simply does the same for the cppm module, which fails to compile otherwise.