### PR TITLE
Tests: Added test for vk::to_string

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ endif()
 vulkan_hpp__setup_test( NAME NoSmartHandle )
 vulkan_hpp__setup_test( NAME StridedArrayProxy )
 vulkan_hpp__setup_test( NAME StructureChain )
+vulkan_hpp__setup_test( NAME ToString )
 # add_subdirectory( UniqueHandle ) # really messy setup, test needs to be shortened
 if(CMAKE_SIZEOF_VOID_P EQUAL 8)
 	vulkan_hpp__setup_test( NAME UniqueHandleDefaultArguments )
@@ -87,6 +88,7 @@ if( VULKAN_HPP_TESTS_CTEST AND VULKAN_HPP_BUILD_CXX_MODULE )
 	if( NOT MSVC ) # MSVC cannot deduct types for structured binding
 		vulkan_hpp__setup_test( NAME StructureChain CXX_MODULE )
 	endif()
+	vulkan_hpp__setup_test( NAME ToString CXX_MODULE )
 	# add_subdirectory( UniqueHandle ) # no CXX_MODULE test version yet
 	vulkan_hpp__setup_test( NAME UniqueHandleDefaultArguments CXX_MODULE )
 	vulkan_hpp__setup_test( NAME Video CXX_MODULE )

--- a/tests/ToString/CMakeLists.txt
+++ b/tests/ToString/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright(c) 2018, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required( VERSION 3.12 )
+project( VulkanHppTest LANGUAGES CXX )
+
+include( ${CMAKE_CURRENT_SOURCE_DIR}/../../CMakeLists.txt )
+vulkan_hpp__setup_test_project()

--- a/tests/ToString/ToString.cpp
+++ b/tests/ToString/ToString.cpp
@@ -1,0 +1,30 @@
+// Copyright(c) 2018, NVIDIA CORPORATION. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef VULKAN_HPP_USE_CXX_MODULE
+import vulkan;
+#else
+#  include <iostream>
+#  include <vulkan/vulkan.hpp>
+#endif
+
+int main( int /*argc*/, char ** /*argv*/ )
+{
+  std::cout << vk::to_string( vk::PresentModeKHR::eFifo ) << std::endl;
+  std::cout << vk::to_string( vk::SharingMode::eExclusive ) << std::endl;
+  std::cout << vk::to_string( vk::ColorSpaceKHR::eSrgbNonlinear ) << std::endl;
+  std::cout << vk::to_string( vk::Format::eA2R10G10B10UnormPack32 ) << std::endl;
+  std::cout << vk::to_string( vk::ImageUsageFlagBits::eTransferDst ) << std::endl;
+  return 0;
+}


### PR DESCRIPTION
Should catch issues with `vk::to_string`, also with modules as discussed in #2443.