### PR TITLE
C++Module: Manually export vk::SwapchainOwns

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -5195,6 +5195,11 @@ std::string VulkanHppGenerator::generateCppModuleSharedHandleUsings() const
   sharedHandleUsings += R"(  using VULKAN_HPP_NAMESPACE::SharedHandleTraits;
 )";
 
+  sharedHandleUsings += R"(
+  //=== VK_KHR_swapchain enum ===
+  using VULKAN_HPP_NAMESPACE::SwapchainOwns;
+)";
+
   sharedHandleUsings += smartHandleLeave + "\n";
 
   return sharedHandleUsings;

--- a/vulkan/vulkan.cppm
+++ b/vulkan/vulkan.cppm
@@ -5487,6 +5487,9 @@ export namespace VULKAN_HPP_NAMESPACE
   using VULKAN_HPP_NAMESPACE::SharedHandleTraits;
   using VULKAN_HPP_NAMESPACE::SharedIndirectCommandsLayoutEXT;
   using VULKAN_HPP_NAMESPACE::SharedIndirectExecutionSetEXT;
+
+  //=== VK_KHR_swapchain enum ===
+  using VULKAN_HPP_NAMESPACE::SwapchainOwns;
 #endif /*VULKAN_HPP_NO_SMART_HANDLE*/
 
   //===========================


### PR DESCRIPTION
This flag was previously not exported, though I'm not entirely sure why it is not part of the `m_handles` or `requireData.types`. Are enums exluded?

Either way, this will resolve #2170