### PR TITLE
Add VULKAN_HPP_NO_STRUCT_DEFAULT_INIT for designated initializer list warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The goal of the Vulkan-Hpp is to provide header only C++ bindings for the Vulkan
 	- [VULKAN_HPP_NO_SETTERS](#no_setters)
 	- [VULKAN_HPP_NO_SMART_HANDLE](#no_smart_handle)
 	- [VULKAN_HPP_NO_SPACESHIP_OPERATOR](#no_spaceship_operator)
+	- [VULKAN_HPP_NO_STRUCT_DEFAULT_INIT](#no_struct_default_init)
 	- [VULKAN_HPP_NO_TO_STRING](#no_to_string)
 	- [VULKAN_HPP_NO_WIN32_PROTOTYPES](#no_win32_prototypes)
 	- [VULKAN_HPP_RAII_NO_EXCEPTIONS](#raii_no_exceptions)
@@ -1034,6 +1035,10 @@ By defining `VULKAN_HPP_NO_SMART_HANDLE` before including `vulkan.hpp`, the help
 #### VULKAN_HPP_NO_SPACESHIP_OPERATOR <a id='no_spaceship_operator'>
 
 With C++20, the so-called spaceship-operator `<=>` is introduced. If that operator is supported, all the structs and classes in vulkan.hpp use the default implementation of it. As currently some implementations of this operator are very slow, and others seem to be incomplete, by defining `VULKAN_HPP_NO_SPACESHIP_OPERATOR` before including `vulkan.hpp` you can remove that operator from those structs and classes.
+
+#### VULKAN_HPP_NO_STRUCT_DEFAULT_INIT <a id='no_struct_default_init'>
+
+With C++20, designated initializers are available. To enable warnings for missing fields in designated initializer lists with flags such as `-Wmissing-field-initializers` define `VULKAN_HPP_NO_STRUCT_DEFAULT_INIT` to remove default initialization for all struct members except `sType`.
 
 #### VULKAN_HPP_NO_TO_STRING <a id='no_to_string'>
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ vk::InstanceCreateInfo instanceCreateInfo({}, &applicationInfo);
 Note, that the designator order needs to match the declaration order.
 Note as well, that now you can explicitly set the `sType` member of vk-structures. This is neither neccessary (as they are correctly initialized by default) nor recommended.
 
+To enable warnings for missing fields in designated initializer lists with flags such as `-Wmissing-field-initializers` you can set `#define VULKAN_HPP_NO_STRUCT_DEFAULT_INIT`. This will remove default initialization for all struct members except `sType`.
+
 ### Passing Arrays to Functions using ArrayProxy <a id='passing_arrays'>
 
 The Vulkan API has several places which require (count, pointer) as two function arguments and C++ has a few containers which map perfectly to this pair. To simplify development the Vulkan-Hpp bindings have replaced those argument pairs with the `vk::ArrayProxy` class template which accepts empty arrays and a single value as well as STL containers `std::initializer_list`, `std::array` and `std::vector` as argument for construction. This way a single generated Vulkan version can accept a variety of inputs without having the combinatoric explosion which would occur when creating a function for each container type.

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -12378,9 +12378,10 @@ std::tuple<std::string, std::string, std::string, std::string>
       assert( member.arraySizes.empty() || member.bitCount.empty() );
       if ( !member.bitCount.empty() )
       {
+        // except for bitfield members, where no default member initialization is supported (up to C++20)
         assert( member.deprecated.empty() );
-        membersWithInit += " : " + member.bitCount;  // except for bitfield members, where no default member initializatin
-        membersNoInit   += " : " + member.bitCount;  // is supported (up to C++20)
+        membersWithInit += " : " + member.bitCount;
+        membersNoInit   += " : " + member.bitCount;
       }
       else if ( member.deprecated.empty() )
       {

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -12379,8 +12379,8 @@ std::tuple<std::string, std::string, std::string, std::string>
       if ( !member.bitCount.empty() )
       {
         assert( member.deprecated.empty() );
-        membersWithInit += " : " + member.bitCount; // except for bitfield members, where no default member initializatin
-        membersNoInit   += " : " + member.bitCount; // is supported (up to C++20)
+        membersWithInit += " : " + member.bitCount;  // except for bitfield members, where no default member initializatin
+        membersNoInit   += " : " + member.bitCount;  // is supported (up to C++20)
       }
       else if ( member.deprecated.empty() )
       {

--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -12379,10 +12379,8 @@ std::tuple<std::string, std::string, std::string, std::string>
       if ( !member.bitCount.empty() )
       {
         assert( member.deprecated.empty() );
-        std::string bitCount = " : " + member.bitCount;  // except for bitfield members, where no default member initializatin
-                                                         // is supported (up to C++20)
-        membersWithInit += bitCount;
-        membersNoInit   += bitCount;
+        membersWithInit += " : " + member.bitCount; // except for bitfield members, where no default member initializatin
+        membersNoInit   += " : " + member.bitCount; // is supported (up to C++20)
       }
       else if ( member.deprecated.empty() )
       {
@@ -12397,7 +12395,7 @@ std::tuple<std::string, std::string, std::string, std::string>
           membersWithInit += "{}";
         }
         else
-        { 
+        {
           assert( member.defaultValue.starts_with( "VK_" ) );
           std::string tag = findTag( member.defaultValue );
           membersWithInit += toCamelCase( stripPostfix( stripPrefix( member.defaultValue, "VK_" ), tag ) ) + tag;

--- a/tests/DesignatedInitializers/CMakeLists.txt
+++ b/tests/DesignatedInitializers/CMakeLists.txt
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-vulkan_hpp__setup_test( NAME DesignatedInitializers CXX_STANDARD 20)
+vulkan_hpp__setup_test( NAME DesignatedInitializers CXX_STANDARD 20 )

--- a/tests/DesignatedInitializers/DesignatedInitializers.cpp
+++ b/tests/DesignatedInitializers/DesignatedInitializers.cpp
@@ -53,6 +53,7 @@ int main( int /*argc*/, char ** /*argv*/ )
   uint32_t     appVersion    = 1;
   char const * engineName    = "Vulkan.hpp";
   uint32_t     engineVersion = 1;
+  uint32_t     apiVersion    = 1;
 
   // default initialization is available in any case
   vk::ApplicationInfo ai0;
@@ -81,12 +82,27 @@ int main( int /*argc*/, char ** /*argv*/ )
   // it's allowed, but not recommended to explicitly specify sType
   vk::ApplicationInfo ai2 = { .sType = vk::StructureType::eApplicationInfo };
 
+#    if !defined ( VULKAN_HPP_NO_STRUCT_DEFAULT_INIT )  
   // any number of the members can be specified; the order has to be respected
   vk::ApplicationInfo ai3 = { .pApplicationName = appName };
   vk::ApplicationInfo ai4 = { .applicationVersion = 1, .engineVersion = 2 };
 
   vk::ApplicationInfo ai5{ .pEngineName = engineName };
   vk::ApplicationInfo ai6{ .pApplicationName = appName, .apiVersion = VK_API_VERSION_1_2 };
+#    else
+  // all members except sType have to be specified; the order has to be respected
+  vk::ApplicationInfo ai7 = { .pApplicationName   = appName,
+                              .applicationVersion = appVersion,
+                              .pEngineName        = engineName,
+                              .engineVersion      = engineVersion,
+                              .apiVersion         = apiVersion };
+
+  vk::ApplicationInfo ai8 { .pApplicationName   = appName,
+                            .applicationVersion = appVersion,
+                            .pEngineName        = engineName,
+                            .engineVersion      = engineVersion,
+                            .apiVersion         = apiVersion };
+#    endif
 #  endif
 #endif
 

--- a/tests/DesignatedInitializers/DesignatedInitializers.cpp
+++ b/tests/DesignatedInitializers/DesignatedInitializers.cpp
@@ -53,7 +53,6 @@ int main( int /*argc*/, char ** /*argv*/ )
   uint32_t     appVersion    = 1;
   char const * engineName    = "Vulkan.hpp";
   uint32_t     engineVersion = 1;
-  uint32_t     apiVersion    = 1;
 
   // default initialization is available in any case
   vk::ApplicationInfo ai0;

--- a/tests/DesignatedInitializersNoDefault/CMakeLists.txt
+++ b/tests/DesignatedInitializersNoDefault/CMakeLists.txt
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-vulkan_hpp__setup_test( NAME DesignatedInitializersNoDefault CXX_STANDARD 20)
+vulkan_hpp__setup_test( NAME DesignatedInitializersNoDefault CXX_STANDARD 20 )

--- a/tests/DesignatedInitializersNoDefault/CMakeLists.txt
+++ b/tests/DesignatedInitializersNoDefault/CMakeLists.txt
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-vulkan_hpp__setup_test( NAME DesignatedInitializers CXX_STANDARD 20)
+vulkan_hpp__setup_test( NAME DesignatedInitializersNoDefault CXX_STANDARD 20)

--- a/tests/DesignatedInitializersNoDefault/DesignatedInitializersNoDefault.cpp
+++ b/tests/DesignatedInitializersNoDefault/DesignatedInitializersNoDefault.cpp
@@ -30,18 +30,22 @@ private:
 };
 
 #if defined( __clang__ ) || defined( __GNUC__ )
+#  pragma GCC diagnostic ignored "-Wunused-variable"
+
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic error "-Wmissing-field-initializers"
 #endif
 
 MyVulkanTest::MyVulkanTest()
-  : applicationInfo{ .pApplicationName   = "My Application",
+  : applicationInfo{ .pNext              = nullptr,
+                     .pApplicationName   = "My Application",
                      .applicationVersion = VK_MAKE_VERSION( 0, 0, 1 ),
                      .pEngineName        = "My Engine",
                      .engineVersion      = VK_MAKE_VERSION( 0, 0, 1 ),
                      .apiVersion         = VK_API_VERSION_1_0 }
 {
-  this->applicationInfo = vk::ApplicationInfo{ .pApplicationName   = "My Application",
+  this->applicationInfo = vk::ApplicationInfo{ .pNext              = nullptr,
+                                               .pApplicationName   = "My Application",
                                                .applicationVersion = VK_MAKE_VERSION( 0, 0, 1 ),
                                                .pEngineName        = "My Engine",
                                                .engineVersion      = VK_MAKE_VERSION( 0, 0, 1 ),
@@ -64,13 +68,15 @@ int main( int /*argc*/, char ** /*argv*/ )
 
 #if ( 20 <= VULKAN_HPP_CPP_VERSION )
   // no default initialization: all members except sType have to be specified; the order has to be respected
-  vk::ApplicationInfo ai2 = { .pApplicationName   = appName,
+  vk::ApplicationInfo ai2 = { .pNext              = nullptr,
+                              .pApplicationName   = appName,
                               .applicationVersion = appVersion,
                               .pEngineName        = engineName,
                               .engineVersion      = engineVersion,
                               .apiVersion         = apiVersion };
 
-  vk::ApplicationInfo ai3{ .pApplicationName = appName,
+  vk::ApplicationInfo ai3{ .pNext              = nullptr,
+                           .pApplicationName   = appName,
                            .applicationVersion = appVersion,
                            .pEngineName        = engineName,
                            .engineVersion      = engineVersion,

--- a/tests/DesignatedInitializersNoDefault/DesignatedInitializersNoDefault.cpp
+++ b/tests/DesignatedInitializersNoDefault/DesignatedInitializersNoDefault.cpp
@@ -31,9 +31,6 @@ private:
 
 #if defined( __clang__ ) || defined( __GNUC__ )
 #  pragma GCC diagnostic ignored "-Wunused-variable"
-
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic error "-Wmissing-field-initializers"
 #endif
 
 MyVulkanTest::MyVulkanTest()
@@ -85,7 +82,3 @@ int main( int /*argc*/, char ** /*argv*/ )
 
   return 0;
 }
-
-#if defined( __clang__ ) || defined( __GNUC__ )
-#  pragma GCC diagnostic pop
-#endif

--- a/tests/DesignatedInitializersNoDefault/DesignatedInitializersNoDefault.cpp
+++ b/tests/DesignatedInitializersNoDefault/DesignatedInitializersNoDefault.cpp
@@ -16,13 +16,9 @@
 //                   Compile test on using designated initializers
 
 #define VULKAN_HPP_NO_STRUCT_CONSTRUCTORS
+#define VULKAN_HPP_NO_STRUCT_DEFAULT_INIT
 
-#include <iostream>
 #include <vulkan/vulkan.hpp>
-
-#if defined( __clang__ ) || defined( __GNUC__ )
-#  pragma GCC diagnostic ignored "-Wunused-variable"
-#endif
 
 class MyVulkanTest
 {
@@ -32,6 +28,11 @@ public:
 private:
   vk::ApplicationInfo applicationInfo;
 };
+
+#if defined( __clang__ ) || defined( __GNUC__ )
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic error "-Wmissing-field-initializers"
+#endif
 
 MyVulkanTest::MyVulkanTest()
   : applicationInfo{ .pApplicationName   = "My Application",
@@ -58,38 +59,27 @@ int main( int /*argc*/, char ** /*argv*/ )
   // default initialization is available in any case
   vk::ApplicationInfo ai0;
 
-#if !defined( VULKAN_HPP_NO_STRUCT_CONSTRUCTORS )
-  // due to default initializers, any number of members can be initialized
-  // most IDEs will probably help with the order of the members !
-  vk::ApplicationInfo ai1( appName );
-  vk::ApplicationInfo ai2( appName, appVersion );
-  vk::ApplicationInfo ai3( appName, appVersion, engineName );
-  vk::ApplicationInfo ai4( appName, appVersion, engineName, engineVersion );
-  vk::ApplicationInfo ai5( appName, appVersion, engineName, engineVersion, VK_API_VERSION_1_2 );
-
-  // a structure in namespace vk:: can be copied from the corresponding vulkan C-struct
-  VkApplicationInfo   vai;
-  vk::ApplicationInfo ai6( vai );
-
-#else
-
-  // aggregate initialization: need to explicitly specify sType and pNext, as well as all the other members !
+  // aggregate initialization: need to explicitly specify sType and pNext, as well as all the other members
   vk::ApplicationInfo ai1{ vk::StructureType::eApplicationInfo, nullptr, appName, appVersion, engineName, engineVersion, VK_API_VERSION_1_2 };
 
-#  if ( 20 <= VULKAN_HPP_CPP_VERSION )
-  // designated initializers are available with C++20
+#if ( 20 <= VULKAN_HPP_CPP_VERSION )
+  // no default initialization: all members except sType have to be specified; the order has to be respected
+  vk::ApplicationInfo ai2 = { .pApplicationName = appName,
+                              .applicationVersion = appVersion,
+                              .pEngineName = engineName,
+                              .engineVersion = engineVersion,
+                              .apiVersion = apiVersion };
 
-  // it's allowed, but not recommended to explicitly specify sType
-  vk::ApplicationInfo ai2 = { .sType = vk::StructureType::eApplicationInfo };
-
-  // any number of the members can be specified; the order has to be respected
-  vk::ApplicationInfo ai3 = { .pApplicationName = appName };
-  vk::ApplicationInfo ai4 = { .applicationVersion = 1, .engineVersion = 2 };
-
-  vk::ApplicationInfo ai5{ .pEngineName = engineName };
-  vk::ApplicationInfo ai6{ .pApplicationName = appName, .apiVersion = VK_API_VERSION_1_2 };
-#  endif
-#endif
+  vk::ApplicationInfo ai3{ .pApplicationName = appName,
+                           .applicationVersion = appVersion,
+                           .pEngineName = engineName,
+                           .engineVersion = engineVersion,
+                           .apiVersion = apiVersion };
+#endif /*VULKAN_HPP_CPP_VERSION*/
 
   return 0;
 }
+
+#if defined( __clang__ ) || defined( __GNUC__ )
+#  pragma GCC diagnostic pop
+#endif

--- a/tests/DesignatedInitializersNoDefault/DesignatedInitializersNoDefault.cpp
+++ b/tests/DesignatedInitializersNoDefault/DesignatedInitializersNoDefault.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-// VulkanHpp Tests : DesignatedInitializers
-//                   Compile test on using designated initializers
+// VulkanHpp Tests : DesignatedInitializersNoDefault
+//                   Compile test on init lists without default values
 
 #define VULKAN_HPP_NO_STRUCT_CONSTRUCTORS
 #define VULKAN_HPP_NO_STRUCT_DEFAULT_INIT
@@ -64,17 +64,17 @@ int main( int /*argc*/, char ** /*argv*/ )
 
 #if ( 20 <= VULKAN_HPP_CPP_VERSION )
   // no default initialization: all members except sType have to be specified; the order has to be respected
-  vk::ApplicationInfo ai2 = { .pApplicationName = appName,
+  vk::ApplicationInfo ai2 = { .pApplicationName   = appName,
                               .applicationVersion = appVersion,
-                              .pEngineName = engineName,
-                              .engineVersion = engineVersion,
-                              .apiVersion = apiVersion };
+                              .pEngineName        = engineName,
+                              .engineVersion      = engineVersion,
+                              .apiVersion         = apiVersion };
 
   vk::ApplicationInfo ai3{ .pApplicationName = appName,
                            .applicationVersion = appVersion,
-                           .pEngineName = engineName,
-                           .engineVersion = engineVersion,
-                           .apiVersion = apiVersion };
+                           .pEngineName        = engineName,
+                           .engineVersion      = engineVersion,
+                           .apiVersion         = apiVersion };
 #endif /*VULKAN_HPP_CPP_VERSION*/
 
   return 0;


### PR DESCRIPTION
Currently vulkan-structs.hpp default initializes all struct members as in:
```
  public:
    StructureType sType              = StructureType::eApplicationInfo;
    const void *  pNext              = {};
    const char *  pApplicationName   = {};
    uint32_t      applicationVersion = {};
    const char *  pEngineName        = {};
    uint32_t      engineVersion      = {};
    uint32_t      apiVersion         = {};
```
this prevents flags like `-Wmissing-field-initializers` from properly generating warnings as technically everything is initialized, even if not by me explicitly.

This change will render struct members as follows instead:
```
  public:
#if !defined( VULKAN_HPP_NO_STRUCT_DEFAULT_INIT )
    StructureType sType              = StructureType::eApplicationInfo;
    const void *  pNext              = {};
    const char *  pApplicationName   = {};
    uint32_t      applicationVersion = {};
    const char *  pEngineName        = {};
    uint32_t      engineVersion      = {};
    uint32_t      apiVersion         = {};
#else
    StructureType sType = StructureType::eApplicationInfo;
    const void *  pNext;
    const char *  pApplicationName;
    uint32_t      applicationVersion;
    const char *  pEngineName;
    uint32_t      engineVersion;
    uint32_t      apiVersion;
#endif /*VULKAN_HPP_NO_STRUCT_DEFAULT_INIT*/
```
enabling for the absence of default initialization of struct members by setting `VULKAN_HPP_NO_STRUCT_DEFAULT_INIT`.

Happy to discuss any changes or to close the PR if this change is out of scope for the project.