### PR TITLE
Tests: Enabling C++Module tests for ArrayWrapper

### DIFF
--- a/tests/ArrayWrapper/ArrayWrapper.cpp
+++ b/tests/ArrayWrapper/ArrayWrapper.cpp
@@ -16,7 +16,6 @@
 //                     Compile test on using vk::ArrayWrapper1D
 
 #include <string>
-#include <cassert>
 #include <iostream>
 
 #include <vulkan/vulkan_hpp_macros.hpp>
@@ -39,7 +38,7 @@ int main( int /*argc*/, char ** /*argv*/ )
 {
   vk::ArrayWrapper1D<char, 10> awc1( { 'f', 'o', 'o', 'b', 'a', 'h' } );
   std::string                  s1 = awc1;
-  assert( s1.length() == 6 );
+  void( s1.length() == 6 );
   std::cout << "<" << awc1 << ">" << std::endl;
 
   // s1 = awc1;  // 'operator =' is ambiguous
@@ -51,50 +50,50 @@ int main( int /*argc*/, char ** /*argv*/ )
 
   vk::ArrayWrapper1D<char, 5> awc3( { 'f', 'o', 'o', 'b', 'a', 'h' } );
   std::string                 s3 = awc3;
-  assert( s3.length() == 4 );
+  void( s3.length() == 4 );
   std::cout << "<" << s3 << ">" << std::endl;
 
   vk::ArrayWrapper1D<char, 5> awc4( foobah );
   std::string                 s4 = awc4;
-  assert( s4.length() == 4 );
+  void( s4.length() == 4 );
 
 #if 17 <= VULKAN_HPP_CPP_VERSION
   std::cout << std::boolalpha << std::is_convertible_v<vk::ArrayWrapper1D<char, 10>, std::string_view> << std::endl;
 
   std::string_view sv1 = awc1;
-  assert( sv1.size() == 6 );
+  void( sv1.size() == 6 );
   sv1 = awc2;
-  assert( sv1.size() == 6 );
+  void( sv1.size() == 6 );
   sv1 = awc3;
-  assert( sv1.size() == 5 );
+  void( sv1.size() == 5 );
 
   vk::ArrayWrapper1D<char, 8> awc5( sv1 );
 #endif
 
-  assert( awc1 == awc2 );
-  assert( !( awc1 != awc2 ) );
-  assert( awc1 <= awc2 );
-  assert( !( awc1 < awc2 ) );
-  assert( awc1 >= awc2 );
-  assert( !( awc1 > awc2 ) );
+  void( awc1 == awc2 );
+  void( !( awc1 != awc2 ) );
+  void( awc1 <= awc2 );
+  void( !( awc1 < awc2 ) );
+  void( awc1 >= awc2 );
+  void( !( awc1 > awc2 ) );
 
-  assert( awc3 == awc4 );
+  void( awc3 == awc4 );
+  
+  void( foobah == awc1 );
+  // void( !( foobah != awc1 ) );
+  // void( foobah <= awc1 );
+  // void( !( foobah < awc1 ) );
+  // void( foobah >= awc1 );
+  // void( !( foobah > awc1 ) );
 
-  assert( foobah == awc1 );
-  assert( !( foobah != awc1 ) );
-  assert( foobah <= awc1 );
-  assert( !( foobah < awc1 ) );
-  assert( foobah >= awc1 );
-  assert( !( foobah > awc1 ) );
+  // void( awc1 == foobah );
+  // void( !( awc1 != foobah ) );
+  // void( awc1 <= foobah );
+  // void( !( awc1 < foobah ) );
+  // void( awc1 >= foobah );
+  // void( !( awc1 > foobah ) );
 
-  assert( awc1 == foobah );
-  assert( !( awc1 != foobah ) );
-  assert( awc1 <= foobah );
-  assert( !( awc1 < foobah ) );
-  assert( awc1 >= foobah );
-  assert( !( awc1 > foobah ) );
-
-  assert( foobah > awc4 );
+  // void( foobah > awc4 );
 
   return 0;
 }

--- a/tests/ArrayWrapper/CMakeLists.txt
+++ b/tests/ArrayWrapper/CMakeLists.txt
@@ -14,5 +14,5 @@
 
 vulkan_hpp__setup_test( NAME ArrayWrapper )
 if( VULKAN_HPP_ENABLE_CPP20_MODULES )
-    # vulkan_hpp__setup_test( NAME ArrayWrapper CXX_MODULE ) # error with GCC and Clang
+    vulkan_hpp__setup_test( NAME ArrayWrapper CXX_MODULE )
 endif()


### PR DESCRIPTION
Related to #1993.
Replacing `assert` with `void` evaluates the expressions even in Release mode (which it previously didn't).

This is currently a WIP, as there is an issue with the comparison operators between `std::string` and `vk::ArrayWrapper1D<char, N>`. This issue is only found when using `import vulkan_hpp`.

It seems like the compiler does not consider using the explicit comparison operators provided in the import, instead it tries to convert the `ArrayWrapper` to everything that has a comparison operator with `std::string`. This goes both ways (`ArrayWrapper == string` and `string == ArrayWrapper`). Funnily enough, adding it again explicitly in the test source itself results in an ambiguity error. Creating the comparison operator in the `vulkan.cppm` module emits complaints about ISO C++20 not allowing reversed operators, even though a unique non-amiguous operator can be chosen (the compiler even explicitly states this).

Found in both Clang and GCC, with similar errors in both. Need some ideas about what actually causes this.

<details>

<summary>Clang 20</summary>

```
FAILED: tests/ArrayWrapper/CMakeFiles/ArrayWrapper_module.dir/ArrayWrapper.cpp.o 
/usr/bin/clang++ -DVK_USE_PLATFORM_XCB_KHR -DVULKAN_HPP_USE_CXX_MODULE -IVulkan-Hpp -IVulkan-Hpp/Vulkan-Headers/include -O3 -DNDEBUG -std=gnu++20 -Wall -Wextra -Wpedantic -Werror -MD -MT tests/ArrayWrapper/CMakeFiles/ArrayWrapper_module.dir/ArrayWrapper.cpp.o -MF tests/ArrayWrapper/CMakeFiles/ArrayWrapper_module.dir/ArrayWrapper.cpp.o.d @tests/ArrayWrapper/CMakeFiles/ArrayWrapper_module.dir/ArrayWrapper.cpp.o.modmap -o tests/ArrayWrapper/CMakeFiles/ArrayWrapper_module.dir/ArrayWrapper.cpp.o -c Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp
Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:82:16: error: invalid operands to binary expression ('std::string' (aka 'basic_string<char>') and 'vk::ArrayWrapper1D<char, 10>')
   82 |   void( foobah == awc1 );
      |         ~~~~~~ ^  ~~~~
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/allocator.h:221:7: note: candidate function not viable: no known conversion from 'std::string' (aka 'basic_string<char>') to 'const allocator<char>' for 1st argument
  221 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
      |       ^          ~~~~~~~~~~~~~~~~
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/system_error:451:3: note: candidate function not viable: no known conversion from 'std::string' (aka 'basic_string<char>') to 'const error_code' for 1st argument
  451 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
      |   ^          ~~~~~~~~~~~~~~~~~~~~~~~
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/system_error:467:3: note: candidate function not viable: no known conversion from 'std::string' (aka 'basic_string<char>') to 'const error_code' for 1st argument
  467 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
      |   ^          ~~~~~~~~~~~~~~~~~~~~~~~
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/system_error:467:3: note: candidate function (with reversed parameter order) not viable: no known conversion from 'std::string' (aka 'basic_string<char>') to 'const error_condition' for 1st argument
  467 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
      |   ^          ~~~~~~~~~~~~~~~~~~~~~~~
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/system_error:482:3: note: candidate function not viable: no known conversion from 'std::string' (aka 'basic_string<char>') to 'const error_condition' for 1st argument
  482 |   operator==(const error_condition& __lhs,
      |   ^          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/stl_pair.h:1031:5: note: candidate template ignored: could not match 'pair' against 'std::basic_string'
 1031 |     operator==(const pair<_T1, _T2>& __x, const pair<_U1, _U2>& __y)
      |     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/stl_pair.h:1031:5: note: candidate template ignored: could not match 'pair' against 'vk::ArrayWrapper1D'
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/stl_iterator.h:529:5: note: candidate template ignored: could not match 'reverse_iterator' against 'std::basic_string'
  529 |     operator==(const reverse_iterator<_IteratorL>& __x,
      |     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/stl_iterator.h:588:5: note: candidate template ignored: could not match 'reverse_iterator' against 'std::basic_string'
  588 |     operator==(const reverse_iterator<_Iterator>& __x,
      |     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/stl_iterator.h:1662:5: note: candidate template ignored: could not match 'move_iterator' against 'std::basic_string'
 1662 |     operator==(const move_iterator<_IteratorL>& __x,
      |     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/stl_iterator.h:1662:5: note: candidate template ignored: could not match 'move_iterator' against 'vk::ArrayWrapper1D'
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/stl_iterator.h:1732:5: note: candidate template ignored: could not match 'move_iterator' against 'std::basic_string'
 1732 |     operator==(const move_iterator<_Iterator>& __x,
      |     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/postypes.h:197:5: note: candidate template ignored: could not match 'fpos' against 'std::basic_string'
  197 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
      |     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/new_allocator.h:215:2: note: candidate template ignored: could not match '__new_allocator' against 'vk::ArrayWrapper1D'
  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
      |         ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/new_allocator.h:215:2: note: candidate template ignored: could not match '__new_allocator' against 'std::basic_string'
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/allocator.h:242:5: note: candidate template ignored: could not match 'allocator' against 'std::basic_string'
  242 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
      |     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/allocator.h:242:5: note: candidate template ignored: could not match 'allocator' against 'vk::ArrayWrapper1D'
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/string_view:616:5: note: candidate template ignored: could not match 'basic_string_view' against 'std::basic_string'
  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
      |     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/string_view:616:5: note: candidate template ignored: could not match 'basic_string_view' against 'vk::ArrayWrapper1D'
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/basic_string.h:4045:5: note: candidate template ignored: could not match 'basic_string' against 'vk::ArrayWrapper1D'
 4045 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
      |     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/basic_string.h:4062:5: note: candidate template ignored: could not match 'const _CharT *' against 'vk::ArrayWrapper1D<char, 10>'
 4062 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
      |     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/basic_string.h:4062:5: note: candidate template ignored: could not match 'basic_string' against 'vk::ArrayWrapper1D'
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/tuple:2532:5: note: candidate template ignored: could not match 'tuple' against 'std::basic_string'
 2532 |     operator== [[nodiscard]] (const tuple<_Tps...>& __t,
      |     ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/tuple:2532:5: note: candidate template ignored: could not match 'tuple' against 'vk::ArrayWrapper1D'
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/15.2.1/../../../../include/c++/15.2.1/bits/streambuf_iterator.h:236:5: note: candidate template ignored: could not match 'istreambuf_iterator' against 'std::basic_string'
  236 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
      |     ^
```

</details>

<details>

<summary>GCC 15</summary>

```
FAILED: tests/ArrayWrapper/CMakeFiles/ArrayWrapper_module.dir/ArrayWrapper.cpp.o 
/usr/bin/g++ -DVK_USE_PLATFORM_XCB_KHR -DVULKAN_HPP_USE_CXX_MODULE -IVulkan-Hpp -IVulkan-Hpp/Vulkan-Headers/include -O3 -DNDEBUG -std=gnu++20 -Wall -Wextra -Wpedantic -Werror -MD -MT tests/ArrayWrapper/CMakeFiles/ArrayWrapper_module.dir/ArrayWrapper.cpp.o -MF tests/ArrayWrapper/CMakeFiles/ArrayWrapper_module.dir/ArrayWrapper.cpp.o.d -fmodules-ts -fmodule-mapper=tests/ArrayWrapper/CMakeFiles/ArrayWrapper_module.dir/ArrayWrapper.cpp.o.modmap -MD -fdeps-format=p1689r5 -x c++ -o tests/ArrayWrapper/CMakeFiles/ArrayWrapper_module.dir/ArrayWrapper.cpp.o -c Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp
Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp: In function ‘int main(int, char**)’:
Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:82:16: error: no match for ‘operator==’ (operand types are ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} and ‘vk::ArrayWrapper1D<char, 10>’)
   82 |   void( foobah == awc1 );
      |         ~~~~~~ ^~ ~~~~
      |         |         |
      |         |         vk::ArrayWrapper1D<char, 10>
      |         std::string {aka std::__cxx11::basic_string<char>}
Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:82:16: note: there are 17 candidates
   82 |   void( foobah == awc1 );
      |         ~~~~~~~^~~~~~~
In file included from /usr/include/c++/15.2.1/x86_64-pc-linux-gnu/bits/c++allocator.h:33,
                 from /usr/include/c++/15.2.1/bits/allocator.h:46,
                 from /usr/include/c++/15.2.1/string:45,
                 from Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:18:
/usr/include/c++/15.2.1/bits/new_allocator.h:215:9: note: candidate 1: ‘template<class _Up> constexpr bool std::operator==(const __new_allocator<char>&, const __new_allocator<_Tp>&)’ (reversed)
  215 |         operator==(const __new_allocator&, const __new_allocator<_Up>&)
      |         ^~~~~~~~
/usr/include/c++/15.2.1/bits/new_allocator.h:215:9: note: template argument deduction/substitution failed:
Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:82:19: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::__new_allocator<_Tp>’
   82 |   void( foobah == awc1 );
      |                   ^~~~
/usr/include/c++/15.2.1/bits/allocator.h:242:5: note: candidate 2: ‘template<class _T1, class _T2> constexpr bool std::operator==(const allocator<_CharT>&, const allocator<_T2>&)’ (reversed)
  242 |     operator==(const allocator<_T1>&, const allocator<_T2>&)
      |     ^~~~~~~~
/usr/include/c++/15.2.1/bits/allocator.h:242:5: note: template argument deduction/substitution failed:
Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:82:19: note:   ‘vk::ArrayWrapper1D<char, 10>’ is not derived from ‘const std::allocator<_CharT>’
   82 |   void( foobah == awc1 );
      |                   ^~~~
In file included from /usr/include/c++/15.2.1/string:50:
/usr/include/c++/15.2.1/bits/stl_iterator.h:529:5: note: candidate 3: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const reverse_iterator<_IteratorL>&, const reverse_iterator<_IteratorR>&) requires requires{{std::operator==::__x->base() == std::operator==::__y->base()} -> decltype(auto) [requires std::convertible_to<<placeholder>, bool>];}’ (reversed)
  529 |     operator==(const reverse_iterator<_IteratorL>& __x,
      |     ^~~~~~~~
/usr/include/c++/15.2.1/bits/stl_iterator.h:529:5: note: template argument deduction/substitution failed:
Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:82:19: note:   ‘vk::ArrayWrapper1D<char, 10>’ is not derived from ‘const std::reverse_iterator<_IteratorL>’
   82 |   void( foobah == awc1 );
      |                   ^~~~
/usr/include/c++/15.2.1/bits/stl_iterator.h:1662:5: note: candidate 4: ‘template<class _IteratorL, class _IteratorR> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorR>&) requires requires{{std::operator==::__x->base() == std::operator==::__y->base()} -> decltype(auto) [requires std::convertible_to<<placeholder>, bool>];}’ (reversed)
 1662 |     operator==(const move_iterator<_IteratorL>& __x,
      |     ^~~~~~~~
/usr/include/c++/15.2.1/bits/stl_iterator.h:1662:5: note: template argument deduction/substitution failed:
Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:82:19: note:   ‘vk::ArrayWrapper1D<char, 10>’ is not derived from ‘const std::move_iterator<_IteratorL>’
   82 |   void( foobah == awc1 );
      |                   ^~~~
In file included from /usr/include/c++/15.2.1/bits/stl_algobase.h:64,
                 from /usr/include/c++/15.2.1/string:53:
/usr/include/c++/15.2.1/bits/stl_pair.h:1031:5: note: candidate 5: ‘template<class _T1, class _T2, class _U1, class _U2> constexpr bool std::operator==(const pair<_T1, _T2>&, const pair<_U1, _U2>&) requires requires{{std::operator==::__x->first == std::operator==::__y->first} -> decltype(auto) [requires std::__detail::__boolean_testable<<placeholder>, >];{std::operator==::__x->second == std::operator==::__y->second} -> decltype(auto) [requires std::__detail::__boolean_testable<<placeholder>, >];}’ (reversed)
 1031 |     operator==(const pair<_T1, _T2>& __x, const pair<_U1, _U2>& __y)
      |     ^~~~~~~~
/usr/include/c++/15.2.1/bits/stl_pair.h:1031:5: note: template argument deduction/substitution failed:
Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:82:19: note:   ‘vk::ArrayWrapper1D<char, 10>’ is not derived from ‘const std::pair<_T1, _T2>’
   82 |   void( foobah == awc1 );
      |                   ^~~~
In file included from /usr/include/c++/15.2.1/bits/basic_string.h:51,
                 from /usr/include/c++/15.2.1/string:56:
/usr/include/c++/15.2.1/string_view:616:5: note: candidate 6: ‘template<class _CharT, class _Traits> constexpr bool std::operator==(basic_string_view<_CharT, _Traits>, type_identity_t<basic_string_view<_CharT, _Traits> >)’ (reversed)
  616 |     operator==(basic_string_view<_CharT, _Traits> __x,
      |     ^~~~~~~~
/usr/include/c++/15.2.1/string_view:616:5: note: template argument deduction/substitution failed:
Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:82:19: note:   ‘vk::ArrayWrapper1D<char, 10>’ is not derived from ‘std::basic_string_view<_CharT, _Traits>’
   82 |   void( foobah == awc1 );
      |                   ^~~~
/usr/include/c++/15.2.1/bits/basic_string.h:4062:5: note: candidate 7: ‘template<class _CharT, class _Traits, class _Alloc> constexpr bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Alloc>&, const _CharT*)’ (reversed)
 4062 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
      |     ^~~~~~~~
/usr/include/c++/15.2.1/bits/basic_string.h:4062:5: note: template argument deduction/substitution failed:
Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:82:19: note:   ‘vk::ArrayWrapper1D<char, 10>’ is not derived from ‘const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>’
   82 |   void( foobah == awc1 );
      |                   ^~~~
In file included from /usr/include/c++/15.2.1/bits/uses_allocator_args.h:41,
                 from /usr/include/c++/15.2.1/bits/memory_resource.h:43,
                 from /usr/include/c++/15.2.1/string:72:
/usr/include/c++/15.2.1/tuple:2532:5: note: candidate 8: ‘template<class ... _Tps, class ... _Ups>  requires  sizeof ... (_Tps ...) == sizeof ... (_Ups ...) && ((requires(const _Tps& __t, const _Ups& __u) {{__t == __u} -> decltype(auto) [requires std::__detail::__boolean_testable<<placeholder>, >];} && ...)) constexpr bool std::operator==(const tuple<_UTypes ...>&, const tuple<_Elements ...>&)’ (reversed)
 2532 |     operator== [[nodiscard]] (const tuple<_Tps...>& __t,
      |     ^~~~~~~~
/usr/include/c++/15.2.1/tuple:2532:5: note: template argument deduction/substitution failed:
Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:82:19: note:   ‘vk::ArrayWrapper1D<char, 10>’ is not derived from ‘const std::tuple<_UTypes ...>’
   82 |   void( foobah == awc1 );
      |                   ^~~~
In file included from /usr/include/c++/15.2.1/bits/ios_base.h:48,
                 from /usr/include/c++/15.2.1/ios:46,
                 from /usr/include/c++/15.2.1/bits/ostream.h:43,
                 from /usr/include/c++/15.2.1/ostream:42,
                 from /usr/include/c++/15.2.1/iostream:43,
                 from Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:19:
/usr/include/c++/15.2.1/system_error:467:3: note: candidate 9: ‘bool std::operator==(const error_code&, const error_condition&)’ (reversed)
  467 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
      |   ^~~~~~~~
/usr/include/c++/15.2.1/system_error:467:32: note: no known conversion for argument 1 from ‘vk::ArrayWrapper1D<char, 10>’ to ‘const std::error_code&’
  467 |   operator==(const error_code& __lhs, const error_condition& __rhs) noexcept
      |              ~~~~~~~~~~~~~~~~~~^~~~~
In file included from /usr/include/c++/15.2.1/bits/char_traits.h:44,
                 from /usr/include/c++/15.2.1/string:44:
/usr/include/c++/15.2.1/bits/postypes.h:197:5: note: candidate 10: ‘template<class _StateT> bool std::operator==(const fpos<_StateT>&, const fpos<_StateT>&)’
  197 |     operator==(const fpos<_StateT>& __lhs, const fpos<_StateT>& __rhs)
      |     ^~~~~~~~
/usr/include/c++/15.2.1/bits/postypes.h:197:5: note: template argument deduction/substitution failed:
Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:82:19: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::fpos<_StateT>’
   82 |   void( foobah == awc1 );
      |                   ^~~~
/usr/include/c++/15.2.1/bits/stl_iterator.h:588:5: note: candidate 11: ‘template<class _Iterator> constexpr bool std::operator==(const reverse_iterator<_IteratorL>&, const reverse_iterator<_IteratorL>&) requires requires{{std::operator==::__x->base() == std::operator==::__y->base()} -> decltype(auto) [requires std::convertible_to<<placeholder>, bool>];}’
  588 |     operator==(const reverse_iterator<_Iterator>& __x,
      |     ^~~~~~~~
/usr/include/c++/15.2.1/bits/stl_iterator.h:588:5: note: template argument deduction/substitution failed:
Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:82:19: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::reverse_iterator<_IteratorL>’
   82 |   void( foobah == awc1 );
      |                   ^~~~
/usr/include/c++/15.2.1/bits/stl_iterator.h:1732:5: note: candidate 12: ‘template<class _Iterator> constexpr bool std::operator==(const move_iterator<_IteratorL>&, const move_iterator<_IteratorL>&)’
 1732 |     operator==(const move_iterator<_Iterator>& __x,
      |     ^~~~~~~~
/usr/include/c++/15.2.1/bits/stl_iterator.h:1732:5: note: template argument deduction/substitution failed:
Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:82:19: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::move_iterator<_IteratorL>’
   82 |   void( foobah == awc1 );
      |                   ^~~~
/usr/include/c++/15.2.1/bits/basic_string.h:4045:5: note: candidate 13: ‘template<class _CharT, class _Traits, class _Alloc> constexpr bool std::operator==(const __cxx11::basic_string<_CharT, _Traits, _Alloc>&, const __cxx11::basic_string<_CharT, _Traits, _Alloc>&)’
 4045 |     operator==(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
      |     ^~~~~~~~
/usr/include/c++/15.2.1/bits/basic_string.h:4045:5: note: template argument deduction/substitution failed:
Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:82:19: note:   ‘vk::ArrayWrapper1D<char, 10>’ is not derived from ‘const std::__cxx11::basic_string<_CharT, _Traits, _Alloc>’
   82 |   void( foobah == awc1 );
      |                   ^~~~
In file included from /usr/include/c++/15.2.1/bits/locale_facets.h:50,
                 from /usr/include/c++/15.2.1/bits/basic_ios.h:39,
                 from /usr/include/c++/15.2.1/ios:48:
/usr/include/c++/15.2.1/bits/streambuf_iterator.h:236:5: note: candidate 14: ‘template<class _CharT, class _Traits> bool std::operator==(const istreambuf_iterator<_CharT, _Traits>&, const istreambuf_iterator<_CharT, _Traits>&)’
  236 |     operator==(const istreambuf_iterator<_CharT, _Traits>& __a,
      |     ^~~~~~~~
/usr/include/c++/15.2.1/bits/streambuf_iterator.h:236:5: note: template argument deduction/substitution failed:
Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:82:19: note:   ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} is not derived from ‘const std::istreambuf_iterator<_CharT, _Traits>’
   82 |   void( foobah == awc1 );
      |                   ^~~~
/usr/include/c++/15.2.1/bits/allocator.h:221:7: note: candidate 15: ‘constexpr bool std::operator==(const allocator<char>&, const allocator<char>&)’
  221 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
      |       ^~~~~~~~
In file included from /usr/include/c++/15.2.1/string:45,
                 from Vulkan-Hpp/vulkan/vulkan.hpp:23,
                 from Vulkan-Hpp/vulkan/vulkan.cppm:19,
of module vulkan_hpp, imported at Vulkan-Hpp/tests/ArrayWrapper/ArrayWrapper.cpp:27:
/usr/include/c++/15.2.1/bits/allocator.h:221:18: note: no known conversion for argument 1 from ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘const std::allocator<char>&’
  221 |       operator==(const allocator&, const allocator&) _GLIBCXX_NOTHROW
      |                  ^~~~~~~~~~~~~~~~
/usr/include/c++/15.2.1/system_error:451:3: note: candidate 16: ‘bool std::operator==(const error_code&, const error_code&)’
  451 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
      |   ^~~~~~~~
/usr/include/c++/15.2.1/system_error:451:32: note: no known conversion for argument 1 from ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘const std::error_code&’
  451 |   operator==(const error_code& __lhs, const error_code& __rhs) noexcept
      |              ~~~~~~~~~~~~~~~~~~^~~~~
/usr/include/c++/15.2.1/system_error:482:3: note: candidate 17: ‘bool std::operator==(const error_condition&, const error_condition&)’
  482 |   operator==(const error_condition& __lhs,
      |   ^~~~~~~~
/usr/include/c++/15.2.1/system_error:482:37: note: no known conversion for argument 1 from ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘const std::error_condition&’
  482 |   operator==(const error_condition& __lhs,
      |              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~
```

</details>