### PR TITLE
C++20 Module: Fixing dynamic dispatch on Windows MSVC

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -5615,6 +5615,9 @@ std::string VulkanHppGenerator::generateCppModuleUsings() const
   {
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderBase;
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic;
+#if defined( VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
+    using VULKAN_HPP_NAMESPACE::detail::defaultDispatchLoaderDynamic;
+#endif
 #if !defined( VK_NO_PROTOTYPES )
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderStatic;
     using VULKAN_HPP_NAMESPACE::detail::getDispatchLoaderStatic;

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -5616,9 +5616,9 @@ std::string VulkanHppGenerator::generateCppModuleUsings() const
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderBase;
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic;
 #if !defined( VULKAN_HPP_DEFAULT_DISPATCHER )
-#   if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
-      using VULKAN_HPP_NAMESPACE::detail::defaultDispatchLoaderDynamic;
-#   endif
+# if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
+    using VULKAN_HPP_NAMESPACE::detail::defaultDispatchLoaderDynamic;
+# endif
 #endif
 #if !defined( VK_NO_PROTOTYPES )
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderStatic;

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -5615,8 +5615,10 @@ std::string VulkanHppGenerator::generateCppModuleUsings() const
   {
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderBase;
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic;
-#if defined( VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
-    using VULKAN_HPP_NAMESPACE::detail::defaultDispatchLoaderDynamic;
+#if !defined( VULKAN_HPP_DEFAULT_DISPATCHER )
+#   if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
+      using VULKAN_HPP_NAMESPACE::detail::defaultDispatchLoaderDynamic;
+#   endif
 #endif
 #if !defined( VK_NO_PROTOTYPES )
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderStatic;

--- a/vulkan/vulkan.cppm
+++ b/vulkan/vulkan.cppm
@@ -42,6 +42,9 @@ export namespace VULKAN_HPP_NAMESPACE
   {
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderBase;
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic;
+#if defined( VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
+    using VULKAN_HPP_NAMESPACE::detail::defaultDispatchLoaderDynamic;
+#endif
 #if !defined( VK_NO_PROTOTYPES )
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderStatic;
     using VULKAN_HPP_NAMESPACE::detail::getDispatchLoaderStatic;

--- a/vulkan/vulkan.cppm
+++ b/vulkan/vulkan.cppm
@@ -42,8 +42,10 @@ export namespace VULKAN_HPP_NAMESPACE
   {
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderBase;
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic;
-#if defined( VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
-    using VULKAN_HPP_NAMESPACE::detail::defaultDispatchLoaderDynamic;
+#if !defined( VULKAN_HPP_DEFAULT_DISPATCHER )
+#   if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
+      using VULKAN_HPP_NAMESPACE::detail::defaultDispatchLoaderDynamic;
+#   endif
 #endif
 #if !defined( VK_NO_PROTOTYPES )
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderStatic;

--- a/vulkan/vulkan.cppm
+++ b/vulkan/vulkan.cppm
@@ -43,9 +43,9 @@ export namespace VULKAN_HPP_NAMESPACE
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderBase;
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderDynamic;
 #if !defined( VULKAN_HPP_DEFAULT_DISPATCHER )
-#   if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
-      using VULKAN_HPP_NAMESPACE::detail::defaultDispatchLoaderDynamic;
-#   endif
+#  if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
+    using VULKAN_HPP_NAMESPACE::detail::defaultDispatchLoaderDynamic;
+#  endif
 #endif
 #if !defined( VK_NO_PROTOTYPES )
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderStatic;


### PR DESCRIPTION
Under Windows, we need to export the `defaultDispatchLoaderDynamic` symbol, as simply importing vulkan_hpp will not provide it without including the macro header in every .cppm file that imports vulkan_hpp. I'm actually suprised it worked under Clang. It wasn't caught by the tests, as they manually include `vulkan_hpp_macros.hpp` for dynamic storage, so the symbol will always be present in that single .cppm source.

This also enables the storage placement with modules to be handled without the macro header inclusion:
```cpp
import vulkan_hpp;
namespace vk::detail {
    DispatchLoaderDynamic defaultDispatchLoaderDynamic;
}
```