### PR TITLE
#2299 Added default initializers to deprecated struct members

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -12265,7 +12265,7 @@ std::tuple<std::string, std::string, std::string, std::string>
         members += " : " + member.bitCount;  // except for bitfield members, where no default member initializatin
                                              // is supported (up to C++20)
       }
-      else if ( member.deprecated.empty() )
+      else
       {
         members += " = ";
         auto enumIt = m_enums.find( member.type.type );


### PR DESCRIPTION
Leaving deprecated members uninitialized leaves room for UB in the wrong scenarios.
This PR fixes that. Default initializers won't trigger deprecation warning, while also resolving warning about uninitialized members with designated initializers.