### PR TITLE
CI: Added workflow to build against latest spec from Vulkan-Docs

### DIFF
--- a/.github/workflows/build-latest-spec.yml
+++ b/.github/workflows/build-latest-spec.yml
@@ -1,0 +1,46 @@
+name: CI Build with latest Vulkan-Docs
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: khronosgroup/docker-images@sha256:f1ca671f3bdb10ad49e238b9bf28853088a21af49504498fc9084c9b4fea4762
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Generate Vulkan Headers
+        run: |
+          # Generate the headers
+          git clone https://github.com/KhronosGroup/Vulkan-Docs.git --depth 1
+          make -C Vulkan-Docs/xml clean install codec_headers
+
+          # Copy headers and xml registry to Vulkan-Headers (makes it easier for Vulkan-Hpp)
+          rm -rf Vulkan-Headers/include/ Vulkan-Headers/registry
+          cp -r Vulkan-Docs/gen/include/ Vulkan-Headers/include/
+          cp -r Vulkan-Docs/xml Vulkan-Headers/registry/
+          
+      - name: Generate Vulkan-Hpp and Build Samples/Tests
+        run: |
+          cmake -B build -G Ninja                      \
+          -D VULKAN_HPP_GENERATOR_BUILD=ON             \
+          -D VULKAN_HPP_RUN_GENERATOR=ON               \
+          -D VULKAN_HPP_SAMPLES_BUILD=ON               \
+          -D VULKAN_HPP_TESTS_BUILD=ON                 \
+          -D VULKAN_HPP_TESTS_CTEST=ON                 \
+          -D VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=ON     \
+          -D VULKAN_HPP_BUILD_WITH_LOCAL_VULKAN_HPP=ON \
+          -D VULKAN_HPP_PRECOMPILE=OFF                 \
+          -D CMAKE_C_COMPILER=gcc                      \
+          -D CMAKE_CXX_COMPILER=g++                    \
+          -D CMAKE_CXX_STANDARD=23                     \
+          -D CMAKE_BUILD_TYPE=Release
+          cmake --build build --parallel
+          ctest -j --output-on-failure --test-dir build


### PR DESCRIPTION
This will resolve #1761 and performs the following:
1. Pulls and runs on khronos docker `sha256:f1ca671f3bdb10ad49e238b9bf28853088a21af49504498fc9084c9b4fea4762`
2. Pulls latest Vulkan-Docs and generate headers via `make -C Vulkan-Docs/xml clean install codec_headers`
3. Generates Vulkan-Hpp headers from latest Vulkan-Docs xml registry
4. Builds samples/tests with latest Vulkan-Docs generated headers in C++23 using the default compiler (gcc 14.2.0)

Please have a look @oddhack if this is sufficient; in particular the method of generating the header artefacts in step 2.
I could also update the CI steps over at `Vulkan-Docs` once everyone is happy with this runner, so that they both run identical setups (at the very least, it should also use the docker image over there as tracked in KhronosGroup/Vulkan-Docs#2654).