### PR TITLE
CI: Added bleeding-edge ubuntu ci with clang 19/20 and newest cmake (4.1)

### DIFF
--- a/.github/workflows/ci-ubuntu-ext.yml
+++ b/.github/workflows/ci-ubuntu-ext.yml
@@ -1,0 +1,142 @@
+
+name: CI Ubuntu 24
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      matrix:
+        clang_version: [19, 20]
+    
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Install libraries
+      run: sudo apt update && sudo apt install libgl-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev
+
+    - name: Install Ninja
+      uses: ashutoshvarma/setup-ninja@master
+      with:
+        version: 1.11.0
+    - name: Install Clang and CMake
+      run: |
+        sudo apt-get update && sudo apt-get install lsb-release gpg software-properties-common wget
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh ${{matrix.clang_version}} all
+
+        sudo apt purge --auto-remove cmake
+        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+        echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ noble main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
+        sudo apt update && sudo apt install cmake
+
+    - name: Install glm, glfw and glslang
+      run: |
+        cd glm 
+        cmake -B build -G Ninja                                   \
+          -D CMAKE_CXX_COMPILER=clang++-${{matrix.clang_version}} \
+          -D CMAKE_CXX_STANDARD=11                                \
+          -D CMAKE_BUILD_TYPE=Release                             \
+          -D GLM_BUILD_LIBRARY=ON                                 \
+          -D GLM_BUILD_INSTALL=ON                                 \
+          -D GLM_BUILD_TESTS=OFF
+        cmake --build build --parallel
+        sudo cmake --install build
+
+        cd ../glfw
+        cmake -B build -G Ninja                                   \
+          -D CMAKE_CXX_COMPILER=clang++-${{matrix.clang_version}} \
+          -D CMAKE_CXX_STANDARD=11                                \
+          -D CMAKE_BUILD_TYPE=Release                             \
+          -D GLFW_BUILD_EXAMPLES=OFF                              \
+          -D GLFW_BUILD_TESTS=OFF                                 \
+          -D GLFW_BUILD_DOCS=OFF                                  \
+          -D GLFW_INSTALL=ON
+        cmake --build build --parallel
+        sudo cmake --install build
+
+        cd ../glslang
+        cmake -B build -G Ninja                                   \
+          -D CMAKE_CXX_COMPILER=clang++-${{matrix.clang_version}} \
+          -D CMAKE_CXX_STANDARD=11                                \
+          -D CMAKE_BUILD_TYPE=Release                             \
+          -D ENABLE_OPT=OFF                                       \
+          -D GLSLANG_TESTS_DEFAULT=OFF                            \
+          -D GLSLANG_ENABLE_INSTALL_DEFAULT=ON
+        cmake --build build --parallel
+        sudo cmake --install build
+        cd ..
+        
+    - name: Generate headers
+      run: |
+        cmake -B build -G Ninja                                     \
+          -D VULKAN_HPP_GENERATOR_BUILD=ON                          \
+          -D VULKAN_HPP_RUN_GENERATOR=OFF                           \
+          -D VULKAN_HPP_SAMPLES_BUILD=OFF                           \
+          -D VULKAN_HPP_TESTS_BUILD=OFF                             \
+          -D VULKAN_HPP_ENABLE_CPP20_MODULES=OFF                    \
+          -D VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=ON                  \
+          -D VULKAN_HPP_BUILD_WITH_LOCAL_VULKAN_HPP=ON              \
+          -D VULKAN_HPP_PRECOMPILE=OFF                              \
+          -D CMAKE_CXX_COMPILER=clang++-${{matrix.clang_version}}   \
+          -D CMAKE_CXX_STANDARD=20                                  \
+          -D CMAKE_BUILD_TYPE=Debug
+        cmake --build build --parallel
+
+        cmake -B build -G Ninja --fresh                             \
+          -D VULKAN_HPP_GENERATOR_BUILD=ON                          \
+          -D VULKAN_HPP_RUN_GENERATOR=ON                            \
+          -D VULKAN_HPP_SAMPLES_BUILD=OFF                           \
+          -D VULKAN_HPP_TESTS_BUILD=OFF                             \
+          -D VULKAN_HPP_ENABLE_CPP20_MODULES=OFF                    \
+          -D VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=ON                  \
+          -D VULKAN_HPP_BUILD_WITH_LOCAL_VULKAN_HPP=ON              \
+          -D VULKAN_HPP_PRECOMPILE=OFF                              \
+          -D CMAKE_CXX_COMPILER=clang++-${{matrix.clang_version}}   \
+          -D CMAKE_CXX_STANDARD=20                                  \
+          -D CMAKE_BUILD_TYPE=Release
+        cmake --build build --parallel --clean-first
+
+    - name: Build samples and tests
+      run: |
+        for CXX_STANDARD in 11 14 17 20 23; do
+          for BUILD_TYPE in Debug Release; do
+            if [ clang++-${{matrix.clang_version}} == clang++-17 ] && [ $CXX_STANDARD == 23 ]; then
+              continue
+            fi
+
+            CXX_MODULES=ON
+            if [ $CXX_STANDARD -lt 20 ]; then
+              CXX_MODULES=OFF
+            fi
+
+            echo "================================================================================="
+            echo "Building C++$CXX_STANDARD in $BUILD_TYPE"
+            echo "================================================================================="
+            
+            cmake -B build -G Ninja --fresh                           \
+              -D VULKAN_HPP_GENERATOR_BUILD=OFF                       \
+              -D VULKAN_HPP_RUN_GENERATOR=OFF                         \
+              -D VULKAN_HPP_SAMPLES_BUILD=ON                          \
+              -D VULKAN_HPP_TESTS_BUILD=ON                            \
+              -D VULKAN_HPP_ENABLE_CPP20_MODULES=$CXX_MODULES         \
+              -D VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=ON                \
+              -D VULKAN_HPP_BUILD_WITH_LOCAL_VULKAN_HPP=ON            \
+              -D VULKAN_HPP_PRECOMPILE=OFF                            \
+              -D CMAKE_CXX_COMPILER=clang++-${{matrix.clang_version}} \
+              -D CMAKE_CXX_STANDARD=$CXX_STANDARD                     \
+              -D CMAKE_BUILD_TYPE=$BUILD_TYPE
+            cmake --build build --parallel --clean-first
+          done
+        done

--- a/.github/workflows/ci-ubuntu-ext.yml
+++ b/.github/workflows/ci-ubuntu-ext.yml
@@ -1,5 +1,5 @@
 
-name: CI Ubuntu 24
+name: CI Ubuntu EXT
 
 on:
   pull_request:
@@ -112,9 +112,6 @@ jobs:
       run: |
         for CXX_STANDARD in 11 14 17 20 23; do
           for BUILD_TYPE in Debug Release; do
-            if [ clang++-${{matrix.clang_version}} == clang++-17 ] && [ $CXX_STANDARD == 23 ]; then
-              continue
-            fi
 
             CXX_MODULES=ON
             if [ $CXX_STANDARD -lt 20 ]; then


### PR DESCRIPTION
This new CI is supposed to test newest compiler versions that are not available on the runners by default yet, hopefully catching errors before they make it into stable distro releases.
It pulls newest builds for clang and cmake from the publishers apt repos.

The plan is to also use these to test `import std` in the near future, as newer version of CMake are required (min `3.30`, though much more stable in `4.1`).