### PR TITLE
CMake: Generate .gitignore template when top-level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,27 @@ function( vulkan_hpp__setup_warning_level )
 	endif()
 endfunction()
 
+# Create a .gitignore file that ignores itself to avoid tracking
+if( NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.gitignore" AND PROJECT_IS_TOP_LEVEL )
+	string(CONCAT VULKAN_HPP_GITIGNORE_ENTRIES
+		"builds/\n"
+		"build/\n"
+		"out/\n"
+		"\n"
+		".cache/\n"
+		".vscode/\n"
+		".vs/\n"
+		"\n"
+		".clang-format\n"
+		".gitignore\n"
+		"\n"
+		"*.pdb\n"
+		"*.proj.DotSettings\n"
+		"\n"
+		"Folder.DotSettings.user\n" )
+	file( WRITE ${CMAKE_CURRENT_SOURCE_DIR}/.gitignore ${VULKAN_HPP_GITIGNORE_ENTRIES} )
+endif()
+
 # Build Vulkan-Hpp and Video-Hpp generators
 if( VULKAN_HPP_GENERATOR_BUILD )
 	set_property( GLOBAL PROPERTY USE_FOLDERS ON )


### PR DESCRIPTION
This will ignore common build artefacts that I know of. I've always kept this one (alongside an entry for `.gitignore` itself) when working with this repository. Having one by default makes it easier to work with this repo out of the gate.

Are there any entries I missed? I have not used any MacOS IDEs for example.