### PR TITLE
Added using declaration for SwapchainOwns enum to Module File

### DIFF
--- a/vulkan/vulkan.cppm
+++ b/vulkan/vulkan.cppm
@@ -5159,6 +5159,9 @@ export namespace VULKAN_HPP_NAMESPACE
   //=== VK_KHR_swapchain ===
   using VULKAN_HPP_NAMESPACE::SharedSwapchainKHR;
 
+  //=== SharedImage SwapchainOwns enum
+  using VULKAN_HPP_NAMESPACE::SwapchainOwns;
+
   //=== VK_KHR_display ===
   using VULKAN_HPP_NAMESPACE::SharedDisplayKHR;
   using VULKAN_HPP_NAMESPACE::SharedDisplayModeKHR;


### PR DESCRIPTION
This PR adds a using declaration for the SwapchainOwns enum flag, which is utilized in the construction of SharedImages to assign ownership to the SwapchainKHR object. Previously, the definition of this enum class was invisible to the compiler and intellisense if using the C++20 module.

fixes #2170 