### PR TITLE
Fix: Correct IWYU pragmas

### DIFF
--- a/snippets/EnumsHppTemplate.hpp
+++ b/snippets/EnumsHppTemplate.hpp
@@ -4,7 +4,7 @@ ${licenseHeader}
 #  define VULKAN_ENUMS_HPP
 
 // include-what-you-use: make sure, vulkan.hpp is used by code-completers
-// IWYU pragma: private; include "vulkan.hpp"
+// IWYU pragma: private, include "vulkan/vulkan.hpp"
 
 #include <type_traits>    // for std::underlying_type
 

--- a/snippets/FuncsHppTemplate.hpp
+++ b/snippets/FuncsHppTemplate.hpp
@@ -3,7 +3,7 @@ ${licenseHeader}
 #  define VULKAN_FUNCS_HPP
 
 // include-what-you-use: make sure, vulkan.hpp is used by code-completers
-// IWYU pragma: private; include "vulkan.hpp"
+// IWYU pragma: private, include "vulkan/vulkan.hpp"
 
 namespace VULKAN_HPP_NAMESPACE
 {

--- a/snippets/HandlesHppTemplate.hpp
+++ b/snippets/HandlesHppTemplate.hpp
@@ -3,7 +3,7 @@ ${licenseHeader}
 #  define VULKAN_HANDLES_HPP
 
 // include-what-you-use: make sure, vulkan.hpp is used by code-completers
-// IWYU pragma: private; include "vulkan.hpp"
+// IWYU pragma: private, include "vulkan/vulkan.hpp"
 
 namespace VULKAN_HPP_NAMESPACE
 {

--- a/snippets/StructsHppTemplate.hpp
+++ b/snippets/StructsHppTemplate.hpp
@@ -4,7 +4,7 @@ ${licenseHeader}
 #  define VULKAN_STRUCTS_HPP
 
 // include-what-you-use: make sure, vulkan.hpp is used by code-completers
-// IWYU pragma: private; include "vulkan.hpp"
+// IWYU pragma: private, include "vulkan/vulkan.hpp"
 
 #include <cstring>  // strcmp
 #include <cstdlib>  // free

--- a/vulkan/vulkan_enums.hpp
+++ b/vulkan/vulkan_enums.hpp
@@ -9,7 +9,7 @@
 #define VULKAN_ENUMS_HPP
 
 // include-what-you-use: make sure, vulkan.hpp is used by code-completers
-// IWYU pragma: private; include "vulkan.hpp"
+// IWYU pragma: private, include "vulkan/vulkan.hpp"
 
 #include <type_traits>  // for std::underlying_type
 

--- a/vulkan/vulkan_funcs.hpp
+++ b/vulkan/vulkan_funcs.hpp
@@ -9,7 +9,7 @@
 #define VULKAN_FUNCS_HPP
 
 // include-what-you-use: make sure, vulkan.hpp is used by code-completers
-// IWYU pragma: private; include "vulkan.hpp"
+// IWYU pragma: private, include "vulkan/vulkan.hpp"
 
 namespace VULKAN_HPP_NAMESPACE
 {

--- a/vulkan/vulkan_handles.hpp
+++ b/vulkan/vulkan_handles.hpp
@@ -9,7 +9,7 @@
 #define VULKAN_HANDLES_HPP
 
 // include-what-you-use: make sure, vulkan.hpp is used by code-completers
-// IWYU pragma: private; include "vulkan.hpp"
+// IWYU pragma: private, include "vulkan/vulkan.hpp"
 
 namespace VULKAN_HPP_NAMESPACE
 {


### PR DESCRIPTION
This builds on #1936 and #1939, correcting typos and file paths, as well as addressing false-positive unused include warnings.

As @rwols pointed out in [this comment](https://github.com/KhronosGroup/Vulkan-Hpp/pull/1939#discussion_r2346016464), the IWYU [private](https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-private) pragma uses a comma, not a semicolon. I have corrected this and also updated the paths from `"vulkan.hpp"` to `"vulkan/vulkan.hpp"`.

~In addition to this, I've added IWYU [export](https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-export) pragmas to `vulkan/vulkan.hpp` so that tools like clangd no longer incorrectly flag it as being unused.~

Edit: It appears the `export` pragmas are unnecessary after correcting the `private` typos. They have been removed.