### PR TITLE
Update submodule glslang to version 15.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,6 +536,7 @@ if( VULKAN_HPP_SAMPLES_BUILD OR VULKAN_HPP_TESTS_BUILD )
 	set( GLFW_BUILD_EXAMPLES OFF )
 	set( GLFW_BUILD_TESTS OFF )
 	add_subdirectory( glfw )
+	set( ENABLE_OPT OFF ) # could use ALLOW_EXTERNAL_SPIRV_TOOLS=ON instead
 	add_subdirectory( glslang )
 
 	add_subdirectory( samples/utils )


### PR DESCRIPTION
In the current glslang version 13.0.0, `SpvBuilder.h` is missing `#include <cstdint>`, which can cause compilers to complain about the use of uint32_t in that header. I got an error with both Clang 19.1.7 and GCC 15.1.1 when building tests and samples.

I also disabled `ENABLE_OPT` for glslang, since we would either have to add SPIRV_Tools as a submodule or rely on find_package for it using ALLOW_EXTERNAL_SPIRV_TOOLS. Otherwise we would get this CMake error:
```
CMake Error at glslang/CMakeLists.txt:296 (message):
    ENABLE_OPT set but SPIR-V tools not found.  Please run
    update_glslang_sources.py, set the ALLOW_EXTERNAL_SPIRV_TOOLS option to use
    a local install of SPIRV-Tools, or set ENABLE_OPT=0.
```
 I think not having the glslang opt enabled is fine, since its for testing purposes anyways.