### PR TITLE
Export vk::raii::isVulkanRAIIHandleType

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -5701,6 +5701,7 @@ std::string VulkanHppGenerator::generateCppModuleRaiiUsings() const
     //======================
 
     using VULKAN_HPP_RAII_NAMESPACE::Context;
+    using VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType;
     namespace detail
     {
       using VULKAN_HPP_RAII_NAMESPACE::detail::ContextDispatcher;

--- a/vulkan/vulkan.cppm
+++ b/vulkan/vulkan.cppm
@@ -5737,6 +5737,7 @@ export namespace VULKAN_HPP_NAMESPACE
     //======================
 
     using VULKAN_HPP_RAII_NAMESPACE::Context;
+    using VULKAN_HPP_RAII_NAMESPACE::isVulkanRAIIHandleType;
 
     namespace detail
     {


### PR DESCRIPTION
`vk::isVulkanHandleType` is exported, but `vk::raii::isVulkanRAIIHandleType` is not