### PR TITLE
Update docs to be consistent with prevalent style

### DIFF
--- a/docs/Handles.md
+++ b/docs/Handles.md
@@ -83,21 +83,22 @@ Add a `friend` declaration for the base class.
 // Example of a custom shared device, that accepts an instance as a parent
 class MySharedHandle<VkDevice> : public vk::SharedHandleBase<VkDevice, vk::SharedInstance, MySharedHandle<VkDevice>>
 {
-  using base = vk::SharedHandleBase<VkDevice, vk::SharedInstance, MySharedHandle<VkDevice>>;
-  friend base;
+  using Base = vk::SharedHandleBase<VkDevice, vk::SharedInstance, MySharedHandle<VkDevice>>;
+  friend Base;
 
 public:
   MySharedHandle() = default;
-  explicit MySharedHandle(VkDevice handle, vk::SharedInstance parent) noexcept
-    : base(handle, std::move(parent)) {}
+  explicit MySharedHandle(VkDevice handle, vk::SharedInstance parent) noexcept:
+    Base(handle, std::move(parent)) {}
 
-  const auto& getParent() const noexcept
+  [[nodiscard]]
+  const vk::SharedInstance& getParent() const noexcept
   {
     return getHeader();
   }
 
 protected:
-  static void internalDestroy(const vk::SharedInstance& /*control*/, VkDevice handle) noexcept
+  static void internalDestroy([[maybe_unused]] const vk::SharedInstance& control, VkDevice handle) noexcept
   {
     vkDestroyDevice(handle);
   }

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -905,14 +905,15 @@ This may be combined with the following basic `main.cpp` consumer code:
 // optional include for VULKAN_HPP_DEFAULT_DISPATCHER
 // otherwise, use vk::detail::defaultDispatchLoaderDynamic
 #include <vulkan/vulkan_hpp_macros.hpp>
+
 import vulkan;
 
-auto main(int argc, char* const argv[]) -> int
+int main(int argc, char* argv[])
 {
     // initialize minimal set of function pointers
     VULKAN_HPP_DEFAULT_DISPATCHER.init();
 
-    auto appInfo = vk::ApplicationInfo("My App", 1, "My Engine", 1, vk::makeApiVersion(1, 0, 0, 0));
+    vk::ApplicationInfo appInfo("My App", 1, "My Engine", 1, vk::makeApiVersion(1, 0, 0, 0));
 
     vk::Instance instance;
     // create vk::Instance instance here


### PR DESCRIPTION
This PR addresses some of the inconsistencies seen in the docs:
- The `MySharedHandle` class names its base class as `base`, though the rest of the library uses PascalCase, so this should be updated to `Base`.
- `MySharedHandle::getParent` should be clearer on what it returns, so I updated the return type from `const auto&` to `const vk::SharedInstance&`. I also marked it `[[nodiscard]]` because it is a getter function and its value shouldn't be discarded if called.
- Instead of commenting out the parameter name on `MySharedHandle::internalDestroy`, use the `[[maybe_unused]]` attribute to make it clear the parameter is not considered.
- The C++ modules example used `auto` declarations (`auto appInfo = ApplicationInfo(/* ... */);`), but the rest of the library doesn't. This could instead more simply (and more briefly) be written with direct-initialisation (`ApplicationInfo appInfo(/* ... */);`).
- The traditional `main()` signature is most often depicted as `int main()`, rather than with trailing return type (`auto main() -> int`), and there's no reason to make this arbitrary difference. Also, `argv` is most often depicted as `char* argv[]`, not `char* const argv[]`, so we might as well just stick with `char* argv[]` (without the `const` specifier).