### PR TITLE
CMake: Replaced test-specific dynamic loader options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,6 @@ option( VULKAN_HPP_GENERATOR_BUILD "Build the HPP generator" ${PROJECT_IS_TOP_LE
 option( VULKAN_HPP_SAMPLES_BUILD "Build samples" OFF )
 option( VULKAN_HPP_TESTS_BUILD "Build tests" OFF )
 option( VULKAN_HPP_SAMPLES_BUILD_ONLY_DYNAMIC "Build only dynamic. Required in case the Vulkan SDK is not available" OFF )
-option( VULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC "Build only dynamic" OFF )
 option( VULKAN_HPP_BUILD_WITH_LOCAL_VULKAN_HPP "Build with local Vulkan headers" ON )
 option( VULKAN_HPP_ENABLE_CPP20_MODULES "Build Vulkan-Hpp as C++20 module; requires minimum CMake version 3.28" OFF )
 option( VULKAN_HPP_ENABLE_STD_MODULE "Build Vulkan-Hpp with import std; requires minimum CMake version 3.30" OFF )
@@ -500,10 +499,6 @@ function( vulkan_hpp__setup_test )
 	set( oneValueArgs CXX_STANDARD NAME )
 	set( multiValueArgs LIBRARIES )
 	cmake_parse_arguments( TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
-
-	if( NOT (VULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC AND VULKAN_HPP_BUILD_WITH_LOCAL_VULKAN_HPP) )
-		find_package( Vulkan REQUIRED )
-	endif()
 
 	if( NOT TARGET_NAME )
 		message( FATAL_ERROR "NAME must be defined in vulkan_hpp__setup_test" )

--- a/tests/ArrayProxy/CMakeLists.txt
+++ b/tests/ArrayProxy/CMakeLists.txt
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if( NOT VULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC )
+if( NOT VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
 	vulkan_hpp__setup_test( NAME ArrayProxy )
 endif()

--- a/tests/ArrayProxyNoTemporaries/CMakeLists.txt
+++ b/tests/ArrayProxyNoTemporaries/CMakeLists.txt
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if( NOT VULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC )
+if( NOT VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
 	vulkan_hpp__setup_test( NAME ArrayProxyNoTemporaries NO_UTILS )
 endif()

--- a/tests/ArrayWrapper/CMakeLists.txt
+++ b/tests/ArrayWrapper/CMakeLists.txt
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if( NOT VULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC )
+if( NOT VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
 	vulkan_hpp__setup_test( NAME ArrayWrapper )
 endif()

--- a/tests/CppType/CMakeLists.txt
+++ b/tests/CppType/CMakeLists.txt
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if( NOT VULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC )
+if( NOT VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
 	vulkan_hpp__setup_test( NAME CppType )
 endif()

--- a/tests/DesignatedInitializers/CMakeLists.txt
+++ b/tests/DesignatedInitializers/CMakeLists.txt
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if( NOT VULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC )
+if( NOT VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
 	vulkan_hpp__setup_test( NAME DesignatedInitializers CXX_STANDARD 20 )
 endif()

--- a/tests/DeviceFunctions/CMakeLists.txt
+++ b/tests/DeviceFunctions/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if( NOT VULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC )
+if( NOT VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
 	find_package( Vulkan REQUIRED )
 
 	vulkan_hpp__setup_test( NAME DeviceFunctions LIBRARIES ${Vulkan_LIBRARIES} )

--- a/tests/DispatchLoaderStatic/CMakeLists.txt
+++ b/tests/DispatchLoaderStatic/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if( NOT VULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC )
+if( NOT VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
 	find_package( Vulkan REQUIRED )
 
 	vulkan_hpp__setup_test(

--- a/tests/EnableBetaExtensions/CMakeLists.txt
+++ b/tests/EnableBetaExtensions/CMakeLists.txt
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if( NOT VULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC )
+if( NOT VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
 	vulkan_hpp__setup_test( NAME EnableBetaExtensions )
 endif()

--- a/tests/Handles/CMakeLists.txt
+++ b/tests/Handles/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if( NOT VULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC )
+if( NOT VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
 	find_package( Vulkan REQUIRED )
 
 	vulkan_hpp__setup_test( NAME Handles LIBRARIES ${Vulkan_LIBRARIES} )

--- a/tests/HandlesMoveExchange/CMakeLists.txt
+++ b/tests/HandlesMoveExchange/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if( NOT VULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC )
+if( NOT VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
 	find_package( Vulkan REQUIRED )
 
 	vulkan_hpp__setup_test( NAME HandlesMoveExchange LIBRARIES ${Vulkan_LIBRARIES} )

--- a/tests/Hash/CMakeLists.txt
+++ b/tests/Hash/CMakeLists.txt
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if( NOT VULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC )
+if( NOT VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
 	vulkan_hpp__setup_test( NAME Hash )
 endif()

--- a/tests/StridedArrayProxy/CMakeLists.txt
+++ b/tests/StridedArrayProxy/CMakeLists.txt
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if( NOT VULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC )
+if( NOT VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
 	vulkan_hpp__setup_test( NAME StridedArrayProxy )
 endif()


### PR DESCRIPTION
Here's an example of how `VULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC` could be replaced by the use of `VULKAN_HPP_DISPATCH_LOADER_DYNAMIC`, meaning I've only touched the testing side of things so far.

And looking at this, why are those tests disabled for dynamic loading? CI always enables `VULKAN_HPP_TESTS_BUILD_ONLY_DYNAMIC` at the moment, so they never get tested at all.