### PR TITLE
Fix typo leading to module compilation error

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -5480,8 +5480,8 @@ std::string VulkanHppGenerator::generateCppModuleUsings() const
     using VULKAN_HPP_NAMESPACE::detail::getDispatchLoaderStatic;
 #endif /*VK_NO_PROTOTYPES*/
     using VULKAN_HPP_NAMESPACE::detail::createResultValueType;
+    using VULKAN_HPP_NAMESPACE::detail::isDispatchLoader;
     using VULKAN_HPP_NAMESPACE::detail::resultCheck;
-    using VULKAN_HPP_NAMESAPCE::detail::isDispatchLoader;
   }
 #if !defined( VULKAN_HPP_DISABLE_ENHANCED_MODE )
   namespace VULKAN_HPP_RAII_NAMESPACE

--- a/vulkan/vulkan.cppm
+++ b/vulkan/vulkan.cppm
@@ -52,8 +52,8 @@ export namespace VULKAN_HPP_NAMESPACE
     using VULKAN_HPP_NAMESPACE::detail::DispatchLoaderStatic;
     using VULKAN_HPP_NAMESPACE::detail::getDispatchLoaderStatic;
 #endif /*VK_NO_PROTOTYPES*/
-    using VULKAN_HPP_NAMESAPCE::detail::isDispatchLoader;
     using VULKAN_HPP_NAMESPACE::detail::createResultValueType;
+    using VULKAN_HPP_NAMESPACE::detail::isDispatchLoader;
     using VULKAN_HPP_NAMESPACE::detail::resultCheck;
   }  // namespace detail
 #if !defined( VULKAN_HPP_DISABLE_ENHANCED_MODE )


### PR DESCRIPTION
This typo breaks module compilation.
Unfortunately, it already got into Vulkan-Headers 1.4.333.
If you are interested, take a look at the [CI I set up](https://github.com/YaaZ/VulkanMemoryAllocator-Hpp/actions/runs/19361567816/job/55394558090?pr=66) to test the modules - it works with MSVC on Windows and LLVM/Clang+libc on Linux & macOS.