### PR TITLE
CI: Removed g++-12 compiler instance from ubuntu 22 CI

### DIFF
--- a/.github/workflows/ci-ubuntu-22.yml
+++ b/.github/workflows/ci-ubuntu-22.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        compiler: [clang++-13, clang++-14, clang++-15, g++-10, g++-11, g++-12]
+        compiler: [clang++-13, clang++-14, clang++-15, g++-10, g++-11]
         cpp_standard: [11, 14, 17, 20, 23]
         build_type: [Debug, Release]
         exclude:


### PR DESCRIPTION
g++-12 is tested by both Ubuntu 22 and Ubuntu 24, so does it really make sense to have it on both?