### PR TITLE
Remove unused parameters from `main()` and apply `[[maybe_unused]]` elsewhere

### DIFF
--- a/RAII_Samples/01_InitInstance/01_InitInstance.cpp
+++ b/RAII_Samples/01_InitInstance/01_InitInstance.cpp
@@ -22,7 +22,7 @@
 static std::string AppName    = "01_InitInstanceRAII";
 static std::string EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   /* VULKAN_HPP_KEY_START */
 

--- a/RAII_Samples/02_EnumerateDevices/02_EnumerateDevices.cpp
+++ b/RAII_Samples/02_EnumerateDevices/02_EnumerateDevices.cpp
@@ -32,7 +32,7 @@
 static std::string AppName    = "02_EnumerateDevicesRAII";
 static std::string EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/03_InitDevice/03_InitDevice.cpp
+++ b/RAII_Samples/03_InitDevice/03_InitDevice.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "03_InitDeviceRAII";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/04_InitCommandBuffer/04_InitCommandBuffer.cpp
+++ b/RAII_Samples/04_InitCommandBuffer/04_InitCommandBuffer.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "04_InitCommandBufferRAII";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/05_InitSwapchain/05_InitSwapchain.cpp
+++ b/RAII_Samples/05_InitSwapchain/05_InitSwapchain.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "05_InitSwapchainRAII";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/06_InitDepthBuffer/06_InitDepthBuffer.cpp
+++ b/RAII_Samples/06_InitDepthBuffer/06_InitDepthBuffer.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "06_InitDepthBuffer";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/07_InitUniformBuffer/07_InitUniformBuffer.cpp
+++ b/RAII_Samples/07_InitUniformBuffer/07_InitUniformBuffer.cpp
@@ -35,7 +35,7 @@
 static char const * AppName    = "07_InitUniformBuffer";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/08_InitPipelineLayout/08_InitPipelineLayout.cpp
+++ b/RAII_Samples/08_InitPipelineLayout/08_InitPipelineLayout.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "08_InitPipelineLayout";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/09_InitDescriptorSet/09_InitDescriptorSet.cpp
+++ b/RAII_Samples/09_InitDescriptorSet/09_InitDescriptorSet.cpp
@@ -35,7 +35,7 @@
 static char const * AppName    = "09_InitDescriptorSet";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/10_InitRenderPass/10_InitRenderPass.cpp
+++ b/RAII_Samples/10_InitRenderPass/10_InitRenderPass.cpp
@@ -34,7 +34,7 @@
 static char const * AppName    = "10_InitRenderPass";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/11_InitShaders/11_InitShaders.cpp
+++ b/RAII_Samples/11_InitShaders/11_InitShaders.cpp
@@ -24,7 +24,7 @@
 static char const * AppName    = "11_InitShaders";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/12_InitFrameBuffers/12_InitFrameBuffers.cpp
+++ b/RAII_Samples/12_InitFrameBuffers/12_InitFrameBuffers.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "12_InitFrameBuffers";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/13_InitVertexBuffer/13_InitVertexBuffer.cpp
+++ b/RAII_Samples/13_InitVertexBuffer/13_InitVertexBuffer.cpp
@@ -33,7 +33,7 @@
 static char const * AppName    = "13_InitVertexBuffer";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/14_InitPipeline/14_InitPipeline.cpp
+++ b/RAII_Samples/14_InitPipeline/14_InitPipeline.cpp
@@ -36,7 +36,7 @@
 static char const * AppName    = "14_InitPipeline";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/15_DrawCube/15_DrawCube.cpp
+++ b/RAII_Samples/15_DrawCube/15_DrawCube.cpp
@@ -37,7 +37,7 @@
 static char const * AppName    = "15_DrawCube";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/16_Vulkan_1_1/16_Vulkan_1_1.cpp
+++ b/RAII_Samples/16_Vulkan_1_1/16_Vulkan_1_1.cpp
@@ -20,7 +20,7 @@
 static char const * AppName    = "16_Vulkan_1_1";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/CopyBlitImage/CopyBlitImage.cpp
+++ b/RAII_Samples/CopyBlitImage/CopyBlitImage.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "CopyBlitImage";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/CreateDebugUtilsMessenger/CreateDebugUtilsMessenger.cpp
+++ b/RAII_Samples/CreateDebugUtilsMessenger/CreateDebugUtilsMessenger.cpp
@@ -27,8 +27,9 @@ static char const * EngineName = "Vulkan.hpp";
 VKAPI_ATTR VkBool32 VKAPI_CALL debugMessageFunc( vk::DebugUtilsMessageSeverityFlagBitsEXT       messageSeverity,
                                                  vk::DebugUtilsMessageTypeFlagsEXT              messageTypes,
                                                  vk::DebugUtilsMessengerCallbackDataEXT const * pCallbackData,
-                                                 void * /*pUserData*/ )
+                                                 VULKAN_HPP_MAYBE_UNUSED void * pUserData )
 {
+  VULKAN_HPP_UNUSED( pUserData );
   std::ostringstream message;
 
   message << vk::to_string( messageSeverity ) << ": " << vk::to_string( messageTypes ) << ":\n";
@@ -75,7 +76,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL debugMessageFunc( vk::DebugUtilsMessageSeverityFl
   return false;
 }
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/DebugUtilsObjectName/DebugUtilsObjectName.cpp
+++ b/RAII_Samples/DebugUtilsObjectName/DebugUtilsObjectName.cpp
@@ -26,7 +26,7 @@ static char const * EngineName = "Vulkan.hpp";
 #  define NON_DISPATCHABLE_HANDLE_TO_UINT64_CAST( type, x ) reinterpret_cast<uint64_t>( static_cast<type>( x ) )
 #endif
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/DrawTexturedCube/DrawTexturedCube.cpp
+++ b/RAII_Samples/DrawTexturedCube/DrawTexturedCube.cpp
@@ -27,7 +27,7 @@
 static char const * AppName    = "DrawTexturedCube";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/DynamicUniform/DynamicUniform.cpp
+++ b/RAII_Samples/DynamicUniform/DynamicUniform.cpp
@@ -31,7 +31,7 @@
 static char const * AppName    = "DynamicUniform";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/EnableValidationWithCallback/EnableValidationWithCallback.cpp
+++ b/RAII_Samples/EnableValidationWithCallback/EnableValidationWithCallback.cpp
@@ -55,8 +55,9 @@ VKAPI_ATTR void VKAPI_CALL vkDestroyDebugUtilsMessengerEXT( VkInstance instance,
 VKAPI_ATTR VkBool32 VKAPI_CALL debugMessageFunc( vk::DebugUtilsMessageSeverityFlagBitsEXT       messageSeverity,
                                                  vk::DebugUtilsMessageTypeFlagsEXT              messageTypes,
                                                  vk::DebugUtilsMessengerCallbackDataEXT const * pCallbackData,
-                                                 void * /*pUserData*/ )
+                                                 VULKAN_HPP_MAYBE_UNUSED void * pUserData )
 {
+  VULKAN_HPP_UNUSED( pUserData );
   std::string message;
 
   message += vk::to_string( messageSeverity ) + ": " + vk::to_string( messageTypes ) + ":\n";
@@ -115,7 +116,7 @@ bool checkLayers( std::vector<char const *> const & layers, std::vector<vk::Laye
                       } );
 }
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/EnumerateDevicesAdvanced/EnumerateDevicesAdvanced.cpp
+++ b/RAII_Samples/EnumerateDevicesAdvanced/EnumerateDevicesAdvanced.cpp
@@ -24,7 +24,7 @@
 static char const * AppName    = "EnumerateDevicesAdvanced";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/Events/Events.cpp
+++ b/RAII_Samples/Events/Events.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "Events";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/ImmutableSampler/ImmutableSampler.cpp
+++ b/RAII_Samples/ImmutableSampler/ImmutableSampler.cpp
@@ -39,7 +39,7 @@
 static char const * AppName    = "ImmutableSampler";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/InitTexture/InitTexture.cpp
+++ b/RAII_Samples/InitTexture/InitTexture.cpp
@@ -37,7 +37,7 @@
 static char const * AppName    = "InitTexture";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/InputAttachment/InputAttachment.cpp
+++ b/RAII_Samples/InputAttachment/InputAttachment.cpp
@@ -66,7 +66,7 @@ void main()
 }
 )";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/InstanceExtensionProperties/InstanceExtensionProperties.cpp
+++ b/RAII_Samples/InstanceExtensionProperties/InstanceExtensionProperties.cpp
@@ -21,7 +21,7 @@
 #include <iostream>
 #include <sstream>
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/InstanceLayerExtensionProperties/InstanceLayerExtensionProperties.cpp
+++ b/RAII_Samples/InstanceLayerExtensionProperties/InstanceLayerExtensionProperties.cpp
@@ -31,7 +31,7 @@ struct PropertyData
   std::vector<vk::ExtensionProperties> extensionProperties;
 };
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/InstanceLayerProperties/InstanceLayerProperties.cpp
+++ b/RAII_Samples/InstanceLayerProperties/InstanceLayerProperties.cpp
@@ -21,7 +21,7 @@
 #include <sstream>
 #include <vector>
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {
@@ -55,7 +55,7 @@ int main( int /*argc*/, char ** /*argv*/ )
   }
   catch ( std::exception & err )
   {
-    std::cout << "std::runtexceptionime_error: " << err.what() << std::endl;
+    std::cout << "std::exception: " << err.what() << std::endl;
     exit( -1 );
   }
   catch ( ... )

--- a/RAII_Samples/InstanceVersion/InstanceVersion.cpp
+++ b/RAII_Samples/InstanceVersion/InstanceVersion.cpp
@@ -26,7 +26,7 @@ std::string decodeAPIVersion( uint32_t apiVersion )
          std::to_string( VK_VERSION_PATCH( apiVersion ) );
 }
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/MultipleSets/MultipleSets.cpp
+++ b/RAII_Samples/MultipleSets/MultipleSets.cpp
@@ -89,7 +89,7 @@ void main()
 }
 )";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/OcclusionQuery/OcclusionQuery.cpp
+++ b/RAII_Samples/OcclusionQuery/OcclusionQuery.cpp
@@ -27,7 +27,7 @@
 static char const * AppName    = "OcclusionQuery";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/PhysicalDeviceExtensions/PhysicalDeviceExtensions.cpp
+++ b/RAII_Samples/PhysicalDeviceExtensions/PhysicalDeviceExtensions.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "DeviceExtensionProperties";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/PhysicalDeviceFeatures/PhysicalDeviceFeatures.cpp
+++ b/RAII_Samples/PhysicalDeviceFeatures/PhysicalDeviceFeatures.cpp
@@ -31,7 +31,7 @@
 static char const * AppName    = "PhysicalDeviceFeatures";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/PhysicalDeviceGroups/PhysicalDeviceGroups.cpp
+++ b/RAII_Samples/PhysicalDeviceGroups/PhysicalDeviceGroups.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "PhysicalDeviceGroups";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/PhysicalDeviceMemoryProperties/PhysicalDeviceMemoryProperties.cpp
+++ b/RAII_Samples/PhysicalDeviceMemoryProperties/PhysicalDeviceMemoryProperties.cpp
@@ -46,7 +46,7 @@ std::string formatSize( vk::DeviceSize size )
   return oss.str();
 }
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/PhysicalDeviceProperties/PhysicalDeviceProperties.cpp
+++ b/RAII_Samples/PhysicalDeviceProperties/PhysicalDeviceProperties.cpp
@@ -95,7 +95,7 @@ namespace vk
   }  // namespace su
 }  // namespace vk
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/PhysicalDeviceQueueFamilyProperties/PhysicalDeviceQueueFamilyProperties.cpp
+++ b/RAII_Samples/PhysicalDeviceQueueFamilyProperties/PhysicalDeviceQueueFamilyProperties.cpp
@@ -25,7 +25,7 @@
 static char const * AppName    = "PhysicalDeviceQueueFamilyProperties";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/PipelineCache/PipelineCache.cpp
+++ b/RAII_Samples/PipelineCache/PipelineCache.cpp
@@ -68,7 +68,7 @@ timestamp_t getMilliseconds()
 static char const * AppName    = "PipelineCache";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/PipelineDerivative/PipelineDerivative.cpp
+++ b/RAII_Samples/PipelineDerivative/PipelineDerivative.cpp
@@ -35,7 +35,7 @@
 static char const * AppName    = "PipelineDerivative";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/PushConstants/PushConstants.cpp
+++ b/RAII_Samples/PushConstants/PushConstants.cpp
@@ -77,7 +77,7 @@ void main()
 }
 )";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/PushDescriptors/PushDescriptors.cpp
+++ b/RAII_Samples/PushDescriptors/PushDescriptors.cpp
@@ -28,7 +28,7 @@
 static char const * AppName    = "PushDescriptors";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/RayTracing/RayTracing.cpp
+++ b/RAII_Samples/RayTracing/RayTracing.cpp
@@ -573,8 +573,10 @@ static void framebufferSizeCallback( GLFWwindow * window, int w, int h )
   cameraManipulator.setWindowSize( glm::ivec2( w, h ) );
 }
 
-static void keyCallback( GLFWwindow * window, int key, int /*scancode*/, int action, int /*mods*/ )
+static void keyCallback( GLFWwindow * window, int key, VULKAN_HPP_MAYBE_UNUSED int scancode, int action, VULKAN_HPP_MAYBE_UNUSED int mods )
 {
+  VULKAN_HPP_UNUSED( scancode );
+  VULKAN_HPP_UNUSED( mods );
   if ( action == GLFW_PRESS )
   {
     switch ( key )
@@ -591,8 +593,11 @@ static void keyCallback( GLFWwindow * window, int key, int /*scancode*/, int act
   }
 }
 
-static void mouseButtonCallback( GLFWwindow * window, int /*button*/, int /*action*/, int /*mods*/ )
+static void mouseButtonCallback( GLFWwindow * window, VULKAN_HPP_MAYBE_UNUSED int button, VULKAN_HPP_MAYBE_UNUSED int action, VULKAN_HPP_MAYBE_UNUSED int mods )
 {
+  VULKAN_HPP_UNUSED( button );
+  VULKAN_HPP_UNUSED( action );
+  VULKAN_HPP_UNUSED( mods );
   double xpos, ypos;
   glfwGetCursorPos( window, &xpos, &ypos );
 
@@ -600,8 +605,9 @@ static void mouseButtonCallback( GLFWwindow * window, int /*button*/, int /*acti
   cameraManipulator.setMousePosition( glm::ivec2( static_cast<int>( xpos ), static_cast<int>( ypos ) ) );
 }
 
-static void scrollCallback( GLFWwindow * window, double /*xoffset*/, double yoffset )
+static void scrollCallback( GLFWwindow * window, VULKAN_HPP_MAYBE_UNUSED double xoffset, double yoffset )
 {
+  VULKAN_HPP_UNUSED( xoffset );
   vk::su::CameraManipulator & cameraManipulator = reinterpret_cast<AppInfo *>( glfwGetWindowUserPointer( window ) )->cameraManipulator;
   cameraManipulator.wheel( static_cast<int>( yoffset ) );
 }
@@ -631,7 +637,7 @@ uint32_t roundUp( uint32_t value, uint32_t alignment )
   return ( ( value + alignment - 1 ) / alignment ) * alignment;
 }
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   // number of cubes in x-, y-, and z-direction
   const size_t xMax = 10;

--- a/RAII_Samples/SecondaryCommandBuffer/SecondaryCommandBuffer.cpp
+++ b/RAII_Samples/SecondaryCommandBuffer/SecondaryCommandBuffer.cpp
@@ -37,7 +37,7 @@
 static char const * AppName    = "SecondaryCommandBuffer";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/SeparateImageSampler/SeparateImageSampler.cpp
+++ b/RAII_Samples/SeparateImageSampler/SeparateImageSampler.cpp
@@ -65,7 +65,7 @@ void main()
 }
 )";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/SurfaceCapabilities/SurfaceCapabilities.cpp
+++ b/RAII_Samples/SurfaceCapabilities/SurfaceCapabilities.cpp
@@ -44,7 +44,7 @@ void cout( vk::SurfaceCapabilitiesKHR const & surfaceCapabilities )
   std::cout << "\n";
 }
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/SurfaceFormats/SurfaceFormats.cpp
+++ b/RAII_Samples/SurfaceFormats/SurfaceFormats.cpp
@@ -25,7 +25,7 @@
 static char const * AppName    = "SurfaceFormats";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/Template/Template.cpp
+++ b/RAII_Samples/Template/Template.cpp
@@ -27,7 +27,7 @@
 static char const * AppName    = "Template";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/RAII_Samples/TexelBuffer/TexelBuffer.cpp
+++ b/RAII_Samples/TexelBuffer/TexelBuffer.cpp
@@ -52,7 +52,7 @@ void main()
 }
 )";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   const float texels[] = { 118.0f / 255.0f, 185.0f / 255.0f, 0.0f };
 

--- a/samples/01_InitInstance/01_InitInstance.cpp
+++ b/samples/01_InitInstance/01_InitInstance.cpp
@@ -21,7 +21,7 @@
 static std::string AppName    = "01_InitInstance";
 static std::string EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   /* VULKAN_HPP_KEY_START */
 

--- a/samples/02_EnumerateDevices/02_EnumerateDevices.cpp
+++ b/samples/02_EnumerateDevices/02_EnumerateDevices.cpp
@@ -33,7 +33,7 @@
 static std::string AppName    = "02_EnumerateDevices";
 static std::string EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/03_InitDevice/03_InitDevice.cpp
+++ b/samples/03_InitDevice/03_InitDevice.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "03_InitDevice";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/04_InitCommandBuffer/04_InitCommandBuffer.cpp
+++ b/samples/04_InitCommandBuffer/04_InitCommandBuffer.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "04_InitCommandBuffer";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/05_InitSwapchain/05_InitSwapchain.cpp
+++ b/samples/05_InitSwapchain/05_InitSwapchain.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "05_InitSwapchain";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/06_InitDepthBuffer/06_InitDepthBuffer.cpp
+++ b/samples/06_InitDepthBuffer/06_InitDepthBuffer.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "06_InitDepthBuffer";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/07_InitUniformBuffer/07_InitUniformBuffer.cpp
+++ b/samples/07_InitUniformBuffer/07_InitUniformBuffer.cpp
@@ -35,7 +35,7 @@
 static char const * AppName    = "07_InitUniformBuffer";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/08_InitPipelineLayout/08_InitPipelineLayout.cpp
+++ b/samples/08_InitPipelineLayout/08_InitPipelineLayout.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "08_InitPipelineLayout";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/09_InitDescriptorSet/09_InitDescriptorSet.cpp
+++ b/samples/09_InitDescriptorSet/09_InitDescriptorSet.cpp
@@ -35,7 +35,7 @@
 static char const * AppName    = "09_InitDescriptorSet";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/10_InitRenderPass/10_InitRenderPass.cpp
+++ b/samples/10_InitRenderPass/10_InitRenderPass.cpp
@@ -34,7 +34,7 @@
 static char const * AppName    = "10_InitRenderPass";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/11_InitShaders/11_InitShaders.cpp
+++ b/samples/11_InitShaders/11_InitShaders.cpp
@@ -24,7 +24,7 @@
 static char const * AppName    = "11_InitShaders";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/12_InitFrameBuffers/12_InitFrameBuffers.cpp
+++ b/samples/12_InitFrameBuffers/12_InitFrameBuffers.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "12_InitFrameBuffers";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/13_InitVertexBuffer/13_InitVertexBuffer.cpp
+++ b/samples/13_InitVertexBuffer/13_InitVertexBuffer.cpp
@@ -23,7 +23,7 @@
 static char const * AppName    = "13_InitVertexBuffer";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/14_InitPipeline/14_InitPipeline.cpp
+++ b/samples/14_InitPipeline/14_InitPipeline.cpp
@@ -36,7 +36,7 @@
 static char const * AppName    = "14_InitPipeline";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/15_DrawCube/15_DrawCube.cpp
+++ b/samples/15_DrawCube/15_DrawCube.cpp
@@ -27,7 +27,7 @@
 static char const * AppName    = "15_DrawCube";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/16_Vulkan_1_1/16_Vulkan_1_1.cpp
+++ b/samples/16_Vulkan_1_1/16_Vulkan_1_1.cpp
@@ -20,7 +20,7 @@
 static char const * AppName    = "16_Vulkan_1_1";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/CopyBlitImage/CopyBlitImage.cpp
+++ b/samples/CopyBlitImage/CopyBlitImage.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "CopyBlitImage";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/CreateDebugUtilsMessenger/CreateDebugUtilsMessenger.cpp
+++ b/samples/CreateDebugUtilsMessenger/CreateDebugUtilsMessenger.cpp
@@ -42,8 +42,9 @@ VKAPI_ATTR void VKAPI_CALL vkDestroyDebugUtilsMessengerEXT( VkInstance instance,
 VKAPI_ATTR vk::Bool32 VKAPI_CALL debugMessageFunc( vk::DebugUtilsMessageSeverityFlagBitsEXT       messageSeverity,
                                                    vk::DebugUtilsMessageTypeFlagsEXT              messageTypes,
                                                    vk::DebugUtilsMessengerCallbackDataEXT const * pCallbackData,
-                                                   void * /*pUserData*/ )
+                                                   VULKAN_HPP_MAYBE_UNUSED void * pUserData )
 {
+  VULKAN_HPP_UNUSED( pUserData );
   std::ostringstream message;
 
   message << vk::to_string( messageSeverity ) << ": " << vk::to_string( messageTypes ) << ":\n";
@@ -90,7 +91,7 @@ VKAPI_ATTR vk::Bool32 VKAPI_CALL debugMessageFunc( vk::DebugUtilsMessageSeverity
   return false;
 }
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/DebugUtilsObjectName/DebugUtilsObjectName.cpp
+++ b/samples/DebugUtilsObjectName/DebugUtilsObjectName.cpp
@@ -26,7 +26,7 @@ static char const * EngineName = "Vulkan.hpp";
 #  define NON_DISPATCHABLE_HANDLE_TO_UINT64_CAST( type, x ) reinterpret_cast<uint64_t>( static_cast<type>( x ) )
 #endif
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/DrawTexturedCube/DrawTexturedCube.cpp
+++ b/samples/DrawTexturedCube/DrawTexturedCube.cpp
@@ -27,7 +27,7 @@
 static char const * AppName    = "DrawTexturedCube";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/DynamicUniform/DynamicUniform.cpp
+++ b/samples/DynamicUniform/DynamicUniform.cpp
@@ -37,7 +37,7 @@
 static char const * AppName    = "DynamicUniform";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/EnableValidationWithCallback/EnableValidationWithCallback.cpp
+++ b/samples/EnableValidationWithCallback/EnableValidationWithCallback.cpp
@@ -55,8 +55,9 @@ VKAPI_ATTR void VKAPI_CALL vkDestroyDebugUtilsMessengerEXT( VkInstance instance,
 VKAPI_ATTR VkBool32 VKAPI_CALL debugMessageFunc( vk::DebugUtilsMessageSeverityFlagBitsEXT       messageSeverity,
                                                  vk::DebugUtilsMessageTypeFlagsEXT              messageTypes,
                                                  vk::DebugUtilsMessengerCallbackDataEXT const * pCallbackData,
-                                                 void * /*pUserData*/ )
+                                                 VULKAN_HPP_MAYBE_UNUSED void * pUserData )
 {
+  VULKAN_HPP_UNUSED( pUserData );
   std::string message;
 
   message += vk::to_string( messageSeverity ) + ": " + vk::to_string( messageTypes ) + ":\n";
@@ -115,7 +116,7 @@ bool checkLayers( std::vector<char const *> const & layers, std::vector<vk::Laye
                       } );
 }
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/EnumerateDevicesAdvanced/EnumerateDevicesAdvanced.cpp
+++ b/samples/EnumerateDevicesAdvanced/EnumerateDevicesAdvanced.cpp
@@ -24,7 +24,7 @@
 static char const * AppName    = "EnumerateDevicesAdvanced";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/Events/Events.cpp
+++ b/samples/Events/Events.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "Events";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/ImmutableSampler/ImmutableSampler.cpp
+++ b/samples/ImmutableSampler/ImmutableSampler.cpp
@@ -36,7 +36,7 @@
 static char const * AppName    = "ImmutableSampler";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/InitTexture/InitTexture.cpp
+++ b/samples/InitTexture/InitTexture.cpp
@@ -37,7 +37,7 @@
 static char const * AppName    = "InitTexture";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/InputAttachment/InputAttachment.cpp
+++ b/samples/InputAttachment/InputAttachment.cpp
@@ -66,7 +66,7 @@ void main()
 }
 )";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/InstanceExtensionProperties/InstanceExtensionProperties.cpp
+++ b/samples/InstanceExtensionProperties/InstanceExtensionProperties.cpp
@@ -20,7 +20,7 @@
 #include <sstream>
 #include <vulkan/vulkan.hpp>
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/InstanceLayerExtensionProperties/InstanceLayerExtensionProperties.cpp
+++ b/samples/InstanceLayerExtensionProperties/InstanceLayerExtensionProperties.cpp
@@ -31,7 +31,7 @@ struct PropertyData
   std::vector<vk::ExtensionProperties> extensionProperties;
 };
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/InstanceLayerProperties/InstanceLayerProperties.cpp
+++ b/samples/InstanceLayerProperties/InstanceLayerProperties.cpp
@@ -20,7 +20,7 @@
 #include <vector>
 #include <vulkan/vulkan.hpp>
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {
@@ -52,7 +52,7 @@ int main( int /*argc*/, char ** /*argv*/ )
   }
   catch ( std::exception & err )
   {
-    std::cout << "std::runtexceptionime_error: " << err.what() << std::endl;
+    std::cout << "std::exception: " << err.what() << std::endl;
     exit( -1 );
   }
   catch ( ... )

--- a/samples/InstanceVersion/InstanceVersion.cpp
+++ b/samples/InstanceVersion/InstanceVersion.cpp
@@ -25,7 +25,7 @@ std::string decodeAPIVersion( uint32_t apiVersion )
          std::to_string( VK_VERSION_PATCH( apiVersion ) );
 }
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/MultipleSets/MultipleSets.cpp
+++ b/samples/MultipleSets/MultipleSets.cpp
@@ -86,7 +86,7 @@ void main()
 }
 )";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/OcclusionQuery/OcclusionQuery.cpp
+++ b/samples/OcclusionQuery/OcclusionQuery.cpp
@@ -27,7 +27,7 @@
 static char const * AppName    = "OcclusionQuery";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/PhysicalDeviceExtensions/PhysicalDeviceExtensions.cpp
+++ b/samples/PhysicalDeviceExtensions/PhysicalDeviceExtensions.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "DeviceExtensionProperties";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/PhysicalDeviceFeatures/PhysicalDeviceFeatures.cpp
+++ b/samples/PhysicalDeviceFeatures/PhysicalDeviceFeatures.cpp
@@ -31,7 +31,7 @@
 static char const * AppName    = "PhysicalDeviceFeatures";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/PhysicalDeviceGroups/PhysicalDeviceGroups.cpp
+++ b/samples/PhysicalDeviceGroups/PhysicalDeviceGroups.cpp
@@ -22,7 +22,7 @@
 static char const * AppName    = "PhysicalDeviceGroups";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/PhysicalDeviceMemoryProperties/PhysicalDeviceMemoryProperties.cpp
+++ b/samples/PhysicalDeviceMemoryProperties/PhysicalDeviceMemoryProperties.cpp
@@ -46,7 +46,7 @@ std::string formatSize( vk::DeviceSize size )
   return oss.str();
 }
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/PhysicalDeviceProperties/PhysicalDeviceProperties.cpp
+++ b/samples/PhysicalDeviceProperties/PhysicalDeviceProperties.cpp
@@ -95,7 +95,7 @@ namespace vk
   }  // namespace su
 }  // namespace vk
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/PhysicalDeviceQueueFamilyProperties/PhysicalDeviceQueueFamilyProperties.cpp
+++ b/samples/PhysicalDeviceQueueFamilyProperties/PhysicalDeviceQueueFamilyProperties.cpp
@@ -25,7 +25,7 @@
 static char const * AppName    = "PhysicalDeviceQueueFamilyProperties";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/PipelineCache/PipelineCache.cpp
+++ b/samples/PipelineCache/PipelineCache.cpp
@@ -67,7 +67,7 @@ timestamp_t                getMilliseconds()
 static char const * AppName    = "PipelineCache";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/PipelineDerivative/PipelineDerivative.cpp
+++ b/samples/PipelineDerivative/PipelineDerivative.cpp
@@ -35,7 +35,7 @@
 static char const * AppName    = "PipelineDerivative";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/PushConstants/PushConstants.cpp
+++ b/samples/PushConstants/PushConstants.cpp
@@ -77,7 +77,7 @@ void main()
 }
 )";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/PushDescriptors/PushDescriptors.cpp
+++ b/samples/PushDescriptors/PushDescriptors.cpp
@@ -27,7 +27,7 @@
 static char const * AppName    = "PushDescriptors";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/RayTracing/RayTracing.cpp
+++ b/samples/RayTracing/RayTracing.cpp
@@ -605,8 +605,11 @@ static void keyCallback( GLFWwindow * window, int key, int /*scancode*/, int act
   }
 }
 
-static void mouseButtonCallback( GLFWwindow * window, int /*button*/, int /*action*/, int /*mods*/ )
+static void mouseButtonCallback( GLFWwindow * window, VULKAN_HPP_MAYBE_UNUSED int button, VULKAN_HPP_MAYBE_UNUSED int action, VULKAN_HPP_MAYBE_UNUSED int mods )
 {
+  VULKAN_HPP_UNUSED( button );
+  VULKAN_HPP_UNUSED( action );
+  VULKAN_HPP_UNUSED( mods );
   double xpos, ypos;
   glfwGetCursorPos( window, &xpos, &ypos );
 
@@ -614,8 +617,9 @@ static void mouseButtonCallback( GLFWwindow * window, int /*button*/, int /*acti
   cameraManipulator.setMousePosition( glm::ivec2( static_cast<int>( xpos ), static_cast<int>( ypos ) ) );
 }
 
-static void scrollCallback( GLFWwindow * window, double /*xoffset*/, double yoffset )
+static void scrollCallback( GLFWwindow * window, VULKAN_HPP_MAYBE_UNUSED double xoffset, double yoffset )
 {
+  VULKAN_HPP_UNUSED( xoffset );
   vk::su::CameraManipulator & cameraManipulator = reinterpret_cast<AppInfo *>( glfwGetWindowUserPointer( window ) )->cameraManipulator;
   cameraManipulator.wheel( static_cast<int>( yoffset ) );
 }
@@ -645,7 +649,7 @@ uint32_t roundUp( uint32_t value, uint32_t alignment )
   return ( ( value + alignment - 1 ) / alignment ) * alignment;
 }
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   // number of cubes in x-, y-, and z-direction
   const size_t xMax = 10;

--- a/samples/SecondaryCommandBuffer/SecondaryCommandBuffer.cpp
+++ b/samples/SecondaryCommandBuffer/SecondaryCommandBuffer.cpp
@@ -37,7 +37,7 @@
 static char const * AppName    = "SecondaryCommandBuffer";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/SeparateImageSampler/SeparateImageSampler.cpp
+++ b/samples/SeparateImageSampler/SeparateImageSampler.cpp
@@ -65,7 +65,7 @@ void main()
 }
 )";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/SharedHandles/SharedHandles.cpp
+++ b/samples/SharedHandles/SharedHandles.cpp
@@ -357,7 +357,7 @@ private:
   Asset  asset;
 };
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/SurfaceCapabilities/SurfaceCapabilities.cpp
+++ b/samples/SurfaceCapabilities/SurfaceCapabilities.cpp
@@ -44,7 +44,7 @@ void cout( vk::SurfaceCapabilitiesKHR const & surfaceCapabilities )
   std::cout << "\n";
 }
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/SurfaceFormats/SurfaceFormats.cpp
+++ b/samples/SurfaceFormats/SurfaceFormats.cpp
@@ -25,7 +25,7 @@
 static char const * AppName    = "SurfaceFormats";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/Template/Template.cpp
+++ b/samples/Template/Template.cpp
@@ -27,7 +27,7 @@
 static char const * AppName    = "DrawTexturedCube";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/samples/TexelBuffer/TexelBuffer.cpp
+++ b/samples/TexelBuffer/TexelBuffer.cpp
@@ -52,7 +52,7 @@ void main()
 }
 )";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   const float texels[] = { 118.0f / 255.0f, 185.0f / 255.0f, 0.0f };
 

--- a/samples/utils/utils.cpp
+++ b/samples/utils/utils.cpp
@@ -351,8 +351,9 @@ namespace vk
     VKAPI_ATTR vk::Bool32 VKAPI_CALL debugUtilsMessengerCallback( vk::DebugUtilsMessageSeverityFlagBitsEXT       messageSeverity,
                                                                   vk::DebugUtilsMessageTypeFlagsEXT              messageTypes,
                                                                   const vk::DebugUtilsMessengerCallbackDataEXT * pCallbackData,
-                                                                  void * /*pUserData*/ )
+                                                                  VULKAN_HPP_MAYBE_UNUSED void * pUserData )
     {
+      VULKAN_HPP_UNUSED( pUserData );
 #if !defined( NDEBUG )
       switch ( static_cast<uint32_t>( pCallbackData->messageIdNumber ) )
       {

--- a/samples/utils/utils.hpp
+++ b/samples/utils/utils.hpp
@@ -402,7 +402,7 @@ namespace vk
     VKAPI_ATTR vk::Bool32 VKAPI_CALL debugUtilsMessengerCallback( vk::DebugUtilsMessageSeverityFlagBitsEXT       messageSeverity,
                                                                   vk::DebugUtilsMessageTypeFlagsEXT              messageTypes,
                                                                   vk::DebugUtilsMessengerCallbackDataEXT const * pCallbackData,
-                                                                  void * /*pUserData*/ );
+                                                                  VULKAN_HPP_MAYBE_UNUSED void * pUserData );
     uint32_t                         findGraphicsQueueFamilyIndex( std::vector<vk::QueueFamilyProperties> const & queueFamilyProperties );
     std::pair<uint32_t, uint32_t>    findGraphicsAndPresentQueueFamilyIndex( vk::PhysicalDevice physicalDevice, vk::SurfaceKHR const & surface );
     uint32_t findMemoryType( vk::PhysicalDeviceMemoryProperties const & memoryProperties, uint32_t typeBits, vk::MemoryPropertyFlags requirementsMask );

--- a/snippets/MacrosHppTemplate.hpp
+++ b/snippets/MacrosHppTemplate.hpp
@@ -246,6 +246,14 @@ ${vulkan_64_bit_ptr_defines}
 #  define VULKAN_HPP_NODISCARD_WHEN_NO_EXCEPTIONS
 #endif
 
+#if 17 <= VULKAN_HPP_CPP_VERSION
+#  define VULKAN_HPP_MAYBE_UNUSED [[maybe_unused]]
+#  define VULKAN_HPP_UNUSED( var )
+#else
+#  define VULKAN_HPP_MAYBE_UNUSED
+#  define VULKAN_HPP_UNUSED( var ) ( (void)( var ) )
+#endif
+
 #if !defined( VULKAN_HPP_NAMESPACE )
 #  define VULKAN_HPP_NAMESPACE vk
 #endif

--- a/tests/ArrayProxy/ArrayProxy.cpp
+++ b/tests/ArrayProxy/ArrayProxy.cpp
@@ -28,6 +28,7 @@
 
 #include "../test_macros.hpp"
 #ifdef VULKAN_HPP_USE_CXX_MODULE
+#  include <vulkan/vulkan_hpp_macros.hpp>
 import vulkan;
 #else
 #  include <array>
@@ -37,11 +38,17 @@ import vulkan;
 #endif
 
 
-void fct( vk::ArrayProxy<int> /*ap*/ ) {}
+void fct( VULKAN_HPP_MAYBE_UNUSED vk::ArrayProxy<int> ap )
+{
+  VULKAN_HPP_UNUSED( ap );
+}
 
-void fctc( vk::ArrayProxy<const int> /*ap*/ ) {}
+void fctc( VULKAN_HPP_MAYBE_UNUSED vk::ArrayProxy<const int> ap )
+{
+  VULKAN_HPP_UNUSED( ap );
+}
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/tests/ArrayProxyNoTemporaries/ArrayProxyNoTemporaries.cpp
+++ b/tests/ArrayProxyNoTemporaries/ArrayProxyNoTemporaries.cpp
@@ -28,6 +28,7 @@
 
 #include "../test_macros.hpp"
 #ifdef VULKAN_HPP_USE_CXX_MODULE
+#  include <vulkan/vulkan_hpp_macros.hpp>
 import vulkan;
 #else
 #  include <array>
@@ -37,9 +38,15 @@ import vulkan;
 #endif
 
 
-void fct( vk::ArrayProxyNoTemporaries<int> /*ap*/ ) {}
+void fct( VULKAN_HPP_MAYBE_UNUSED vk::ArrayProxy<int> ap )
+{
+  VULKAN_HPP_UNUSED( ap );
+}
 
-void fctc( vk::ArrayProxyNoTemporaries<const int> /*ap*/ ) {}
+void fctc( VULKAN_HPP_MAYBE_UNUSED vk::ArrayProxy<const int> ap )
+{
+  VULKAN_HPP_UNUSED( ap );
+}
 
 int getInt()
 {
@@ -78,7 +85,7 @@ std::vector<int> const getConstVector()
   return { 1, 2 };
 }
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/tests/ArrayWrapper/ArrayWrapper.cpp
+++ b/tests/ArrayWrapper/ArrayWrapper.cpp
@@ -34,7 +34,7 @@ void f( std::string const & s )
   std::cout << "<" << s << ">" << std::endl;
 }
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   vk::ArrayWrapper1D<char, 10> awc1( { 'f', 'o', 'o', 'b', 'a', 'h' } );
   std::string                  s1 = awc1;

--- a/tests/CppType/CppType.cpp
+++ b/tests/CppType/CppType.cpp
@@ -42,7 +42,7 @@ static_assert( std::is_same<vk::CppType<VkInstance>::Type, vk::Instance>::value,
 
 static_assert( std::is_same<vk::raii::Instance::CppType, vk::Instance>::value, "" );
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   return 0;
 }

--- a/tests/DesignatedInitializers/DesignatedInitializers.cpp
+++ b/tests/DesignatedInitializers/DesignatedInitializers.cpp
@@ -53,7 +53,7 @@ MyVulkanTest::MyVulkanTest()
                                                .apiVersion         = vk::ApiVersion10 };
 }
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   char const * appName       = "DesignatedInitializers";
   uint32_t     appVersion    = 1;
@@ -79,9 +79,9 @@ int main( int /*argc*/, char ** /*argv*/ )
   std::vector<vk::DeviceQueueCreateInfo> queueCreateInfos;
   std::vector<char const *>              extensions;
   vk::DeviceCreateInfo                   info_device{
-                      .queueCreateInfoCount    = (uint32_t)queueCreateInfos.size(),
+                      .queueCreateInfoCount    = static_cast<uint32_t>(queueCreateInfos.size()),
                       .pQueueCreateInfos       = queueCreateInfos.data(),
-                      .enabledExtensionCount   = (uint32_t)extensions.size(),
+                      .enabledExtensionCount   = static_cast<uint32_t>(extensions.size()),
                       .ppEnabledExtensionNames = extensions.data(),
   };
 

--- a/tests/DeviceFunctions/DeviceFunctions.cpp
+++ b/tests/DeviceFunctions/DeviceFunctions.cpp
@@ -50,7 +50,7 @@ std::vector<vk::UniqueHandle<vk::CommandBuffer, Dispatch>, Alloc> createCommandB
   return device.allocateCommandBuffersUnique( allocateInfo, alloc, d );
 }
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/tests/DispatchLoaderDynamic/DispatchLoaderDynamic.cpp
+++ b/tests/DispatchLoaderDynamic/DispatchLoaderDynamic.cpp
@@ -30,7 +30,7 @@ import vulkan;
    VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 #endif
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/tests/DispatchLoaderDynamicSharedLibraryClient/DispatchLoaderDynamicSharedLibraryClient.cpp
+++ b/tests/DispatchLoaderDynamicSharedLibraryClient/DispatchLoaderDynamicSharedLibraryClient.cpp
@@ -24,7 +24,7 @@
 #include <map>
 #include <vulkan/vulkan.hpp>
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/tests/DispatchLoaderStatic/DispatchLoaderStatic.cpp
+++ b/tests/DispatchLoaderStatic/DispatchLoaderStatic.cpp
@@ -26,7 +26,7 @@ import vulkan;
 #endif
 
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/tests/EnableBetaExtensions/EnableBetaExtensions.cpp
+++ b/tests/EnableBetaExtensions/EnableBetaExtensions.cpp
@@ -36,7 +36,7 @@ import vulkan;
   VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 #endif
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   vk::PhysicalDevice physicalDevice;
 

--- a/tests/ExtensionInspection/ExtensionInspection.cpp
+++ b/tests/ExtensionInspection/ExtensionInspection.cpp
@@ -43,7 +43,7 @@ import vulkan;
 #endif
 
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
 #if ( 201907 <= __cpp_constexpr ) && ( !defined( __GNUC__ ) || ( 110400 < GCC_VERSION ) )
   static_assert( vk::isInstanceExtension( vk::KHRSurfaceExtensionName ), "static_assert test failed" );

--- a/tests/Flags/Flags.cpp
+++ b/tests/Flags/Flags.cpp
@@ -41,7 +41,7 @@ import vulkan;
 #endif
 
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   vk::MemoryHeapFlags mhf0;
   release_assert( mhf0.m_mask == 0 );

--- a/tests/FormatTraits/FormatTraits.cpp
+++ b/tests/FormatTraits/FormatTraits.cpp
@@ -27,7 +27,7 @@ import vulkan;
 #endif
 
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
 #if VULKAN_HPP_CPP_VERSION < 14 || defined( VULKAN_HPP_USE_CXX_MODULE )
   release_assert( vk::blockSize( vk::Format::eR4G4UnormPack8 ) == 1 );

--- a/tests/FunctionCalls/FunctionCalls.cpp
+++ b/tests/FunctionCalls/FunctionCalls.cpp
@@ -35,7 +35,7 @@ import vulkan;
 VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 #endif
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   //=== VK_VERSION_1_0 ===
   // Device initialization

--- a/tests/FunctionCallsRAII/FunctionCallsRAII.cpp
+++ b/tests/FunctionCallsRAII/FunctionCallsRAII.cpp
@@ -34,7 +34,7 @@ import vulkan;
 #  include <vulkan/vulkan_raii.hpp>
 #endif
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   //=== VK_VERSION_1_0 ===
   // Device initialization

--- a/tests/Handles/Handles.cpp
+++ b/tests/Handles/Handles.cpp
@@ -25,7 +25,7 @@ import vulkan;
    VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 #endif
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/tests/HandlesMoveExchange/HandlesMoveExchange.cpp
+++ b/tests/HandlesMoveExchange/HandlesMoveExchange.cpp
@@ -21,7 +21,7 @@ import vulkan;
    VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 #endif
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/tests/Hash/Hash.cpp
+++ b/tests/Hash/Hash.cpp
@@ -45,7 +45,7 @@ import vulkan;
 static char const * AppName    = "Hash";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/tests/NoDefaultDispatcher/NoDefaultDispatcher.cpp
+++ b/tests/NoDefaultDispatcher/NoDefaultDispatcher.cpp
@@ -24,7 +24,7 @@ import vulkan;
 #  include <vulkan/vulkan_shared.hpp>
 #endif
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   return 0;
 }

--- a/tests/NoExceptions/NoExceptions.cpp
+++ b/tests/NoExceptions/NoExceptions.cpp
@@ -37,7 +37,7 @@ import vulkan;
 static char const * AppName    = "NoExceptions";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   vk::detail::defaultDispatchLoaderDynamic.init();
 

--- a/tests/NoExceptionsRAII/NoExceptionsRAII.cpp
+++ b/tests/NoExceptionsRAII/NoExceptionsRAII.cpp
@@ -31,7 +31,7 @@ import vulkan;
 static char const * AppName    = "NoExceptions";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
 #if defined( VULKAN_HPP_NO_EXCEPTIONS )
   vk::raii::Context context;

--- a/tests/NoSmartHandle/NoSmartHandle.cpp
+++ b/tests/NoSmartHandle/NoSmartHandle.cpp
@@ -21,7 +21,7 @@ import vulkan;
 #  include <vulkan/vulkan_shared.hpp>
 #endif
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   return 0;
 }

--- a/tests/Reflection/Reflection.cpp
+++ b/tests/Reflection/Reflection.cpp
@@ -41,7 +41,7 @@ import vulkan;
 static char const * AppName    = "StructureChain";
 static char const * EngineName = "Vulkan.hpp";
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   vk::AabbPositionsKHR a;
   auto                 ra = a.reflect();

--- a/tests/StridedArrayProxy/StridedArrayProxy.cpp
+++ b/tests/StridedArrayProxy/StridedArrayProxy.cpp
@@ -38,11 +38,17 @@ import vulkan;
 #endif
 
 
-void fct( vk::StridedArrayProxy<int> /*ap*/ ) {}
+void fct( VULKAN_HPP_MAYBE_UNUSED vk::ArrayProxy<int> ap )
+{
+  VULKAN_HPP_UNUSED( ap );
+}
 
-void fctc( vk::StridedArrayProxy<const int> /*ap*/ ) {}
+void fctc( VULKAN_HPP_MAYBE_UNUSED vk::ArrayProxy<const int> ap )
+{
+  VULKAN_HPP_UNUSED( ap );
+}
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/tests/StructureChain/StructureChain.cpp
+++ b/tests/StructureChain/StructureChain.cpp
@@ -34,6 +34,7 @@
 
 #include "../test_macros.hpp"
 #ifdef VULKAN_HPP_USE_CXX_MODULE
+#  include <vulkan/vulkan_hpp_macros.hpp>
 import vulkan;
 #else
 #  include <iostream>
@@ -44,17 +45,12 @@ VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 static char const * AppName    = "StructureChain";
 static char const * EngineName = "Vulkan.hpp";
 
-template <typename T>
-void unused( T const & )
+void test( VULKAN_HPP_MAYBE_UNUSED std::tuple<vk::InstanceCreateInfo, vk::DebugUtilsMessengerCreateInfoEXT> const & cis )
 {
+  VULKAN_HPP_UNUSED( cis );
 }
 
-void test( std::tuple<vk::InstanceCreateInfo, vk::DebugUtilsMessengerCreateInfoEXT> const & cis )
-{
-  unused( cis );
-}
-
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {
@@ -69,7 +65,7 @@ int main( int /*argc*/, char ** /*argv*/ )
     vk::StructureChain<vk::PhysicalDeviceProperties2>                                       sc0;
     vk::StructureChain<vk::PhysicalDeviceProperties2, vk::PhysicalDeviceIDProperties> const sc1;
     auto                                                                                    pdp = sc1.get<vk::PhysicalDeviceProperties2>();
-    unused( pdp );
+    VULKAN_HPP_UNUSED( pdp );
     vk::StructureChain<vk::PhysicalDeviceProperties2, vk::PhysicalDeviceMaintenance3Properties>                                      sc2;
     vk::StructureChain<vk::PhysicalDeviceProperties2, vk::PhysicalDevicePushDescriptorPropertiesKHR>                                 sc3;
     vk::StructureChain<vk::PhysicalDeviceProperties2, vk::PhysicalDeviceIDProperties, vk::PhysicalDeviceMaintenance3Properties>      sc4;
@@ -146,28 +142,28 @@ int main( int /*argc*/, char ** /*argv*/ )
 
     // simple calls, getting structure back
     vk::PhysicalDeviceFeatures2 a = physicalDevice.getFeatures2();
-    unused( a );
+    VULKAN_HPP_UNUSED( a );
 
     // complex calls, getting StructureChain back
     auto                          c  = physicalDevice.getFeatures2<vk::PhysicalDeviceFeatures2, vk::PhysicalDeviceVariablePointerFeatures>();
     vk::PhysicalDeviceFeatures2 & c0 = c.get<vk::PhysicalDeviceFeatures2>();
-    unused( c0 );
+    VULKAN_HPP_UNUSED( c0 );
 
     auto t0 = c.get<vk::PhysicalDeviceFeatures2, vk::PhysicalDeviceVariablePointerFeatures>();
-    unused( t0 );
+    VULKAN_HPP_UNUSED( t0 );
 
     auto                          d  = physicalDevice.getFeatures2<vk::PhysicalDeviceFeatures2, vk::PhysicalDeviceVariablePointerFeatures>();
     vk::PhysicalDeviceFeatures2 & d0 = d.get<vk::PhysicalDeviceFeatures2>();
-    unused( d0 );
+    VULKAN_HPP_UNUSED( d0 );
     vk::PhysicalDeviceVariablePointerFeatures & d1 = d.get<vk::PhysicalDeviceVariablePointerFeatures>();
-    unused( d1 );
+    VULKAN_HPP_UNUSED( d1 );
 
     auto t1 = d.get<vk::PhysicalDeviceFeatures2, vk::PhysicalDeviceVariablePointerFeatures>();
-    unused( t1 );
+    VULKAN_HPP_UNUSED( t1 );
 
     using StructureChain = vk::StructureChain<vk::QueueFamilyProperties2, vk::QueueFamilyCheckpointPropertiesNV>;
     auto qfd             = physicalDevice.getQueueFamilyProperties2<StructureChain>( vk::detail::defaultDispatchLoaderDynamic );
-    unused( qfd );
+    VULKAN_HPP_UNUSED( qfd );
 
     // some tests with structures with allowDuplicate == true
     vk::StructureChain<vk::DeviceCreateInfo, vk::DevicePrivateDataCreateInfoEXT, vk::DevicePrivateDataCreateInfoEXT> dci0;

--- a/tests/UniqueHandle/UniqueHandle.cpp
+++ b/tests/UniqueHandle/UniqueHandle.cpp
@@ -21,6 +21,8 @@
 #include "glslang/SPIRV/GlslangToSpv.h"
 #include "glslang/Public/ShaderLang.h"
 
+#include <vulkan/vulkan_hpp_macros.hpp>
+
 #include <iostream>
 
 static std::string AppName    = "UniqueHandle";
@@ -33,8 +35,9 @@ public:
   MyAllocator() = default;
 
   template <class U>
-  MyAllocator( const MyAllocator<U> & /*unused*/ )
+  MyAllocator( VULKAN_HPP_MAYBE_UNUSED MyAllocator<U> const & unused )
   {
+    VULKAN_HPP_UNUSED( unused );
   }
 
   template <class U>
@@ -210,7 +213,7 @@ vk::UniqueSwapchainKHR createSwapchainKHRUnique( vk::PhysicalDevice physicalDevi
   return device->createSwapchainKHRUnique( swapChainCreateInfo );
 }
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   try
   {

--- a/tests/UniqueHandleDefaultArguments/UniqueHandleDefaultArguments.cpp
+++ b/tests/UniqueHandleDefaultArguments/UniqueHandleDefaultArguments.cpp
@@ -25,7 +25,7 @@ import vulkan;
    VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
 #endif
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   VkSurfaceKHR surface       = 0;
   auto         uniqueSurface = vk::UniqueSurfaceKHR( static_cast<vk::SurfaceKHR>( surface ), vk::Instance() );

--- a/tests/Video/Video.cpp
+++ b/tests/Video/Video.cpp
@@ -34,7 +34,7 @@ import vulkan_video;
 #endif
 
 
-int main( int /*argc*/, char ** /*argv*/ )
+int main()
 {
   vk::video::H264ChromaFormatIdc x;
   vk::video::H264ProfileIdc      y;

--- a/tests/test_macros.hpp
+++ b/tests/test_macros.hpp
@@ -10,3 +10,4 @@
       std::abort();                                                                                    \
     }                                                                                                  \
   } while ( false )
+

--- a/vulkan/vulkan_hpp_macros.hpp
+++ b/vulkan/vulkan_hpp_macros.hpp
@@ -263,6 +263,14 @@ VULKAN_HPP_COMPILE_WARNING( "This is a non-conforming implementation of C++ name
 #  define VULKAN_HPP_NODISCARD_WHEN_NO_EXCEPTIONS
 #endif
 
+#if 17 <= VULKAN_HPP_CPP_VERSION
+#  define VULKAN_HPP_MAYBE_UNUSED [[maybe_unused]]
+#  define VULKAN_HPP_UNUSED( var )
+#else
+#  define VULKAN_HPP_MAYBE_UNUSED
+#  define VULKAN_HPP_UNUSED( var ) ( (void)( var ) )
+#endif
+
 #if !defined( VULKAN_HPP_NAMESPACE )
 #  define VULKAN_HPP_NAMESPACE vk
 #endif


### PR DESCRIPTION
Across tests, a lot of `main()` functions had commented-out parameters (like `int main(int /*argc*/, char** /*argv*/)`). Since these parameters aren't going to be used anyway, we should just make these simply `int main()`. I have also replaced function signatures using commented-out parameters to use the `[[maybe_unused]]` attribute, which is clearer and more consistent with modern C++.