### PR TITLE
Guard includes against VULKAN_HPP_STD_MODULE

### DIFF
--- a/snippets/EnumsHppTemplate.hpp
+++ b/snippets/EnumsHppTemplate.hpp
@@ -6,7 +6,9 @@ ${licenseHeader}
 // include-what-you-use: make sure, vulkan.hpp is used by code-completers
 // IWYU pragma: private; include "vulkan.hpp"
 
-#include <type_traits>    // for std::underlying_type
+#if !( defined( VULKAN_HPP_ENABLE_STD_MODULE ) && defined( VULKAN_HPP_STD_MODULE ) )
+#  include <type_traits>  // for std::underlying_type
+#endif
 
 namespace VULKAN_HPP_NAMESPACE
 {

--- a/snippets/StructsHppTemplate.hpp
+++ b/snippets/StructsHppTemplate.hpp
@@ -6,7 +6,9 @@ ${licenseHeader}
 // include-what-you-use: make sure, vulkan.hpp is used by code-completers
 // IWYU pragma: private; include "vulkan.hpp"
 
-#include <cstring>  // strcmp
+#if !( defined( VULKAN_HPP_ENABLE_STD_MODULE ) && defined( VULKAN_HPP_STD_MODULE ) )
+#  include <cstring>  // strcmp
+#endif
 
 namespace VULKAN_HPP_NAMESPACE
 {

--- a/vulkan/vulkan_enums.hpp
+++ b/vulkan/vulkan_enums.hpp
@@ -11,7 +11,9 @@
 // include-what-you-use: make sure, vulkan.hpp is used by code-completers
 // IWYU pragma: private; include "vulkan.hpp"
 
-#include <type_traits>  // for std::underlying_type
+#if !( defined( VULKAN_HPP_ENABLE_STD_MODULE ) && defined( VULKAN_HPP_STD_MODULE ) )
+#  include <type_traits>  // for std::underlying_type
+#endif
 
 namespace VULKAN_HPP_NAMESPACE
 {


### PR DESCRIPTION
C++20 module with `std` fails to compile for me on MSVC with errors like:
```
MSVC\14.43.34808\include\xtr1common(26): error C2953: 'std::integral_constant': class template has already been defined
```
I traced it to the `#include <type_traits>` in `vulkan_enums.hpp`.
`#include <cstring>` in `vulkan_structs.hpp` doesn't cause problems for me, but also worth fixing.