### PR TITLE
Fix undefined `assert` when using `std` module

### DIFF
--- a/snippets/includes.hpp
+++ b/snippets/includes.hpp
@@ -1,11 +1,13 @@
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 #if defined( VULKAN_HPP_ENABLE_STD_MODULE ) && defined( VULKAN_HPP_STD_MODULE )
+#  include <cassert>
 #  include <string.h>
 import VULKAN_HPP_STD_MODULE;
 #else
 #  include <algorithm>
 #  include <array>  // ArrayWrapperND
+#  include <cassert>
 #  include <string.h>  // strnlen
 #  include <string>    // std::string
 #  include <utility>   // std::exchange
@@ -26,7 +28,6 @@ import VULKAN_HPP_STD_MODULE;
 #    include <span>
 #  endif
 #endif
-#include <cassert>
 #include <vulkan/${vulkan_h}>
 
 #if VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL == 1

--- a/snippets/includes.hpp
+++ b/snippets/includes.hpp
@@ -6,7 +6,6 @@ import VULKAN_HPP_STD_MODULE;
 #else
 #  include <algorithm>
 #  include <array>  // ArrayWrapperND
-#  include <cassert>
 #  include <string.h>  // strnlen
 #  include <string>    // std::string
 #  include <utility>   // std::exchange
@@ -27,6 +26,7 @@ import VULKAN_HPP_STD_MODULE;
 #    include <span>
 #  endif
 #endif
+#include <cassert>
 #include <vulkan/${vulkan_h}>
 
 #if VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL == 1

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -11,11 +11,13 @@
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 #if defined( VULKAN_HPP_ENABLE_STD_MODULE ) && defined( VULKAN_HPP_STD_MODULE )
+#  include <cassert>
 #  include <string.h>
 import VULKAN_HPP_STD_MODULE;
 #else
 #  include <algorithm>
-#  include <array>     // ArrayWrapperND
+#  include <array>  // ArrayWrapperND
+#  include <cassert>
 #  include <string.h>  // strnlen
 #  include <string>    // std::string
 #  include <utility>   // std::exchange
@@ -36,7 +38,6 @@ import VULKAN_HPP_STD_MODULE;
 #    include <span>
 #  endif
 #endif
-#include <cassert>
 #include <vulkan/vulkan.h>
 
 #if VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL == 1

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -15,8 +15,7 @@
 import VULKAN_HPP_STD_MODULE;
 #else
 #  include <algorithm>
-#  include <array>  // ArrayWrapperND
-#  include <cassert>
+#  include <array>     // ArrayWrapperND
 #  include <string.h>  // strnlen
 #  include <string>    // std::string
 #  include <utility>   // std::exchange
@@ -37,6 +36,7 @@ import VULKAN_HPP_STD_MODULE;
 #    include <span>
 #  endif
 #endif
+#include <cassert>
 #include <vulkan/vulkan.h>
 
 #if VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL == 1


### PR DESCRIPTION
Fix the compilation error problem in #2164 using what's described in the issue.