### PR TITLE
Add spaceship operator for vk handles

### DIFF
--- a/snippets/HandlesHppTemplate.hpp
+++ b/snippets/HandlesHppTemplate.hpp
@@ -26,6 +26,13 @@ VULKAN_HPP_EXPORT namespace VULKAN_HPP_NAMESPACE
     return static_cast<typename T::NativeType>( lhs ) != static_cast<typename T::NativeType>( rhs );
   }
 
+#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
+  template <typename T, typename std::enable_if<isVulkanHandleType<T>::value, int>::type = 0>
+  auto operator<=>( T const & lhs, T const & rhs )
+  {
+    return static_cast<typename T::NativeType>( lhs ) <=> static_cast<typename T::NativeType>( rhs );
+  }
+#else
   template <typename T, typename std::enable_if<isVulkanHandleType<T>::value, int>::type = 0>
   bool operator<( T const & lhs, T const & rhs )
   {
@@ -49,6 +56,7 @@ VULKAN_HPP_EXPORT namespace VULKAN_HPP_NAMESPACE
   {
     return static_cast<typename T::NativeType>( lhs ) >= static_cast<typename T::NativeType>( rhs );
   }
+#endif
 
   template <typename T, typename std::enable_if<isVulkanHandleType<T>::value, int>::type = 0>
   bool operator==( T const & v, std::nullptr_t )

--- a/vulkan/vulkan_handles.hpp
+++ b/vulkan/vulkan_handles.hpp
@@ -22649,6 +22649,13 @@ VULKAN_HPP_EXPORT namespace VULKAN_HPP_NAMESPACE
     return static_cast<typename T::NativeType>( lhs ) != static_cast<typename T::NativeType>( rhs );
   }
 
+#if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
+  template <typename T, typename std::enable_if<isVulkanHandleType<T>::value, int>::type = 0>
+  auto operator<=>( T const & lhs, T const & rhs )
+  {
+    return static_cast<typename T::NativeType>( lhs ) <=> static_cast<typename T::NativeType>( rhs );
+  }
+#else
   template <typename T, typename std::enable_if<isVulkanHandleType<T>::value, int>::type = 0>
   bool operator<( T const & lhs, T const & rhs )
   {
@@ -22672,6 +22679,7 @@ VULKAN_HPP_EXPORT namespace VULKAN_HPP_NAMESPACE
   {
     return static_cast<typename T::NativeType>( lhs ) >= static_cast<typename T::NativeType>( rhs );
   }
+#endif
 
   template <typename T, typename std::enable_if<isVulkanHandleType<T>::value, int>::type = 0>
   bool operator==( T const & v, std::nullptr_t )


### PR DESCRIPTION
Some comparisons rely on implicit conversions (#2001), which do not work when `VULKAN_HPP_TYPESAFE_CONVERSION=0` (which is default on 32-bit platforms).
Specifically, compilation fails with `VULKAN_HPP_TYPESAFE_CONVERSION=0` and `VULKAN_HPP_HAS_SPACESHIP_OPERATOR`, because structs try to use the spaceship operator for comparing their member handles.
For instance, vk::PipelineShaderStageCreateInfo:
```
vulkan/vulkan_structs.hpp(27059): error C2678: binary '<=>': no operator found which takes a left-hand operand of type 'const vk::ShaderModule' (or there is no acceptable conversion)
vulkan/vulkan_structs.hpp(27059): note: could be 'built-in C++ operator<=>(int, int)'
vulkan/vulkan_structs.hpp(27059): note: '<=>': cannot convert argument 1 from 'const vk::ShaderModule' to 'int'
vulkan/vulkan_structs.hpp(27059): note: or       'built-in C++ operator<=>(VkShaderModule, VkShaderModule)'
vulkan/vulkan_structs.hpp(27059): note: '<=>': cannot convert argument 1 from 'const vk::ShaderModule' to 'VkShaderModule'
```

Note that I did not run the generator - clang-format gave me a crazy diff for some reason, so I patched `vulkan_handles.hpp` by hand.