### PR TITLE
C++Module: Added redefinition guard for `VULKAN_HPP_ENABLE_STD_MODULE`

### DIFF
--- a/snippets/CppmTemplate.hpp
+++ b/snippets/CppmTemplate.hpp
@@ -6,7 +6,7 @@ ${licenseHeader}
 module;
 
 #include <version>
-#if defined( __cpp_lib_modules ) && !defined( VULKAN_HPP_NO_STD_MODULE )
+#if defined( __cpp_lib_modules ) && !defined( VULKAN_HPP_NO_STD_MODULE ) && !defined( VULKAN_HPP_ENABLE_STD_MODULE )
 #  define VULKAN_HPP_ENABLE_STD_MODULE
 #endif
 

--- a/vulkan/vulkan.cppm
+++ b/vulkan/vulkan.cppm
@@ -11,7 +11,7 @@
 module;
 
 #include <version>
-#if defined( __cpp_lib_modules ) && !defined( VULKAN_HPP_NO_STD_MODULE )
+#if defined( __cpp_lib_modules ) && !defined( VULKAN_HPP_NO_STD_MODULE ) && !defined( VULKAN_HPP_ENABLE_STD_MODULE )
 #  define VULKAN_HPP_ENABLE_STD_MODULE
 #endif
 


### PR DESCRIPTION
Simple check for whether `VULKAN_HPP_ENABLE_STD_MODULE` is already defined to prevent warnings about duplicate definitions. Should be kept until Clang fix their `__cpp_lib_modules` shenanigans, which requires manual definition of said macro.