### PR TITLE
Fix `vulkan:video` module by correctly removing suffix

### DIFF
--- a/snippets/VideoCppmTemplate.hpp
+++ b/snippets/VideoCppmTemplate.hpp
@@ -17,7 +17,7 @@ module;
 
 #include <vulkan/vulkan_video.hpp>
 
-export module vulkan_hpp:video;
+export module vulkan:video;
 
 export namespace VULKAN_HPP_NAMESPACE::VULKAN_HPP_VIDEO_NAMESPACE
 {

--- a/vulkan/vulkan_video.cppm
+++ b/vulkan/vulkan_video.cppm
@@ -21,7 +21,7 @@ VULKAN_HPP_COMPILE_WARNING( VULKAN_HPP_CXX_MODULE_EXPERIMENTAL_WARNING )
 
 #include <vulkan/vulkan_video.hpp>
 
-export module vulkan_hpp:video;
+export module vulkan:video;
 
 export namespace VULKAN_HPP_NAMESPACE::VULKAN_HPP_VIDEO_NAMESPACE
 {


### PR DESCRIPTION
Corrects a bug in #2373.