### PR TITLE
BugFix: destroy potentially generated pipeline handles on partial creation failure

### DIFF
--- a/VulkanHppGenerator.hpp
+++ b/VulkanHppGenerator.hpp
@@ -1052,6 +1052,7 @@ private:
                                    std::string const & classSeparator,
                                    std::string         commandName,
                                    bool                enumerating,
+                                   bool                isMultiPipelineCreation,
                                    bool                raii ) const;
   std::string generateResultExceptions() const;
   std::string generateReturnDataType( std::map<size_t, VectorParamData> const & vectorParams,

--- a/snippets/resultChecks.hpp
+++ b/snippets/resultChecks.hpp
@@ -29,4 +29,34 @@
       }
 #endif
     }
+
+    template <typename HandleType, typename AllocatorType, typename Dispatch>
+    VULKAN_HPP_INLINE void resultCheck( Result                                         result,
+                                        char const *                                   message,
+                                        std::initializer_list<Result>                  successCodes,
+                                        VkDevice                                       device,
+                                        std::vector<HandleType, AllocatorType> const & pipelines,
+                                        AllocationCallbacks const *                    pAllocator,
+                                        Dispatch const &                               d )
+    {
+#ifdef VULKAN_HPP_NO_EXCEPTIONS
+      ignore( result );  		// just in case VULKAN_HPP_ASSERT_ON_RESULT is empty
+      ignore( message );
+      ignore( successCodes );	// just in case VULKAN_HPP_ASSERT_ON_RESULT is empty
+      ignore( device );
+      ignore( pipelines );
+      ignore( pAllocator );
+      ignore( d );
+      VULKAN_HPP_ASSERT_ON_RESULT( std::find( successCodes.begin(), successCodes.end(), result ) != successCodes.end() );
+#else
+      if ( std::find( successCodes.begin(), successCodes.end(), result ) == successCodes.end() )
+      {
+        for ( HandleType pipeline : pipelines )
+        {
+          d.vkDestroyPipeline( device, static_cast<VkPipeline>( pipeline ), reinterpret_cast<VkAllocationCallbacks const*>( pAllocator ) );
+        }
+        throwResultException( result, message );
+      }
+#endif
+    }
   }  // namespace detail

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -7596,6 +7596,36 @@ namespace VULKAN_HPP_NAMESPACE
       }
 #endif
     }
+
+    template <typename HandleType, typename AllocatorType, typename Dispatch>
+    VULKAN_HPP_INLINE void resultCheck( Result                                         result,
+                                        char const *                                   message,
+                                        std::initializer_list<Result>                  successCodes,
+                                        VkDevice                                       device,
+                                        std::vector<HandleType, AllocatorType> const & pipelines,
+                                        AllocationCallbacks const *                    pAllocator,
+                                        Dispatch const &                               d )
+    {
+#ifdef VULKAN_HPP_NO_EXCEPTIONS
+      ignore( result );  // just in case VULKAN_HPP_ASSERT_ON_RESULT is empty
+      ignore( message );
+      ignore( successCodes );  // just in case VULKAN_HPP_ASSERT_ON_RESULT is empty
+      ignore( device );
+      ignore( pipelines );
+      ignore( pAllocator );
+      ignore( d );
+      VULKAN_HPP_ASSERT_ON_RESULT( std::find( successCodes.begin(), successCodes.end(), result ) != successCodes.end() );
+#else
+      if ( std::find( successCodes.begin(), successCodes.end(), result ) == successCodes.end() )
+      {
+        for ( HandleType pipeline : pipelines )
+        {
+          d.vkDestroyPipeline( device, static_cast<VkPipeline>( pipeline ), reinterpret_cast<VkAllocationCallbacks const *>( pAllocator ) );
+        }
+        throwResultException( result, message );
+      }
+#endif
+    }
   }  // namespace detail
 
   //===========================

--- a/vulkan/vulkan_funcs.hpp
+++ b/vulkan/vulkan_funcs.hpp
@@ -3768,7 +3768,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                      reinterpret_cast<const VkComputePipelineCreateInfo *>( createInfos.data() ),
                                                                      reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                      reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck( result, VULKAN_HPP_NAMESPACE_STRING "::Device::createComputePipelines", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createComputePipelines",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
 
     return ResultValue<std::vector<Pipeline, PipelineAllocator>>( result, std::move( pipelines ) );
   }
@@ -3797,7 +3803,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                      reinterpret_cast<const VkComputePipelineCreateInfo *>( createInfos.data() ),
                                                                      reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                      reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck( result, VULKAN_HPP_NAMESPACE_STRING "::Device::createComputePipelines", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createComputePipelines",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
 
     return ResultValue<std::vector<Pipeline, PipelineAllocator>>( result, std::move( pipelines ) );
   }
@@ -3850,8 +3862,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                      reinterpret_cast<const VkComputePipelineCreateInfo *>( createInfos.data() ),
                                                                      reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                      reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck(
-      result, VULKAN_HPP_NAMESPACE_STRING "::Device::createComputePipelinesUnique", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createComputePipelinesUnique",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
     std::vector<UniqueHandle<Pipeline, Dispatch>, PipelineAllocator> uniquePipelines;
     uniquePipelines.reserve( createInfos.size() );
     detail::ObjectDestroy<Device, Dispatch> deleter( *this, allocator, d );
@@ -3886,8 +3903,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                      reinterpret_cast<const VkComputePipelineCreateInfo *>( createInfos.data() ),
                                                                      reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                      reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck(
-      result, VULKAN_HPP_NAMESPACE_STRING "::Device::createComputePipelinesUnique", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createComputePipelinesUnique",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
     std::vector<UniqueHandle<Pipeline, Dispatch>, PipelineAllocator> uniquePipelines( pipelineAllocator );
     uniquePipelines.reserve( createInfos.size() );
     detail::ObjectDestroy<Device, Dispatch> deleter( *this, allocator, d );
@@ -4920,7 +4942,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                       reinterpret_cast<const VkGraphicsPipelineCreateInfo *>( createInfos.data() ),
                                                                       reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                       reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck( result, VULKAN_HPP_NAMESPACE_STRING "::Device::createGraphicsPipelines", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createGraphicsPipelines",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
 
     return ResultValue<std::vector<Pipeline, PipelineAllocator>>( result, std::move( pipelines ) );
   }
@@ -4949,7 +4977,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                       reinterpret_cast<const VkGraphicsPipelineCreateInfo *>( createInfos.data() ),
                                                                       reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                       reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck( result, VULKAN_HPP_NAMESPACE_STRING "::Device::createGraphicsPipelines", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createGraphicsPipelines",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
 
     return ResultValue<std::vector<Pipeline, PipelineAllocator>>( result, std::move( pipelines ) );
   }
@@ -5002,8 +5036,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                       reinterpret_cast<const VkGraphicsPipelineCreateInfo *>( createInfos.data() ),
                                                                       reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                       reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck(
-      result, VULKAN_HPP_NAMESPACE_STRING "::Device::createGraphicsPipelinesUnique", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createGraphicsPipelinesUnique",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
     std::vector<UniqueHandle<Pipeline, Dispatch>, PipelineAllocator> uniquePipelines;
     uniquePipelines.reserve( createInfos.size() );
     detail::ObjectDestroy<Device, Dispatch> deleter( *this, allocator, d );
@@ -5038,8 +5077,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                       reinterpret_cast<const VkGraphicsPipelineCreateInfo *>( createInfos.data() ),
                                                                       reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                       reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck(
-      result, VULKAN_HPP_NAMESPACE_STRING "::Device::createGraphicsPipelinesUnique", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createGraphicsPipelinesUnique",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
     std::vector<UniqueHandle<Pipeline, Dispatch>, PipelineAllocator> uniquePipelines( pipelineAllocator );
     uniquePipelines.reserve( createInfos.size() );
     detail::ObjectDestroy<Device, Dispatch> deleter( *this, allocator, d );
@@ -16566,8 +16610,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                   reinterpret_cast<const VkExecutionGraphPipelineCreateInfoAMDX *>( createInfos.data() ),
                                                                   reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                   reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck(
-      result, VULKAN_HPP_NAMESPACE_STRING "::Device::createExecutionGraphPipelinesAMDX", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createExecutionGraphPipelinesAMDX",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
 
     return ResultValue<std::vector<Pipeline, PipelineAllocator>>( result, std::move( pipelines ) );
   }
@@ -16598,8 +16647,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                   reinterpret_cast<const VkExecutionGraphPipelineCreateInfoAMDX *>( createInfos.data() ),
                                                                   reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                   reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck(
-      result, VULKAN_HPP_NAMESPACE_STRING "::Device::createExecutionGraphPipelinesAMDX", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createExecutionGraphPipelinesAMDX",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
 
     return ResultValue<std::vector<Pipeline, PipelineAllocator>>( result, std::move( pipelines ) );
   }
@@ -16657,8 +16711,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                   reinterpret_cast<const VkExecutionGraphPipelineCreateInfoAMDX *>( createInfos.data() ),
                                                                   reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                   reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck(
-      result, VULKAN_HPP_NAMESPACE_STRING "::Device::createExecutionGraphPipelinesAMDXUnique", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createExecutionGraphPipelinesAMDXUnique",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
     std::vector<UniqueHandle<Pipeline, Dispatch>, PipelineAllocator> uniquePipelines;
     uniquePipelines.reserve( createInfos.size() );
     detail::ObjectDestroy<Device, Dispatch> deleter( *this, allocator, d );
@@ -16695,8 +16754,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                   reinterpret_cast<const VkExecutionGraphPipelineCreateInfoAMDX *>( createInfos.data() ),
                                                                   reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                   reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck(
-      result, VULKAN_HPP_NAMESPACE_STRING "::Device::createExecutionGraphPipelinesAMDXUnique", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createExecutionGraphPipelinesAMDXUnique",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
     std::vector<UniqueHandle<Pipeline, Dispatch>, PipelineAllocator> uniquePipelines( pipelineAllocator );
     uniquePipelines.reserve( createInfos.size() );
     detail::ObjectDestroy<Device, Dispatch> deleter( *this, allocator, d );
@@ -17993,7 +18057,11 @@ namespace VULKAN_HPP_NAMESPACE
                                                                            reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
     detail::resultCheck( result,
                          VULKAN_HPP_NAMESPACE_STRING "::Device::createRayTracingPipelinesKHR",
-                         { Result::eSuccess, Result::eOperationDeferredKHR, Result::eOperationNotDeferredKHR, Result::ePipelineCompileRequiredEXT } );
+                         { Result::eSuccess, Result::eOperationDeferredKHR, Result::eOperationNotDeferredKHR, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
 
     return ResultValue<std::vector<Pipeline, PipelineAllocator>>( result, std::move( pipelines ) );
   }
@@ -18027,7 +18095,11 @@ namespace VULKAN_HPP_NAMESPACE
                                                                            reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
     detail::resultCheck( result,
                          VULKAN_HPP_NAMESPACE_STRING "::Device::createRayTracingPipelinesKHR",
-                         { Result::eSuccess, Result::eOperationDeferredKHR, Result::eOperationNotDeferredKHR, Result::ePipelineCompileRequiredEXT } );
+                         { Result::eSuccess, Result::eOperationDeferredKHR, Result::eOperationNotDeferredKHR, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
 
     return ResultValue<std::vector<Pipeline, PipelineAllocator>>( result, std::move( pipelines ) );
   }
@@ -18090,7 +18162,11 @@ namespace VULKAN_HPP_NAMESPACE
                                                                            reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
     detail::resultCheck( result,
                          VULKAN_HPP_NAMESPACE_STRING "::Device::createRayTracingPipelinesKHRUnique",
-                         { Result::eSuccess, Result::eOperationDeferredKHR, Result::eOperationNotDeferredKHR, Result::ePipelineCompileRequiredEXT } );
+                         { Result::eSuccess, Result::eOperationDeferredKHR, Result::eOperationNotDeferredKHR, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
     std::vector<UniqueHandle<Pipeline, Dispatch>, PipelineAllocator> uniquePipelines;
     uniquePipelines.reserve( createInfos.size() );
     detail::ObjectDestroy<Device, Dispatch> deleter( *this, allocator, d );
@@ -18130,7 +18206,11 @@ namespace VULKAN_HPP_NAMESPACE
                                                                            reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
     detail::resultCheck( result,
                          VULKAN_HPP_NAMESPACE_STRING "::Device::createRayTracingPipelinesKHRUnique",
-                         { Result::eSuccess, Result::eOperationDeferredKHR, Result::eOperationNotDeferredKHR, Result::ePipelineCompileRequiredEXT } );
+                         { Result::eSuccess, Result::eOperationDeferredKHR, Result::eOperationNotDeferredKHR, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
     std::vector<UniqueHandle<Pipeline, Dispatch>, PipelineAllocator> uniquePipelines( pipelineAllocator );
     uniquePipelines.reserve( createInfos.size() );
     detail::ObjectDestroy<Device, Dispatch> deleter( *this, allocator, d );
@@ -19225,8 +19305,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                           reinterpret_cast<const VkRayTracingPipelineCreateInfoNV *>( createInfos.data() ),
                                                                           reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                           reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck(
-      result, VULKAN_HPP_NAMESPACE_STRING "::Device::createRayTracingPipelinesNV", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createRayTracingPipelinesNV",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
 
     return ResultValue<std::vector<Pipeline, PipelineAllocator>>( result, std::move( pipelines ) );
   }
@@ -19256,8 +19341,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                           reinterpret_cast<const VkRayTracingPipelineCreateInfoNV *>( createInfos.data() ),
                                                                           reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                           reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck(
-      result, VULKAN_HPP_NAMESPACE_STRING "::Device::createRayTracingPipelinesNV", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createRayTracingPipelinesNV",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
 
     return ResultValue<std::vector<Pipeline, PipelineAllocator>>( result, std::move( pipelines ) );
   }
@@ -19313,8 +19403,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                           reinterpret_cast<const VkRayTracingPipelineCreateInfoNV *>( createInfos.data() ),
                                                                           reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                           reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck(
-      result, VULKAN_HPP_NAMESPACE_STRING "::Device::createRayTracingPipelinesNVUnique", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createRayTracingPipelinesNVUnique",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
     std::vector<UniqueHandle<Pipeline, Dispatch>, PipelineAllocator> uniquePipelines;
     uniquePipelines.reserve( createInfos.size() );
     detail::ObjectDestroy<Device, Dispatch> deleter( *this, allocator, d );
@@ -19350,8 +19445,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                           reinterpret_cast<const VkRayTracingPipelineCreateInfoNV *>( createInfos.data() ),
                                                                           reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                           reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck(
-      result, VULKAN_HPP_NAMESPACE_STRING "::Device::createRayTracingPipelinesNVUnique", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createRayTracingPipelinesNVUnique",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
     std::vector<UniqueHandle<Pipeline, Dispatch>, PipelineAllocator> uniquePipelines( pipelineAllocator );
     uniquePipelines.reserve( createInfos.size() );
     detail::ObjectDestroy<Device, Dispatch> deleter( *this, allocator, d );
@@ -29628,8 +29728,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                           reinterpret_cast<const VkDataGraphPipelineCreateInfoARM *>( createInfos.data() ),
                                                                           reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                           reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck(
-      result, VULKAN_HPP_NAMESPACE_STRING "::Device::createDataGraphPipelinesARM", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createDataGraphPipelinesARM",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
 
     return ResultValue<std::vector<Pipeline, PipelineAllocator>>( result, std::move( pipelines ) );
   }
@@ -29661,8 +29766,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                           reinterpret_cast<const VkDataGraphPipelineCreateInfoARM *>( createInfos.data() ),
                                                                           reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                           reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck(
-      result, VULKAN_HPP_NAMESPACE_STRING "::Device::createDataGraphPipelinesARM", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createDataGraphPipelinesARM",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
 
     return ResultValue<std::vector<Pipeline, PipelineAllocator>>( result, std::move( pipelines ) );
   }
@@ -29722,8 +29832,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                           reinterpret_cast<const VkDataGraphPipelineCreateInfoARM *>( createInfos.data() ),
                                                                           reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                           reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck(
-      result, VULKAN_HPP_NAMESPACE_STRING "::Device::createDataGraphPipelinesARMUnique", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createDataGraphPipelinesARMUnique",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
     std::vector<UniqueHandle<Pipeline, Dispatch>, PipelineAllocator> uniquePipelines;
     uniquePipelines.reserve( createInfos.size() );
     detail::ObjectDestroy<Device, Dispatch> deleter( *this, allocator, d );
@@ -29761,8 +29876,13 @@ namespace VULKAN_HPP_NAMESPACE
                                                                           reinterpret_cast<const VkDataGraphPipelineCreateInfoARM *>( createInfos.data() ),
                                                                           reinterpret_cast<const VkAllocationCallbacks *>( allocator.get() ),
                                                                           reinterpret_cast<VkPipeline *>( pipelines.data() ) ) );
-    detail::resultCheck(
-      result, VULKAN_HPP_NAMESPACE_STRING "::Device::createDataGraphPipelinesARMUnique", { Result::eSuccess, Result::ePipelineCompileRequiredEXT } );
+    detail::resultCheck( result,
+                         VULKAN_HPP_NAMESPACE_STRING "::Device::createDataGraphPipelinesARMUnique",
+                         { Result::eSuccess, Result::ePipelineCompileRequiredEXT },
+                         m_device,
+                         pipelines,
+                         allocator.get(),
+                         d );
     std::vector<UniqueHandle<Pipeline, Dispatch>, PipelineAllocator> uniquePipelines( pipelineAllocator );
     uniquePipelines.reserve( createInfos.size() );
     detail::ObjectDestroy<Device, Dispatch> deleter( *this, allocator, d );


### PR DESCRIPTION
Resolves #2367.