### PR TITLE
Fixed incorrect GCC version checks causing issues with GCC 11.5

### DIFF
--- a/generator/snippets/MacrosHppTemplate.hpp
+++ b/generator/snippets/MacrosHppTemplate.hpp
@@ -188,7 +188,7 @@ ${vulkan_64_bit_ptr_defines}
 #  else
 #    define VULKAN_HPP_CONSTEXPR_17
 #  endif
-#  if ( 201907 <= __cpp_constexpr ) && ( !defined( __GNUC__ ) || ( 110400 < GCC_VERSION ) )
+#  if ( 201907 <= __cpp_constexpr ) && ( !defined( __GNUC__ ) || ( 120000 <= GCC_VERSION ) )
 #    define VULKAN_HPP_CONSTEXPR_20 constexpr
 #  else
 #    define VULKAN_HPP_CONSTEXPR_20

--- a/tests/ExtensionInspection/ExtensionInspection.cpp
+++ b/tests/ExtensionInspection/ExtensionInspection.cpp
@@ -45,7 +45,7 @@ import vulkan;
 
 int main()
 {
-#if ( 201907 <= __cpp_constexpr ) && ( !defined( __GNUC__ ) || ( 110400 < GCC_VERSION ) )
+#if ( 201907 <= __cpp_constexpr ) && ( !defined( __GNUC__ ) || ( 120000 <= GCC_VERSION ) )
   static_assert( vk::isInstanceExtension( vk::KHRSurfaceExtensionName ), "static_assert test failed" );
   static_assert( vk::isDeviceExtension( vk::KHRSwapchainExtensionName ), "static assert test failed" );
   static_assert( vk::isDeprecatedExtension( vk::EXTDebugReportExtensionName ), "static assert test failed" );

--- a/vulkan/vulkan_hpp_macros.hpp
+++ b/vulkan/vulkan_hpp_macros.hpp
@@ -198,7 +198,7 @@ VULKAN_HPP_COMPILE_WARNING( "This is a non-conforming implementation of C++ name
 #  else
 #    define VULKAN_HPP_CONSTEXPR_17
 #  endif
-#  if ( 201907 <= __cpp_constexpr ) && ( !defined( __GNUC__ ) || ( 110400 < GCC_VERSION ) )
+#  if ( 201907 <= __cpp_constexpr ) && ( !defined( __GNUC__ ) || ( 120000 <= GCC_VERSION ) )
 #    define VULKAN_HPP_CONSTEXPR_20 constexpr
 #  else
 #    define VULKAN_HPP_CONSTEXPR_20


### PR DESCRIPTION
Currently, there are preprocessor checks which test if the current GCC version is greater than 11.4, presumably in an effort to check for GCC 12 and later. Unfortunately, GCC 11.5 was released after this check was added, and was never accounted for. This means that if you attempt to build with the Vulkan headers using GCC 11.5, the headers use features which are only available in GCC 12, resulting in a torrent of errors such as this:

```
/mnt/externals/./vulkan-headers/include/vulkan/vulkan_to_string.hpp: In function 'constexpr std::string vk::to_string(vk::DepthClampModeEXT)':
/mnt/externals/./vulkan-headers/include/vulkan/vulkan_to_string.hpp:10063:57: error: invalid return type 'std::string' {aka 'std::__cxx11::basic_string<char>'} of 'constexpr' function 'constexpr std::string vk::to_string(vk::DepthClampModeEXT)'
10063 |   VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_20 std::string to_string( DepthClampModeEXT value )
      |                                                         ^~~~~~~~~
```

To fix this, I've changed these checks to instead simply test for GCC 12 and later. After applying this change, everything works as expected on my end when building with GCC 11.5.