### PR TITLE
C++Module: Fix GCC error and replace `std.compat` with `std`

### DIFF
--- a/snippets/CppmTemplate.hpp
+++ b/snippets/CppmTemplate.hpp
@@ -24,7 +24,7 @@ module;
 #include <vulkan/${api}_shared.hpp>
 
 export module ${api}_hpp;
-export import std.compat;
+export import std;
 
 export namespace VULKAN_HPP_NAMESPACE
 {

--- a/snippets/includes.hpp
+++ b/snippets/includes.hpp
@@ -28,7 +28,7 @@
 #else
 #  include <cassert>
 #  include <cstring>
-import std.compat;
+import std;
 #endif
 
 #if VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL == 1

--- a/vulkan/vulkan.cppm
+++ b/vulkan/vulkan.cppm
@@ -29,7 +29,7 @@ VULKAN_HPP_COMPILE_WARNING( VULKAN_HPP_CXX_MODULE_EXPERIMENTAL_WARNING )
 #include <vulkan/vulkan_shared.hpp>
 
 export module vulkan_hpp;
-export import std.compat;
+export import std;
 
 export namespace VULKAN_HPP_NAMESPACE
 {

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -38,7 +38,7 @@
 #else
 #  include <cassert>
 #  include <cstring>
-import std.compat;
+import std;
 #endif
 
 #if VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL == 1


### PR DESCRIPTION
Resolves #2351.