### PR TITLE
Fix SwapchainCreateInfoKHR where some drivers report maxImageCount as 0

### DIFF
--- a/RAII_Samples/utils/utils.hpp
+++ b/RAII_Samples/utils/utils.hpp
@@ -364,7 +364,7 @@ namespace vk
           vk::PresentModeKHR         presentMode = vk::su::pickPresentMode( physicalDevice.getSurfacePresentModesKHR( surface ) );
           vk::SwapchainCreateInfoKHR swapChainCreateInfo( {},
                                                           surface,
-                                                          vk::su::clamp( 3u, surfaceCapabilities.minImageCount, surfaceCapabilities.maxImageCount ),
+                                                          vk::su::clampSurfaceImageCount( 3u, surfaceCapabilities.minImageCount, surfaceCapabilities.maxImageCount ),
                                                           colorFormat,
                                                           surfaceFormat.colorSpace,
                                                           swapchainExtent,

--- a/samples/utils/utils.hpp
+++ b/samples/utils/utils.hpp
@@ -77,6 +77,7 @@ namespace vk
     VULKAN_HPP_INLINE uint32_t clampSurfaceImageCount( const uint32_t desiredImageCount, const uint32_t minImageCount, const uint32_t maxImageCount )
     {
       uint32_t imageCount = ( std::max )( desiredImageCount, minImageCount );
+      // Some drivers report maxImageCount as 0, so only clamp to max if it is valid.
       if ( maxImageCount > 0 )
       {
         imageCount = ( std::min )( imageCount, maxImageCount );


### PR DESCRIPTION
On the Meteor Lake-P GPU the driver reports maxImageCount as 0, which causes the `vk::su::clamp()` function to pass 0 into the `SwapchainCreateInfoKHR` constructor.  This change catches this and forces it to be greater than or equal to the minimum reported.

Tested on:
Dell Precision 5690 (Meteor Lake-P)
Ubuntu 24.04
Vulkan 1.4.313