### PR TITLE
Fix structure usage in special command flavours of vkSetDebugUtilsObjectNameEXT and vkSetDebugUtilsObjectTagEXT

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -1681,8 +1681,11 @@ void VulkanHppGenerator::extendSpecialCommands( std::string const & name, bool d
     VULKAN_HPP_INLINE typename ResultValueType<void>::type Device::setDebugUtilsObjectNameEXT( HandleType const & handle, std::string const & name ) const
     {
       static_assert( VULKAN_HPP_NAMESPACE::isVulkanHandleType<HandleType>::value, "HandleType must be a Vulkan handle type" );
-      VULKAN_HPP_NAMESPACE::DebugUtilsObjectNameInfoEXT nameInfo(
-        handle.objectType, reinterpret_cast<uint64_t>( static_cast<typename HandleType::CType>( handle ) ), name.c_str() );
+      // It might be, that neither constructors, nor setters, nor designated initializers are available... need to explicitly set member by member
+      VULKAN_HPP_NAMESPACE::DebugUtilsObjectNameInfoEXT nameInfo;
+      nameInfo.objectType   = handle.objectType;
+      nameInfo.objectHandle = reinterpret_cast<uint64_t>( static_cast<typename HandleType::CType>( handle ) );
+      nameInfo.pObjectName  = name.c_str();
       return setDebugUtilsObjectNameEXT( nameInfo );
     }
 )" );
@@ -1712,8 +1715,11 @@ void VulkanHppGenerator::extendSpecialCommands( std::string const & name, bool d
                                           Device::setDebugUtilsObjectNameEXT( HandleType const & handle, std::string const & name, Dispatch const & d ) const
   {
     static_assert( VULKAN_HPP_NAMESPACE::isVulkanHandleType<HandleType>::value, "HandleType must be a Vulkan handle type" );
-    VULKAN_HPP_NAMESPACE::DebugUtilsObjectNameInfoEXT nameInfo(
-      handle.objectType, reinterpret_cast<uint64_t>( static_cast<typename HandleType::CType>( handle ) ), name.c_str() );
+    // It might be, that neither constructors, nor setters, nor designated initializers are available... need to explicitly set member by member
+    VULKAN_HPP_NAMESPACE::DebugUtilsObjectNameInfoEXT nameInfo;
+    nameInfo.objectType   = handle.objectType;
+    nameInfo.objectHandle = reinterpret_cast<uint64_t>( static_cast<typename HandleType::CType>( handle ) );
+    nameInfo.pObjectName  = name.c_str();
     return setDebugUtilsObjectNameEXT( nameInfo, d );
   }
 )" );
@@ -1744,8 +1750,13 @@ void VulkanHppGenerator::extendSpecialCommands( std::string const & name, bool d
       Device::setDebugUtilsObjectTagEXT( HandleType const & handle, uint64_t name, TagType const & tag ) const
     {
       static_assert( VULKAN_HPP_NAMESPACE::isVulkanHandleType<HandleType>::value, "HandleType must be a Vulkan handle type" );
-      VULKAN_HPP_NAMESPACE::DebugUtilsObjectTagInfoEXT tagInfo(
-        handle.objectType, reinterpret_cast<uint64_t>( static_cast<typename HandleType::CType>( handle ) ), name, sizeof( TagType ), &tag );
+      // It might be, that neither constructors, nor setters, nor designated initializers are available... need to explicitly set member by member
+      VULKAN_HPP_NAMESPACE::DebugUtilsObjectTagInfoEXT tagInfo;
+      tagInfo.objectType   = handle.objectType;
+      tagInfo.objectHandle = reinterpret_cast<uint64_t>( static_cast<typename HandleType::CType>( handle ) );
+      tagInfo.tagName      = name;
+      tagInfo.tagSize      = sizeof( TagType );
+      tagInfo.pTag         = &tag;
       return setDebugUtilsObjectTagEXT( tagInfo );
     }
 )" );
@@ -1775,8 +1786,13 @@ void VulkanHppGenerator::extendSpecialCommands( std::string const & name, bool d
     Device::setDebugUtilsObjectTagEXT( HandleType const & handle, uint64_t name, TagType const & tag, Dispatch const & d ) const
   {
     static_assert( VULKAN_HPP_NAMESPACE::isVulkanHandleType<HandleType>::value, "HandleType must be a Vulkan handle type" );
-    VULKAN_HPP_NAMESPACE::DebugUtilsObjectTagInfoEXT tagInfo(
-      handle.objectType, reinterpret_cast<uint64_t>( static_cast<typename HandleType::CType>( handle ) ), name, sizeof( TagType ), &tag );
+    // It might be, that neither constructors, nor setters, nor designated initializers are available... need to explicitly set member by member
+    VULKAN_HPP_NAMESPACE::DebugUtilsObjectTagInfoEXT tagInfo;
+    tagInfo.objectType   = handle.objectType;
+    tagInfo.objectHandle = reinterpret_cast<uint64_t>( static_cast<typename HandleType::CType>( handle ) );
+    tagInfo.tagName      = name;
+    tagInfo.tagSize      = sizeof( TagType );
+    tagInfo.pTag         = &tag;
     return setDebugUtilsObjectTagEXT( tagInfo, d );
   }
 )" );

--- a/vulkan/vulkan.cppm
+++ b/vulkan/vulkan.cppm
@@ -9365,7 +9365,8 @@ export namespace std
 #endif
 }  // namespace std
 
-export {
+export
+{
   // This VkFlags type is used as part of a bitfield in some structures.
   // As it can't be mimicked by vk-data types, we need to export just that.
   using ::VkGeometryInstanceFlagsKHR;

--- a/vulkan/vulkan_funcs.hpp
+++ b/vulkan/vulkan_funcs.hpp
@@ -15995,8 +15995,11 @@ namespace VULKAN_HPP_NAMESPACE
                                           Device::setDebugUtilsObjectNameEXT( HandleType const & handle, std::string const & name, Dispatch const & d ) const
   {
     static_assert( VULKAN_HPP_NAMESPACE::isVulkanHandleType<HandleType>::value, "HandleType must be a Vulkan handle type" );
-    VULKAN_HPP_NAMESPACE::DebugUtilsObjectNameInfoEXT nameInfo(
-      handle.objectType, reinterpret_cast<uint64_t>( static_cast<typename HandleType::CType>( handle ) ), name.c_str() );
+    // It might be, that neither constructors, nor setters, nor designated initializers are available... need to explicitly set member by member
+    VULKAN_HPP_NAMESPACE::DebugUtilsObjectNameInfoEXT nameInfo;
+    nameInfo.objectType   = handle.objectType;
+    nameInfo.objectHandle = reinterpret_cast<uint64_t>( static_cast<typename HandleType::CType>( handle ) );
+    nameInfo.pObjectName  = name.c_str();
     return setDebugUtilsObjectNameEXT( nameInfo, d );
   }
 #endif /* VULKAN_HPP_DISABLE_ENHANCED_MODE */
@@ -16034,8 +16037,13 @@ namespace VULKAN_HPP_NAMESPACE
     Device::setDebugUtilsObjectTagEXT( HandleType const & handle, uint64_t name, TagType const & tag, Dispatch const & d ) const
   {
     static_assert( VULKAN_HPP_NAMESPACE::isVulkanHandleType<HandleType>::value, "HandleType must be a Vulkan handle type" );
-    VULKAN_HPP_NAMESPACE::DebugUtilsObjectTagInfoEXT tagInfo(
-      handle.objectType, reinterpret_cast<uint64_t>( static_cast<typename HandleType::CType>( handle ) ), name, sizeof( TagType ), &tag );
+    // It might be, that neither constructors, nor setters, nor designated initializers are available... need to explicitly set member by member
+    VULKAN_HPP_NAMESPACE::DebugUtilsObjectTagInfoEXT tagInfo;
+    tagInfo.objectType   = handle.objectType;
+    tagInfo.objectHandle = reinterpret_cast<uint64_t>( static_cast<typename HandleType::CType>( handle ) );
+    tagInfo.tagName      = name;
+    tagInfo.tagSize      = sizeof( TagType );
+    tagInfo.pTag         = &tag;
     return setDebugUtilsObjectTagEXT( tagInfo, d );
   }
 #endif /* VULKAN_HPP_DISABLE_ENHANCED_MODE */

--- a/vulkan/vulkan_raii.hpp
+++ b/vulkan/vulkan_raii.hpp
@@ -21153,8 +21153,11 @@ namespace VULKAN_HPP_NAMESPACE
     VULKAN_HPP_INLINE typename ResultValueType<void>::type Device::setDebugUtilsObjectNameEXT( HandleType const & handle, std::string const & name ) const
     {
       static_assert( VULKAN_HPP_NAMESPACE::isVulkanHandleType<HandleType>::value, "HandleType must be a Vulkan handle type" );
-      VULKAN_HPP_NAMESPACE::DebugUtilsObjectNameInfoEXT nameInfo(
-        handle.objectType, reinterpret_cast<uint64_t>( static_cast<typename HandleType::CType>( handle ) ), name.c_str() );
+      // It might be, that neither constructors, nor setters, nor designated initializers are available... need to explicitly set member by member
+      VULKAN_HPP_NAMESPACE::DebugUtilsObjectNameInfoEXT nameInfo;
+      nameInfo.objectType   = handle.objectType;
+      nameInfo.objectHandle = reinterpret_cast<uint64_t>( static_cast<typename HandleType::CType>( handle ) );
+      nameInfo.pObjectName  = name.c_str();
       return setDebugUtilsObjectNameEXT( nameInfo );
     }
 
@@ -21177,8 +21180,13 @@ namespace VULKAN_HPP_NAMESPACE
       Device::setDebugUtilsObjectTagEXT( HandleType const & handle, uint64_t name, TagType const & tag ) const
     {
       static_assert( VULKAN_HPP_NAMESPACE::isVulkanHandleType<HandleType>::value, "HandleType must be a Vulkan handle type" );
-      VULKAN_HPP_NAMESPACE::DebugUtilsObjectTagInfoEXT tagInfo(
-        handle.objectType, reinterpret_cast<uint64_t>( static_cast<typename HandleType::CType>( handle ) ), name, sizeof( TagType ), &tag );
+      // It might be, that neither constructors, nor setters, nor designated initializers are available... need to explicitly set member by member
+      VULKAN_HPP_NAMESPACE::DebugUtilsObjectTagInfoEXT tagInfo;
+      tagInfo.objectType   = handle.objectType;
+      tagInfo.objectHandle = reinterpret_cast<uint64_t>( static_cast<typename HandleType::CType>( handle ) );
+      tagInfo.tagName      = name;
+      tagInfo.tagSize      = sizeof( TagType );
+      tagInfo.pTag         = &tag;
       return setDebugUtilsObjectTagEXT( tagInfo );
     }
 


### PR DESCRIPTION
Resolves #2345.