### PR TITLE
Tests: Fixed C++20 module test for gcc15

### DIFF
--- a/tests/Cpp20Modules/Cpp20Modules.cpp
+++ b/tests/Cpp20Modules/Cpp20Modules.cpp
@@ -15,18 +15,19 @@
 // VulkanHpp Test : Cpp20Module
 //                  Compile test on using c++20 modules
 
-import vulkan_hpp;
-
 #include <memory>   // std::unique_ptr (seems to be needed on Windows)
 #include <string>   // std::string
 #include <iostream> // std::cout
-#include <vulkan/vulkan_hpp_macros.hpp>
+
+import vulkan_hpp;
 
 static std::string AppName    = "Cpp20Modules";
 static std::string EngineName = "Vulkan.cppm";
 
 #if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
-VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
+namespace vk::detail {
+  DispatchLoaderDynamic defaultDispatchLoaderDynamic;
+}
 #endif
 
 int main( int /*argc*/, char ** /*argv*/ )
@@ -38,7 +39,7 @@ int main( int /*argc*/, char ** /*argv*/ )
   {
 #if ( VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1 )
     // initialize minimal set of function pointers
-    VULKAN_HPP_DEFAULT_DISPATCHER.init();
+    vk::detail::defaultDispatchLoaderDynamic.init();
 #endif
 
     // initialize the vk::ApplicationInfo structure
@@ -52,7 +53,7 @@ int main( int /*argc*/, char ** /*argv*/ )
 
 #if ( VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1 )
     // initialize function pointers for instance
-    VULKAN_HPP_DEFAULT_DISPATCHER.init( instance );
+    vk::detail::defaultDispatchLoaderDynamic.init( instance );
 #endif
 
     // destroy it again


### PR DESCRIPTION
The module implementation for gcc is finally somewhat stable in gcc15 and it can now compile the vulkan module. Just have to make sure to `import` things after `include` in `.cpp` files, otherwise there will be symbol clashes.
Can include gcc tests once there's a runner with gcc15 available (likely going to be Ubuntu 26).

I've also used the `defaultDispatchLoaderDynamic` in the tests directly instead of relying on macros, as that is more in line with how modules are supposed to work. Rmoves the need to include the macro header. Might be an argument for pulling it out of the `detail` namespace?

I will not touch the `import std` tests for now, as I don't have a working setup for those yet. They should work with these changes though, completely removing the need for any `#include` directives.