### PR TITLE
Include <cstdlib> on macos for getenv

### DIFF
--- a/snippets/DynamicLoader.hpp
+++ b/snippets/DynamicLoader.hpp
@@ -30,7 +30,7 @@
         }
 		// modern versions of macOS don't search /usr/local/lib automatically contrary to what man dlopen says
 		// Vulkan SDK uses this as the system-wide installation location, so we're going to fallback to this if all else fails
-		if ( !m_library && ( getenv("DYLD_FALLBACK_LIBRARY_PATH") == NULL ) )
+		if ( !m_library && ( std::getenv("DYLD_FALLBACK_LIBRARY_PATH") == NULL ) )
 		{
 		  m_library = dlopen( "/usr/local/lib/libvulkan.dylib", RTLD_NOW | RTLD_LOCAL );
 		}

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -20966,7 +20966,7 @@ namespace VULKAN_HPP_NAMESPACE
           }
           // modern versions of macOS don't search /usr/local/lib automatically contrary to what man dlopen says
           // Vulkan SDK uses this as the system-wide installation location, so we're going to fallback to this if all else fails
-          if ( !m_library && ( getenv( "DYLD_FALLBACK_LIBRARY_PATH" ) == NULL ) )
+          if ( !m_library && ( std::getenv( "DYLD_FALLBACK_LIBRARY_PATH" ) == NULL ) )
           {
             m_library = dlopen( "/usr/local/lib/libvulkan.dylib", RTLD_NOW | RTLD_LOCAL );
           }


### PR DESCRIPTION
Building vulkan.cppm on macOS fails after <cstdlib> was removed from vulkan.hpp in #2344 since the macOS version calls getenv to read the DYLD_LIBRARY_PATH environment variable.