### PR TITLE
ci: C++20 module testing

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -70,21 +70,45 @@ jobs:
         do
           for build_type in Debug Release
           do
-            echo "================================================================================="
-            echo "Building C++"$cpp_standard" in "$build_type" mode on "${{matrix.os}}" with "${{matrix.compiler}}
-            echo "================================================================================="
-            cmake -B build/$cpp_standard/$build_type -GNinja \
-              -DVULKAN_HPP_SAMPLES_BUILD=ON                  \
-              -DVULKAN_HPP_SAMPLES_BUILD_ONLY_DYNAMIC=ON     \
-              -DVULKAN_HPP_TESTS_BUILD=ON                    \
-              -DVULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC=ON       \
-              -DVULKAN_HPP_BUILD_WITH_LOCAL_VULKAN_HPP=ON    \
-              -DVULKAN_HPP_PRECOMPILE=OFF                    \
-              -DVULKAN_HPP_RUN_GENERATOR=ON                  \
-              -DCMAKE_CXX_COMPILER=${{matrix.compiler}}      \
-              -DCMAKE_CXX_STANDARD=$cpp_standard             \
-              -DCMAKE_BUILD_TYPE=$build_type
-            cmake --build build/$cpp_standard/$build_type --parallel
+            # selectively filter out compilers that do not have the requisite C++20 modules capabilities
+            if [[ ${{matrix.compiler}} != clang++-10 && ${{matrix.compiler}} != clang++-11 && ${{matrix.compiler}} != clang++-12 && ${{matrix.compiler}} != clang++-13
+              && ${{matrix.compiler}} != clang++-14 && ${{matrix.compiler}} != clang++-15
+              && ${{matrix.compiler}} != g++-11 && ${{matrix.compiler}} != g++-12 && ${{matrix.compiler}} != g++-13 && ${{matrix.compiler}} != g++-14 ]]
+            then
+              echo "================================================================================="
+              echo "Building C++"$cpp_standard" with modules in "$build_type" mode on "${{matrix.os}}" with "${{matrix.compiler}}
+              echo "================================================================================="
+              cmake -B build/$cpp_standard/$build_type -GNinja \
+                -DVULKAN_HPP_SAMPLES_BUILD=ON                  \
+                -DVULKAN_HPP_SAMPLES_BUILD_ONLY_DYNAMIC=ON     \
+                -DVULKAN_HPP_TESTS_BUILD=ON                    \
+                -DVULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC=ON       \
+                -DVULKAN_HPP_ENABLE_CPP20_MODULES=ON           \
+                -DVULKAN_HPP_DISPATCH_LOADER_DYNAMIC=ON        \
+                -DVULKAN_HPP_BUILD_WITH_LOCAL_VULKAN_HPP=ON    \
+                -DVULKAN_HPP_PRECOMPILE=OFF                    \
+                -DVULKAN_HPP_RUN_GENERATOR=ON                  \
+                -DCMAKE_CXX_COMPILER=${{matrix.compiler}}      \
+                -DCMAKE_CXX_STANDARD=$cpp_standard             \
+                -DCMAKE_BUILD_TYPE=$build_type
+              cmake --build build/$cpp_standard/$build_type --parallel
+            else
+              echo "================================================================================="
+              echo "Building C++"$cpp_standard" in "$build_type" mode on "${{matrix.os}}" with "${{matrix.compiler}}
+              echo "================================================================================="
+              cmake -B build/$cpp_standard/$build_type -GNinja \
+                -DVULKAN_HPP_SAMPLES_BUILD=ON                  \
+                -DVULKAN_HPP_SAMPLES_BUILD_ONLY_DYNAMIC=ON     \
+                -DVULKAN_HPP_TESTS_BUILD=ON                    \
+                -DVULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC=ON       \
+                -DVULKAN_HPP_BUILD_WITH_LOCAL_VULKAN_HPP=ON    \
+                -DVULKAN_HPP_PRECOMPILE=OFF                    \
+                -DVULKAN_HPP_RUN_GENERATOR=ON                  \
+                -DCMAKE_CXX_COMPILER=${{matrix.compiler}}      \
+                -DCMAKE_CXX_STANDARD=$cpp_standard             \
+                -DCMAKE_BUILD_TYPE=$build_type
+              cmake --build build/$cpp_standard/$build_type --parallel
+            fi
           done
         done
 

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -43,6 +43,8 @@ jobs:
             - os: ubuntu-24.04
               compiler: clang++-18
             - os: ubuntu-24.04
+              compiler: clang++-19
+            - os: ubuntu-24.04
               compiler: g++-12
             - os: ubuntu-24.04
               compiler: g++-13


### PR DESCRIPTION
- Added Ubuntu 24.04 with clang++-19
- Added modules testing with clang++-16 to 19
- Modules should theoretically work with g++-14, but there seems to be a bug when the testing source file includes the standard library in any way