### PR TITLE
Export ResultValue related functions

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -5449,6 +5449,8 @@ std::string VulkanHppGenerator::generateCppModuleUsings() const
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderStatic;
     using VULKAN_HPP_NAMESPACE::detail::getDispatchLoaderStatic;
 #endif /*VK_NO_PROTOTYPES*/
+    using VULKAN_HPP_NAMESPACE::detail::createResultValueType;
+    using VULKAN_HPP_NAMESPACE::detail::resultCheck;
   }
 )" };
 

--- a/vulkan/vulkan.cppm
+++ b/vulkan/vulkan.cppm
@@ -49,6 +49,8 @@ export namespace VULKAN_HPP_NAMESPACE
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderStatic;
     using VULKAN_HPP_NAMESPACE::detail::getDispatchLoaderStatic;
 #endif /*VK_NO_PROTOTYPES*/
+    using VULKAN_HPP_NAMESPACE::detail::createResultValueType;
+    using VULKAN_HPP_NAMESPACE::detail::resultCheck;
   }  // namespace detail
 
   using VULKAN_HPP_NAMESPACE::operator&;


### PR DESCRIPTION
Another request for [VMA-Hpp](https://github.com/YaaZ/VulkanMemoryAllocator-Hpp):
VMA functions return `VkResult` codes and VMA-Hpp wraps them the same way Vulkan-Hpp do.
Now we have to copy the implementation of `createResultValueType`, `resultCheck` and `throwResultException`, as it's not exported from the `.cppm`. Maintaining this copy manually is burdensome, as sometimes error codes get deprecated and removed, breaking compilation.
It would be really nice if VMA-Hpp could use these functions directly from Vulkan-Hpp, maybe it could be helpful in other use cases where people have to deal with result codes.

I essentially implemented [this suggestion](https://github.com/KhronosGroup/Vulkan-Hpp/pull/1931#issuecomment-2273060760) to export the symbols under `vk::detail` namespace.