### PR TITLE
CI: Separate header gen and sample stages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
             -D VULKAN_HPP_RUN_GENERATOR=OFF                                                                      \
             -D VULKAN_HPP_SAMPLES_BUILD=ON                                                                       \
             -D VULKAN_HPP_TESTS_BUILD=OFF                                                                        \
-            -D VULKAN_HPP_TESTS_CTEST=ON                                                                         \
+            -D VULKAN_HPP_TESTS_CTEST=OFF                                                                        \
             -D VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=ON                                                             \
             -D VULKAN_HPP_BUILD_WITH_LOCAL_VULKAN_HPP=ON                                                         \
             -D VULKAN_HPP_PRECOMPILE=ON                                                                          \


### PR DESCRIPTION
I had previously merged them to be concise, but separating these has two distinct time advantages:
1. We can skip running the generator in Debug mode, which is suprisingly slow to execute
2. Module runners can skip the sample stage altogether, shaving at least 10 minutes off their total runtime

This pretty much covers all the ideas I had for reducing these runner times and will (hopefully) be the last PR about them for a while..