### PR TITLE
Fix generation for vulkanbase API with extension supported on vulkanbase

### DIFF
--- a/VulkanHppGenerator.cpp
+++ b/VulkanHppGenerator.cpp
@@ -15124,7 +15124,7 @@ void VulkanHppGenerator::readExtension( tinyxml2::XMLElement const * element )
 
   checkAttributes( line,
                    attributes,
-                   { { "name", {} }, { "number", {} }, { "supported", { "disabled", "vulkan", "vulkansc" } } },
+                   { { "name", {} }, { "number", {} }, { "supported", { "disabled", "vulkan", "vulkanbase", "vulkansc" } } },
                    { { "author", {} },
                      { "comment", {} },
                      { "contact", {} },


### PR DESCRIPTION
Add "vulkanbase" to the list of accepted values for the "supported" attribute of the "extension" tag.