### PR TITLE
Make the move constructor of vk::raii::PluralTypes from a std::vector<vk::raii::SingularType> public.

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -9525,7 +9525,6 @@ ${enter}  class ${handleType}s : public std::vector<${handleType}>
     ${handleType}s & operator=( ${handleType}s const & ) = delete;
     ${handleType}s & operator=( ${handleType}s && rhs ) = default;
 
-  private:
     ${handleType}s( std::vector<${handleType}> && rhs )
     {
       std::swap( *this, rhs );

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,7 +41,7 @@ vulkan_hpp__setup_test( NAME Handles )
 vulkan_hpp__setup_test( NAME HandlesMoveExchange )
 vulkan_hpp__setup_test( NAME Hash )
 vulkan_hpp__setup_test( NAME NoDefaultDispatcher )
-if( ( CMAKE_CXX_STANDARD GREATER_EQUAL 23 ) AND NOT ( ( CMAKE_CXX_COMPILER_ID STREQUAL "Clang" ) AND ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15.0 ) ) )
+if( NOT ( ( CMAKE_CXX_COMPILER_ID STREQUAL "Clang" ) AND ( CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15.0 ) ) )
 	vulkan_hpp__setup_test( NAME NoExceptionsRAII ) # errors with clang++13 and clang++14
 endif()
 vulkan_hpp__setup_test( NAME NoSmartHandle )

--- a/tests/NoExceptionsRAII/NoExceptionsRAII.cpp
+++ b/tests/NoExceptionsRAII/NoExceptionsRAII.cpp
@@ -16,18 +16,17 @@
 //                     Compile test with VULKAN_HPP_NO_EXCEPTIONS set and using raii-classes
 //                     Note: this is _no_ functional test!! Don't ever code this way!!
 
-
 #ifdef VULKAN_HPP_USE_CXX_MODULE
-#  include <cstdint>
 #  include <cassert>
+#  include <cstdint>
 import vulkan;
 #else
-#  include <vector>
-#  include <cstdint>
-#  include <algorithm>
 #  include "vulkan/vulkan_raii.hpp"
-#endif
 
+#  include <algorithm>
+#  include <cstdint>
+#  include <vector>
+#endif
 
 static char const * AppName    = "NoExceptions";
 static char const * EngineName = "Vulkan.hpp";
@@ -66,11 +65,29 @@ int main( int /*argc*/, char ** /*argv*/ )
   auto commandPool = device->createCommandPool( vk::CommandPoolCreateInfo( vk::CommandPoolCreateFlags(), deviceQueueCreateInfo.queueFamilyIndex ) );
   assert( commandPool.has_value() );
 
-  // allocate a CommandBuffer from the CommandPool
-  auto commandBuffers = device->allocateCommandBuffers( vk::CommandBufferAllocateInfo( *commandPool, vk::CommandBufferLevel::ePrimary, 1 ) );
-  assert( commandBuffers.has_value() );
+  {
+    // allocate a CommandBuffer from the CommandPool
+    auto commandBuffers = device->allocateCommandBuffers( vk::CommandBufferAllocateInfo( *commandPool, vk::CommandBufferLevel::ePrimary, 1 ) );
+    assert( commandBuffers.has_value() );
 
-  auto commandBuffer = std::move( commandBuffers.value[0] );
+    auto commandBuffer = std::move( commandBuffers.value[0] );
+  }
+
+  {
+    // allocate 10 CommandBuffers from the CommandPool and move them into a std::vector<vk::raii::CommandBuffer>
+    auto rv = device->allocateCommandBuffers( vk::CommandBufferAllocateInfo( *commandPool, vk::CommandBufferLevel::ePrimary, 10 ) );
+    assert( rv.has_value() );
+    std::vector<vk::raii::CommandBuffer> commandBuffers;
+    commandBuffers = std::move( rv.value );
+  }
+
+  {
+    // allocate 10 CommandBuffers from the CommandPool and move them into a vk::raii::CommandBuffers
+    auto rv = device->allocateCommandBuffers( vk::CommandBufferAllocateInfo( *commandPool, vk::CommandBufferLevel::ePrimary, 10 ) );
+    assert( rv.has_value() );
+    vk::raii::CommandBuffers commandBuffers = nullptr;
+    commandBuffers                          = std::move( rv.value );
+  }
 #endif
 
   return 0;

--- a/vulkan/vulkan_raii.hpp
+++ b/vulkan/vulkan_raii.hpp
@@ -4190,7 +4190,6 @@ namespace VULKAN_HPP_NAMESPACE
       PhysicalDevices & operator=( PhysicalDevices const & ) = delete;
       PhysicalDevices & operator=( PhysicalDevices && rhs )  = default;
 
-    private:
       PhysicalDevices( std::vector<PhysicalDevice> && rhs )
       {
         std::swap( *this, rhs );
@@ -8064,7 +8063,6 @@ namespace VULKAN_HPP_NAMESPACE
       CommandBuffers & operator=( CommandBuffers const & ) = delete;
       CommandBuffers & operator=( CommandBuffers && rhs )  = default;
 
-    private:
       CommandBuffers( std::vector<CommandBuffer> && rhs )
       {
         std::swap( *this, rhs );
@@ -9403,7 +9401,6 @@ namespace VULKAN_HPP_NAMESPACE
       DescriptorSets & operator=( DescriptorSets const & ) = delete;
       DescriptorSets & operator=( DescriptorSets && rhs )  = default;
 
-    private:
       DescriptorSets( std::vector<DescriptorSet> && rhs )
       {
         std::swap( *this, rhs );
@@ -10011,7 +10008,6 @@ namespace VULKAN_HPP_NAMESPACE
       DisplayKHRs & operator=( DisplayKHRs const & ) = delete;
       DisplayKHRs & operator=( DisplayKHRs && rhs )  = default;
 
-    private:
       DisplayKHRs( std::vector<DisplayKHR> && rhs )
       {
         std::swap( *this, rhs );
@@ -12254,7 +12250,6 @@ namespace VULKAN_HPP_NAMESPACE
       Pipelines & operator=( Pipelines const & ) = delete;
       Pipelines & operator=( Pipelines && rhs )  = default;
 
-    private:
       Pipelines( std::vector<Pipeline> && rhs )
       {
         std::swap( *this, rhs );
@@ -12414,7 +12409,6 @@ namespace VULKAN_HPP_NAMESPACE
       PipelineBinaryKHRs & operator=( PipelineBinaryKHRs const & ) = delete;
       PipelineBinaryKHRs & operator=( PipelineBinaryKHRs && rhs )  = default;
 
-    private:
       PipelineBinaryKHRs( std::vector<PipelineBinaryKHR> && rhs )
       {
         std::swap( *this, rhs );
@@ -13692,7 +13686,6 @@ namespace VULKAN_HPP_NAMESPACE
       ShaderEXTs & operator=( ShaderEXTs const & ) = delete;
       ShaderEXTs & operator=( ShaderEXTs && rhs )  = default;
 
-    private:
       ShaderEXTs( std::vector<ShaderEXT> && rhs )
       {
         std::swap( *this, rhs );
@@ -14332,7 +14325,6 @@ namespace VULKAN_HPP_NAMESPACE
       SwapchainKHRs & operator=( SwapchainKHRs const & ) = delete;
       SwapchainKHRs & operator=( SwapchainKHRs && rhs )  = default;
 
-    private:
       SwapchainKHRs( std::vector<SwapchainKHR> && rhs )
       {
         std::swap( *this, rhs );


### PR DESCRIPTION
Resolves #2413.