### PR TITLE
Provide other constructors for ObjectDestroy and ObjectFree

### DIFF
--- a/snippets/ObjectDestroy.hpp
+++ b/snippets/ObjectDestroy.hpp
@@ -4,14 +4,34 @@ class ObjectDestroy
 public:
   ObjectDestroy() = default;
 
+// dispatcher parameter cannot be placed after allocationCallbacks when default dispatcher is disabled
+#if defined( VULKAN_HPP_NO_DEFAULT_DISPATCHER )
   ObjectDestroy( OwnerType                           owner,
-                 Optional<const AllocationCallbacks> allocationCallbacks = nullptr,
-                 Dispatch const & dispatch           VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) VULKAN_HPP_NOEXCEPT
+                  Dispatch const & dispatch ) VULKAN_HPP_NOEXCEPT
+    : m_owner( owner )
+    , m_allocationCallbacks( nullptr )
+    , m_dispatch( &dispatch )
+  {
+  }
+
+  ObjectDestroy( OwnerType                           owner,
+                  Optional<const AllocationCallbacks> allocationCallbacks,
+                  Dispatch const & dispatch ) VULKAN_HPP_NOEXCEPT
     : m_owner( owner )
     , m_allocationCallbacks( allocationCallbacks )
     , m_dispatch( &dispatch )
   {
   }
+#else
+  ObjectDestroy( OwnerType                           owner,
+                  Optional<const AllocationCallbacks> allocationCallbacks = nullptr,
+                  Dispatch const & dispatch           VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) VULKAN_HPP_NOEXCEPT
+    : m_owner( owner )
+    , m_allocationCallbacks( allocationCallbacks )
+    , m_dispatch( &dispatch )
+  {
+  }
+#endif // VULKAN_HPP_NO_DEFAULT_DISPATCHER
 
   OwnerType getOwner() const VULKAN_HPP_NOEXCEPT
   {

--- a/snippets/ObjectFree.hpp
+++ b/snippets/ObjectFree.hpp
@@ -4,6 +4,23 @@
   public:
     ObjectFree() = default;
 
+// dispatcher parameter cannot be placed after allocationCallbacks when default dispatcher is disabled
+#if defined( VULKAN_HPP_NO_DEFAULT_DISPATCHER )
+    ObjectFree( OwnerType                           owner,
+                  Dispatch const & dispatch ) VULKAN_HPP_NOEXCEPT
+        : m_owner( owner )
+        , m_allocationCallbacks( nullptr )
+        , m_dispatch( &dispatch )
+      {}
+
+    ObjectFree( OwnerType                           owner,
+                Optional<const AllocationCallbacks> allocationCallbacks = nullptr,
+                Dispatch const & dispatch ) VULKAN_HPP_NOEXCEPT
+      : m_owner( owner )
+      , m_allocationCallbacks( allocationCallbacks )
+      , m_dispatch( &dispatch )
+    {}
+#else
     ObjectFree( OwnerType                           owner,
                 Optional<const AllocationCallbacks> allocationCallbacks = nullptr,
                 Dispatch const & dispatch VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) VULKAN_HPP_NOEXCEPT
@@ -11,6 +28,7 @@
       , m_allocationCallbacks( allocationCallbacks )
       , m_dispatch( &dispatch )
     {}
+#endif // VULKAN_HPP_NO_DEFAULT_DISPATCHER
 
     OwnerType getOwner() const VULKAN_HPP_NOEXCEPT
     {

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -6631,6 +6631,22 @@ namespace VULKAN_HPP_NAMESPACE
     public:
       ObjectDestroy() = default;
 
+// dispatcher parameter cannot be placed after allocationCallbacks when default dispatcher is disabled
+#  if defined( VULKAN_HPP_NO_DEFAULT_DISPATCHER )
+      ObjectDestroy( OwnerType owner, Dispatch const & dispatch ) VULKAN_HPP_NOEXCEPT
+        : m_owner( owner )
+        , m_allocationCallbacks( nullptr )
+        , m_dispatch( &dispatch )
+      {
+      }
+
+      ObjectDestroy( OwnerType owner, Optional<const AllocationCallbacks> allocationCallbacks, Dispatch const & dispatch ) VULKAN_HPP_NOEXCEPT
+        : m_owner( owner )
+        , m_allocationCallbacks( allocationCallbacks )
+        , m_dispatch( &dispatch )
+      {
+      }
+#  else
       ObjectDestroy( OwnerType                           owner,
                      Optional<const AllocationCallbacks> allocationCallbacks = nullptr,
                      Dispatch const & dispatch           VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) VULKAN_HPP_NOEXCEPT
@@ -6639,6 +6655,7 @@ namespace VULKAN_HPP_NAMESPACE
         , m_dispatch( &dispatch )
       {
       }
+#  endif  // VULKAN_HPP_NO_DEFAULT_DISPATCHER
 
       OwnerType getOwner() const VULKAN_HPP_NOEXCEPT
       {
@@ -6713,6 +6730,22 @@ namespace VULKAN_HPP_NAMESPACE
     public:
       ObjectFree() = default;
 
+// dispatcher parameter cannot be placed after allocationCallbacks when default dispatcher is disabled
+#  if defined( VULKAN_HPP_NO_DEFAULT_DISPATCHER )
+      ObjectFree( OwnerType owner, Dispatch const & dispatch ) VULKAN_HPP_NOEXCEPT
+        : m_owner( owner )
+        , m_allocationCallbacks( nullptr )
+        , m_dispatch( &dispatch )
+      {
+      }
+
+      ObjectFree( OwnerType owner, Optional<const AllocationCallbacks> allocationCallbacks = nullptr, Dispatch const & dispatch ) VULKAN_HPP_NOEXCEPT
+        : m_owner( owner )
+        , m_allocationCallbacks( allocationCallbacks )
+        , m_dispatch( &dispatch )
+      {
+      }
+#  else
       ObjectFree( OwnerType                           owner,
                   Optional<const AllocationCallbacks> allocationCallbacks = nullptr,
                   Dispatch const & dispatch           VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) VULKAN_HPP_NOEXCEPT
@@ -6721,6 +6754,7 @@ namespace VULKAN_HPP_NAMESPACE
         , m_dispatch( &dispatch )
       {
       }
+#  endif  // VULKAN_HPP_NO_DEFAULT_DISPATCHER
 
       OwnerType getOwner() const VULKAN_HPP_NOEXCEPT
       {


### PR DESCRIPTION
Resolves #2354.

When `VULKAN_HPP_NO_DEFAULT_DISPATCHER` is used, both `ObjectDestroy` and `ObjectFree` will not have valid constructors, as the optional parameters always need to come last:

https://github.com/KhronosGroup/Vulkan-Hpp/blob/9423ad7f699c17740b79e63c083502fb6deddb84/vulkan/vulkan.hpp#L6634-L6642

A simple solution is to provide a set of two constructors each, which use overloads to make `allocationCallbacks` optional, even when `dispatcher` isn't. These will only be active while `VULKAN_HPP_NO_DEFAULT_DISPATCHER` is used.

I used `#if` for conditional compilation, in fear of breaking something otherwise. It _should_ however be fine to _only_ provide the two new constructors, so please let me know if that is preferred.