### PR TITLE
Fix VULKAN_HPP_NO_SMART_HANDLE compilation

### DIFF
--- a/snippets/HppTemplate.hpp
+++ b/snippets/HppTemplate.hpp
@@ -28,8 +28,9 @@ namespace VULKAN_HPP_NAMESPACE
   }
   ${Exchange}
 
-#if !defined( VULKAN_HPP_NO_SMART_HANDLE )
   struct AllocationCallbacks;
+
+#if !defined( VULKAN_HPP_NO_SMART_HANDLE )
 
   namespace detail
   {

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -6689,8 +6689,9 @@ namespace VULKAN_HPP_NAMESPACE
   }
 #endif
 
-#if !defined( VULKAN_HPP_NO_SMART_HANDLE )
   struct AllocationCallbacks;
+
+#if !defined( VULKAN_HPP_NO_SMART_HANDLE )
 
   namespace detail
   {


### PR DESCRIPTION
Forward declaration of `AllocationCallbacks` is guarded by `VULKAN_HPP_NO_SMART_HANDLE`, while being used uncoditionally in `resultCheck`. This breaks compilation when `VULKAN_HPP_NO_SMART_HANDLE` is defined.

Note that it's not enough to add `VULKAN_HPP_NO_SMART_HANDLE` to a sample to reproduce this, because the PCH used does not define this. You need to either disable the PCH, or compile PCH with that definition.