### PR TITLE
Generator: Added license headers to generators and snippets

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -11,7 +11,7 @@ path = [
 
     ".github/workflows/**",
     "docs/**",
-    "generator/**",
+    "generator/.clang-format_*",
     "RAII_Samples/**",
     "samples/**",
     "tests/**",

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -3,19 +3,18 @@ version = 1
 # ---- Repo infrastructure and documentation ----
 
 [[annotations]]
-path = "**"
-SPDX-FileCopyrightText = "The Khronos Group Inc."
-SPDX-License-Identifier = "Apache-2.0 OR MIT"
-
-[[annotations]]
 path = [
-"generator/**",
-"tests/**",
-"samples/**",
-"RAII_Samples/**",
-"CMakeLists.txt",
-"CmakePresets.json",
-"VulkanHpp.natvis",
+    ".gitmodules",
+    "CMakeLists.txt",
+    "CMakePresets.json",
+    "VulkanHpp.natvis",
+
+    ".github/workflows/**",
+    "docs/**",
+    "generator/**",
+    "RAII_Samples/**",
+    "samples/**",
+    "tests/**",
 ]
 SPDX-FileCopyrightText = "NVIDIA Corporation"
 SPDX-License-Identifier = "Apache-2.0"

--- a/generator/VideoHppGenerator.cpp
+++ b/generator/VideoHppGenerator.cpp
@@ -1,16 +1,5 @@
-// Copyright(c) 2023, NVIDIA CORPORATION. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2023-2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
 
 #include "VideoHppGenerator.hpp"
 

--- a/generator/VideoHppGenerator.hpp
+++ b/generator/VideoHppGenerator.hpp
@@ -1,16 +1,5 @@
-// Copyright(c) 2023, NVIDIA CORPORATION. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2023-2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/generator/VkXMLParser.cpp
+++ b/generator/VkXMLParser.cpp
@@ -1,16 +1,5 @@
-// Copyright(c) 2026, NVIDIA CORPORATION. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
 
 #include "VkXMLParser.hpp"
 

--- a/generator/VkXMLParser.hpp
+++ b/generator/VkXMLParser.hpp
@@ -1,16 +1,5 @@
-// Copyright(c) 2026, NVIDIA CORPORATION. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/generator/VulkanHppGenerator.cpp
+++ b/generator/VulkanHppGenerator.cpp
@@ -1,16 +1,5 @@
-// Copyright(c) 2015-2020, NVIDIA CORPORATION. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2015-2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
 
 #include "VulkanHppGenerator.hpp"
 

--- a/generator/VulkanHppGenerator.hpp
+++ b/generator/VulkanHppGenerator.hpp
@@ -1,16 +1,5 @@
-// Copyright(c) 2015-2019, NVIDIA CORPORATION. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2015-2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/generator/XMLHelper.hpp
+++ b/generator/XMLHelper.hpp
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <assert.h>
-#include <format>
 #include <fstream>
 #include <iostream>
 #include <map>
@@ -429,7 +428,7 @@ inline std::string readSnippet( std::string const & snippetFile )
     }
     if ( !compliant )
     {
-      throw std::runtime_error( std::format( "The snippet {} contains a broken license header", snippetFile ) );
+      throw std::runtime_error( "The snippet " + snippetFile + " contains a broken license header" );
     }
   }
   // return the remainder of the snippet

--- a/generator/XMLHelper.hpp
+++ b/generator/XMLHelper.hpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <assert.h>
+#include <format>
 #include <fstream>
 #include <iostream>
 #include <map>
@@ -411,13 +412,25 @@ inline std::string readSnippet( std::string const & snippetFile )
 {
   std::ifstream ifs( std::string( BASE_PATH ) + "/generator/snippets/" + snippetFile );
   assert( !ifs.fail() );
-  // skip the snippet license header (3 loc)
+  // skip the snippet license header and validate its contents
   std::string line;
   for ( uint32_t i = 0; i < 3; i++ )
   {
-    std::getline(ifs, line);
+    bool compliant = true;
+    std::getline( ifs, line );
+    switch ( i )
+    {
+      case 0: compliant = line.starts_with( "// SPDX-FileCopyrightText:" ); break;
+      case 1: compliant = line.starts_with( "// SPDX-License-Identifier:" ); break;
+      case 2: compliant = line.empty(); break;
+      default: compliant = false; // unreachable
+    }
+    if ( !compliant )
+    {
+      throw std::runtime_error( std::format( "The snippet {} contains a broken license header", snippetFile ) );
+    }
   }
-  // return the remainder
+  // return the remainder of the snippet
   std::ostringstream oss;
   oss << ifs.rdbuf();
   return oss.str();

--- a/generator/XMLHelper.hpp
+++ b/generator/XMLHelper.hpp
@@ -1,16 +1,5 @@
-// Copyright(c) 2023, NVIDIA CORPORATION. All rights reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-FileCopyrightText: 2023 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/generator/XMLHelper.hpp
+++ b/generator/XMLHelper.hpp
@@ -422,6 +422,13 @@ inline std::string readSnippet( std::string const & snippetFile )
 {
   std::ifstream ifs( std::string( BASE_PATH ) + "/generator/snippets/" + snippetFile );
   assert( !ifs.fail() );
+  // skip the snippet license header (3 loc)
+  std::string line;
+  for ( uint32_t i = 0; i < 3; i++ )
+  {
+    std::getline(ifs, line);
+  }
+  // return the remainder
   std::ostringstream oss;
   oss << ifs.rdbuf();
   return oss.str();

--- a/generator/XMLHelper.hpp
+++ b/generator/XMLHelper.hpp
@@ -420,10 +420,12 @@ inline std::string readSnippet( std::string const & snippetFile )
     std::getline( ifs, line );
     switch ( i )
     {
+      // REUSE-IgnoreStart
       case 0: compliant = line.starts_with( "// SPDX-FileCopyrightText:" ); break;
       case 1: compliant = line.starts_with( "// SPDX-License-Identifier:" ); break;
       case 2: compliant = line.empty(); break;
       default: compliant = false; // unreachable
+      // REUSE-IgnoreEnd
     }
     if ( !compliant )
     {

--- a/generator/snippets/ArrayProxy.hpp
+++ b/generator/snippets/ArrayProxy.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
   template <typename T>
   class ArrayProxy
   {

--- a/generator/snippets/ArrayProxyNoTemporaries.hpp
+++ b/generator/snippets/ArrayProxyNoTemporaries.hpp
@@ -1,105 +1,108 @@
-  template <typename T>
-  class ArrayProxyNoTemporaries
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+template <typename T>
+class ArrayProxyNoTemporaries
+{
+public:
+  VULKAN_HPP_CONSTEXPR ArrayProxyNoTemporaries() VULKAN_HPP_NOEXCEPT
+    : m_count( 0 )
+    , m_ptr( nullptr )
   {
-  public:
-    VULKAN_HPP_CONSTEXPR ArrayProxyNoTemporaries() VULKAN_HPP_NOEXCEPT
-      : m_count( 0 )
-      , m_ptr( nullptr )
-    {
-    }
+  }
 
-    VULKAN_HPP_CONSTEXPR ArrayProxyNoTemporaries( std::nullptr_t ) VULKAN_HPP_NOEXCEPT
-      : m_count( 0 )
-      , m_ptr( nullptr )
-    {
-    }
+  VULKAN_HPP_CONSTEXPR ArrayProxyNoTemporaries( std::nullptr_t ) VULKAN_HPP_NOEXCEPT
+    : m_count( 0 )
+    , m_ptr( nullptr )
+  {
+  }
 
-    template <typename B = T, typename std::enable_if<std::is_convertible<B, T>::value && std::is_lvalue_reference<B>::value, int>::type = 0>
-    ArrayProxyNoTemporaries( B && value ) VULKAN_HPP_NOEXCEPT
-      : m_count( 1 )
-      , m_ptr( &value )
-    {
-    }
+  template <typename B = T, typename std::enable_if<std::is_convertible<B, T>::value && std::is_lvalue_reference<B>::value, int>::type = 0>
+  ArrayProxyNoTemporaries( B && value ) VULKAN_HPP_NOEXCEPT
+    : m_count( 1 )
+    , m_ptr( &value )
+  {
+  }
 
-    ArrayProxyNoTemporaries( uint32_t count, T * ptr ) VULKAN_HPP_NOEXCEPT
-      : m_count( count )
-      , m_ptr( ptr )
-    {
-    }
+  ArrayProxyNoTemporaries( uint32_t count, T * ptr ) VULKAN_HPP_NOEXCEPT
+    : m_count( count )
+    , m_ptr( ptr )
+  {
+  }
 
-    template <std::size_t C>
-    ArrayProxyNoTemporaries( T ( &ptr )[C] ) VULKAN_HPP_NOEXCEPT
-      : m_count( C )
-      , m_ptr( ptr )
-    {
-    }
+  template <std::size_t C>
+  ArrayProxyNoTemporaries( T ( &ptr )[C] ) VULKAN_HPP_NOEXCEPT
+    : m_count( C )
+    , m_ptr( ptr )
+  {
+  }
 
-    template <std::size_t C>
-    ArrayProxyNoTemporaries( T ( &&ptr )[C] ) = delete;
+  template <std::size_t C>
+  ArrayProxyNoTemporaries( T ( &&ptr )[C] ) = delete;
 
-    // Any l-value reference with a .data() return type implicitly convertible to T*, and a .size() return type implicitly convertible to size_t.
-    template <typename V,
-              typename std::enable_if<!std::is_convertible<decltype( std::declval<V>().begin() ), T *>::value &&
-                                        std::is_convertible<decltype( std::declval<V>().data() ), T *>::value &&
-                                        std::is_convertible<decltype( std::declval<V>().size() ), std::size_t>::value &&
-                                        std::is_lvalue_reference<V>::value,
-                                      int>::type = 0>
-    ArrayProxyNoTemporaries( V && v ) VULKAN_HPP_NOEXCEPT
-      : m_count( static_cast<uint32_t>( v.size() ) )
-      , m_ptr( v.data() )
-    {
-    }
+  // Any l-value reference with a .data() return type implicitly convertible to T*, and a .size() return type implicitly convertible to size_t.
+  template <typename V,
+            typename std::enable_if<!std::is_convertible<decltype( std::declval<V>().begin() ), T *>::value &&
+                                      std::is_convertible<decltype( std::declval<V>().data() ), T *>::value &&
+                                      std::is_convertible<decltype( std::declval<V>().size() ), std::size_t>::value &&
+                                      std::is_lvalue_reference<V>::value,
+                                    int>::type = 0>
+  ArrayProxyNoTemporaries( V && v ) VULKAN_HPP_NOEXCEPT
+    : m_count( static_cast<uint32_t>( v.size() ) )
+    , m_ptr( v.data() )
+  {
+  }
 
-    // Any l-value reference with a .begin() return type implicitly convertible to T*, and a .size() return type implicitly convertible to size_t.
-    template <typename V,
-              typename std::enable_if<std::is_convertible<decltype( std::declval<V>().begin() ), T *>::value &&
-                                        std::is_convertible<decltype( std::declval<V>().size() ), std::size_t>::value &&
-                                        std::is_lvalue_reference<V>::value,
-                                      int>::type = 0>
-    ArrayProxyNoTemporaries( V && v ) VULKAN_HPP_NOEXCEPT
-      : m_count( static_cast<uint32_t>( v.size() ) )
-      , m_ptr( v.begin() )
-    {
-    }
+  // Any l-value reference with a .begin() return type implicitly convertible to T*, and a .size() return type implicitly convertible to size_t.
+  template <typename V,
+            typename std::enable_if<std::is_convertible<decltype( std::declval<V>().begin() ), T *>::value &&
+                                      std::is_convertible<decltype( std::declval<V>().size() ), std::size_t>::value &&
+                                      std::is_lvalue_reference<V>::value,
+                                    int>::type = 0>
+  ArrayProxyNoTemporaries( V && v ) VULKAN_HPP_NOEXCEPT
+    : m_count( static_cast<uint32_t>( v.size() ) )
+    , m_ptr( v.begin() )
+  {
+  }
 
-    T const * begin() const VULKAN_HPP_NOEXCEPT
-    {
-      return m_ptr;
-    }
+  T const * begin() const VULKAN_HPP_NOEXCEPT
+  {
+    return m_ptr;
+  }
 
-    T const * end() const VULKAN_HPP_NOEXCEPT
-    {
-      return m_ptr + m_count;
-    }
+  T const * end() const VULKAN_HPP_NOEXCEPT
+  {
+    return m_ptr + m_count;
+  }
 
-    T const & front() const VULKAN_HPP_NOEXCEPT
-    {
-      VULKAN_HPP_ASSERT( m_count && m_ptr );
-      return *m_ptr;
-    }
+  T const & front() const VULKAN_HPP_NOEXCEPT
+  {
+    VULKAN_HPP_ASSERT( m_count && m_ptr );
+    return *m_ptr;
+  }
 
-    T const & back() const VULKAN_HPP_NOEXCEPT
-    {
-      VULKAN_HPP_ASSERT( m_count && m_ptr );
-      return *( m_ptr + m_count - 1 );
-    }
+  T const & back() const VULKAN_HPP_NOEXCEPT
+  {
+    VULKAN_HPP_ASSERT( m_count && m_ptr );
+    return *( m_ptr + m_count - 1 );
+  }
 
-    bool empty() const VULKAN_HPP_NOEXCEPT
-    {
-      return ( m_count == 0 );
-    }
+  bool empty() const VULKAN_HPP_NOEXCEPT
+  {
+    return ( m_count == 0 );
+  }
 
-    uint32_t size() const VULKAN_HPP_NOEXCEPT
-    {
-      return m_count;
-    }
+  uint32_t size() const VULKAN_HPP_NOEXCEPT
+  {
+    return m_count;
+  }
 
-    T * data() const VULKAN_HPP_NOEXCEPT
-    {
-      return m_ptr;
-    }
+  T * data() const VULKAN_HPP_NOEXCEPT
+  {
+    return m_ptr;
+  }
 
-  private:
-    uint32_t m_count;
-    T *      m_ptr;
-  };
+private:
+  uint32_t m_count;
+  T *      m_ptr;
+};

--- a/generator/snippets/ArrayWrapper1D.hpp
+++ b/generator/snippets/ArrayWrapper1D.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 template <typename T, size_t N>
 class ArrayWrapper1D : public std::array<T, N>
 {

--- a/generator/snippets/ArrayWrapper2D.hpp
+++ b/generator/snippets/ArrayWrapper2D.hpp
@@ -1,12 +1,15 @@
-  template <typename T, size_t N, size_t M>
-  class ArrayWrapper2D : public std::array<ArrayWrapper1D<T, M>, N>
-  {
-  public:
-    VULKAN_HPP_CONSTEXPR ArrayWrapper2D() VULKAN_HPP_NOEXCEPT
-      : std::array<ArrayWrapper1D<T, M>, N>()
-    {}
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
 
-    VULKAN_HPP_CONSTEXPR ArrayWrapper2D( std::array<std::array<T, M>, N> const & data ) VULKAN_HPP_NOEXCEPT
-      : std::array<ArrayWrapper1D<T, M>, N>( *reinterpret_cast<std::array<ArrayWrapper1D<T, M>, N> const *>( &data ) )
-    {}
-  };
+template <typename T, size_t N, size_t M>
+class ArrayWrapper2D : public std::array<ArrayWrapper1D<T, M>, N>
+{
+public:
+  VULKAN_HPP_CONSTEXPR ArrayWrapper2D() VULKAN_HPP_NOEXCEPT
+    : std::array<ArrayWrapper1D<T, M>, N>()
+  {}
+
+  VULKAN_HPP_CONSTEXPR ArrayWrapper2D( std::array<std::array<T, M>, N> const & data ) VULKAN_HPP_NOEXCEPT
+    : std::array<ArrayWrapper1D<T, M>, N>( *reinterpret_cast<std::array<ArrayWrapper1D<T, M>, N> const *>( &data ) )
+  {}
+};

--- a/generator/snippets/CppmTemplate.hpp
+++ b/generator/snippets/CppmTemplate.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 ${copyrightMessage}
 
 module;

--- a/generator/snippets/DispatchLoaderBase.hpp
+++ b/generator/snippets/DispatchLoaderBase.hpp
@@ -1,23 +1,26 @@
-  class DispatchLoaderBase
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+class DispatchLoaderBase
+{
+public:
+  DispatchLoaderBase() = default;
+  DispatchLoaderBase( std::nullptr_t )
+#if !defined( NDEBUG )
+    : m_valid( false )
+#endif
+  {}
+
+#if !defined( NDEBUG )
+  size_t getVkHeaderVersion() const
   {
-  public:
-    DispatchLoaderBase() = default;
-    DispatchLoaderBase( std::nullptr_t )
-#if !defined( NDEBUG )
-      : m_valid( false )
-#endif
-    {}
+    VULKAN_HPP_ASSERT( m_valid );
+    return vkHeaderVersion;
+  }
 
-#if !defined( NDEBUG )
-    size_t getVkHeaderVersion() const
-    {
-      VULKAN_HPP_ASSERT( m_valid );
-      return vkHeaderVersion;
-    }
-
-  private:
-    size_t vkHeaderVersion = VK_HEADER_VERSION;
-    bool   m_valid         = true;
+private:
+  size_t vkHeaderVersion = VK_HEADER_VERSION;
+  bool   m_valid         = true;
 #endif
-  };
+};
   

--- a/generator/snippets/DynamicLoader.hpp
+++ b/generator/snippets/DynamicLoader.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 #if VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL
   class DynamicLoader
   {

--- a/generator/snippets/EnumsHppTemplate.hpp
+++ b/generator/snippets/EnumsHppTemplate.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 ${copyrightMessage}
 
 #ifndef VULKAN_ENUMS_HPP

--- a/generator/snippets/Exceptions.hpp
+++ b/generator/snippets/Exceptions.hpp
@@ -1,69 +1,72 @@
-  class ErrorCategoryImpl : public std::error_category
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+class ErrorCategoryImpl : public std::error_category
+{
+  public:
+  virtual char const * name() const VULKAN_HPP_NOEXCEPT override { return VULKAN_HPP_NAMESPACE_STRING"::Result"; }
+  virtual std::string message(int ev) const override
   {
-    public:
-    virtual char const * name() const VULKAN_HPP_NOEXCEPT override { return VULKAN_HPP_NAMESPACE_STRING"::Result"; }
-    virtual std::string message(int ev) const override
-    {
 #if defined( VULKAN_HPP_NO_TO_STRING )
-      return std::to_string( ev );
+    return std::to_string( ev );
 #else
-      return to_string(static_cast<Result>(ev));
+    return to_string(static_cast<Result>(ev));
 #endif
-    }
-  };
-
-  class Error
-  {
-    public:
-    Error() VULKAN_HPP_NOEXCEPT              = default;
-    Error(Error const &) VULKAN_HPP_NOEXCEPT = default;
-    virtual ~Error() VULKAN_HPP_NOEXCEPT     = default;
-
-    virtual char const * what() const VULKAN_HPP_NOEXCEPT = 0;
-  };
-
-  class LogicError : public Error, public std::logic_error
-  {
-    public:
-    explicit LogicError( std::string const & what )
-      : Error(), std::logic_error(what) {}
-    explicit LogicError( char const * what )
-      : Error(), std::logic_error(what) {}
-
-    virtual char const * what() const VULKAN_HPP_NOEXCEPT { return std::logic_error::what(); }
-  };
-
-  class SystemError : public Error, public std::system_error
-  {
-    public:
-    SystemError( std::error_code ec )
-      : Error(), std::system_error(ec) {}
-    SystemError( std::error_code ec, std::string const & what )
-      : Error(), std::system_error(ec, what) {}
-    SystemError( std::error_code ec, char const * what )
-      : Error(), std::system_error(ec, what) {}
-    SystemError( int ev, std::error_category const & ecat )
-      : Error(), std::system_error(ev, ecat) {}
-    SystemError( int ev, std::error_category const & ecat, std::string const & what)
-      : Error(), std::system_error(ev, ecat, what) {}
-    SystemError( int ev, std::error_category const & ecat, char const * what)
-      : Error(), std::system_error(ev, ecat, what) {}
-
-    virtual char const * what() const VULKAN_HPP_NOEXCEPT { return std::system_error::what(); }
-  };
-
-  VULKAN_HPP_INLINE std::error_category const & errorCategory() VULKAN_HPP_NOEXCEPT
-  {
-    static ErrorCategoryImpl instance;
-    return instance;
   }
+};
 
-  VULKAN_HPP_INLINE std::error_code make_error_code(Result e) VULKAN_HPP_NOEXCEPT
-  {
-    return std::error_code(static_cast<int>(e), errorCategory());
-  }
+class Error
+{
+  public:
+  Error() VULKAN_HPP_NOEXCEPT              = default;
+  Error(Error const &) VULKAN_HPP_NOEXCEPT = default;
+  virtual ~Error() VULKAN_HPP_NOEXCEPT     = default;
 
-  VULKAN_HPP_INLINE std::error_condition make_error_condition(Result e) VULKAN_HPP_NOEXCEPT
-  {
-    return std::error_condition(static_cast<int>(e), errorCategory());
-  }
+  virtual char const * what() const VULKAN_HPP_NOEXCEPT = 0;
+};
+
+class LogicError : public Error, public std::logic_error
+{
+  public:
+  explicit LogicError( std::string const & what )
+    : Error(), std::logic_error(what) {}
+  explicit LogicError( char const * what )
+    : Error(), std::logic_error(what) {}
+
+  virtual char const * what() const VULKAN_HPP_NOEXCEPT { return std::logic_error::what(); }
+};
+
+class SystemError : public Error, public std::system_error
+{
+  public:
+  SystemError( std::error_code ec )
+    : Error(), std::system_error(ec) {}
+  SystemError( std::error_code ec, std::string const & what )
+    : Error(), std::system_error(ec, what) {}
+  SystemError( std::error_code ec, char const * what )
+    : Error(), std::system_error(ec, what) {}
+  SystemError( int ev, std::error_category const & ecat )
+    : Error(), std::system_error(ev, ecat) {}
+  SystemError( int ev, std::error_category const & ecat, std::string const & what)
+    : Error(), std::system_error(ev, ecat, what) {}
+  SystemError( int ev, std::error_category const & ecat, char const * what)
+    : Error(), std::system_error(ev, ecat, what) {}
+
+  virtual char const * what() const VULKAN_HPP_NOEXCEPT { return std::system_error::what(); }
+};
+
+VULKAN_HPP_INLINE std::error_category const & errorCategory() VULKAN_HPP_NOEXCEPT
+{
+  static ErrorCategoryImpl instance;
+  return instance;
+}
+
+VULKAN_HPP_INLINE std::error_code make_error_code(Result e) VULKAN_HPP_NOEXCEPT
+{
+  return std::error_code(static_cast<int>(e), errorCategory());
+}
+
+VULKAN_HPP_INLINE std::error_condition make_error_condition(Result e) VULKAN_HPP_NOEXCEPT
+{
+  return std::error_condition(static_cast<int>(e), errorCategory());
+}

--- a/generator/snippets/Exchange.hpp
+++ b/generator/snippets/Exchange.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 #if ( 14 <= VULKAN_HPP_CPP_VERSION )
   using std::exchange;
 #else

--- a/generator/snippets/ExtensionInspectionHppTemplate.hpp
+++ b/generator/snippets/ExtensionInspectionHppTemplate.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 ${copyrightMessage}
 
 #ifndef VULKAN_EXTENSION_INSPECTION_HPP

--- a/generator/snippets/Flags.hpp
+++ b/generator/snippets/Flags.hpp
@@ -1,213 +1,216 @@
-  template <typename FlagBitsType>
-  struct FlagTraits
-  {
-    static VULKAN_HPP_CONST_OR_CONSTEXPR bool isBitmask = false;
-  };
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
 
-  template <typename BitType>
-  class Flags
-  {
-  public:
-    using BitsType = BitType;
-    using MaskType = typename std::underlying_type<BitType>::type;
+template <typename FlagBitsType>
+struct FlagTraits
+{
+  static VULKAN_HPP_CONST_OR_CONSTEXPR bool isBitmask = false;
+};
 
-    // constructors
-    VULKAN_HPP_CONSTEXPR Flags() VULKAN_HPP_NOEXCEPT
-      : m_mask( 0 )
-    {}
+template <typename BitType>
+class Flags
+{
+public:
+  using BitsType = BitType;
+  using MaskType = typename std::underlying_type<BitType>::type;
 
-    VULKAN_HPP_CONSTEXPR Flags( BitType bit ) VULKAN_HPP_NOEXCEPT
-      : m_mask( static_cast<MaskType>( bit ) )
-    {}
+  // constructors
+  VULKAN_HPP_CONSTEXPR Flags() VULKAN_HPP_NOEXCEPT
+    : m_mask( 0 )
+  {}
 
-    VULKAN_HPP_CONSTEXPR Flags( Flags<BitType> const & rhs ) VULKAN_HPP_NOEXCEPT = default;
+  VULKAN_HPP_CONSTEXPR Flags( BitType bit ) VULKAN_HPP_NOEXCEPT
+    : m_mask( static_cast<MaskType>( bit ) )
+  {}
 
-    VULKAN_HPP_CONSTEXPR explicit Flags( MaskType flags ) VULKAN_HPP_NOEXCEPT
-      : m_mask( flags )
-    {}
+  VULKAN_HPP_CONSTEXPR Flags( Flags<BitType> const & rhs ) VULKAN_HPP_NOEXCEPT = default;
 
-    // relational operators
+  VULKAN_HPP_CONSTEXPR explicit Flags( MaskType flags ) VULKAN_HPP_NOEXCEPT
+    : m_mask( flags )
+  {}
+
+  // relational operators
 #if defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-    auto operator<=>( Flags<BitType> const & ) const = default;
+  auto operator<=>( Flags<BitType> const & ) const = default;
 #else
-    VULKAN_HPP_CONSTEXPR bool operator<( Flags<BitType> const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_mask < rhs.m_mask;
-    }
-
-    VULKAN_HPP_CONSTEXPR bool operator<=( Flags<BitType> const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_mask <= rhs.m_mask;
-    }
-
-    VULKAN_HPP_CONSTEXPR bool operator>( Flags<BitType> const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_mask > rhs.m_mask;
-    }
-
-    VULKAN_HPP_CONSTEXPR bool operator>=( Flags<BitType> const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_mask >= rhs.m_mask;
-    }
-
-    VULKAN_HPP_CONSTEXPR bool operator==( Flags<BitType> const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_mask == rhs.m_mask;
-    }
-
-    VULKAN_HPP_CONSTEXPR bool operator!=( Flags<BitType> const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return m_mask != rhs.m_mask;
-    }
-#endif
-
-    // logical operator
-    VULKAN_HPP_CONSTEXPR bool operator!() const VULKAN_HPP_NOEXCEPT
-    {
-      return !m_mask;
-    }
-
-    // bitwise operators
-    VULKAN_HPP_CONSTEXPR Flags<BitType> operator&( Flags<BitType> const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return Flags<BitType>( m_mask & rhs.m_mask );
-    }
-
-    VULKAN_HPP_CONSTEXPR Flags<BitType> operator|( Flags<BitType> const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return Flags<BitType>( m_mask | rhs.m_mask );
-    }
-
-    VULKAN_HPP_CONSTEXPR Flags<BitType> operator^( Flags<BitType> const & rhs ) const VULKAN_HPP_NOEXCEPT
-    {
-      return Flags<BitType>( m_mask ^ rhs.m_mask );
-    }
-
-    VULKAN_HPP_CONSTEXPR Flags<BitType> operator~() const VULKAN_HPP_NOEXCEPT
-    {
-      return Flags<BitType>( m_mask ^ FlagTraits<BitType>::allFlags.m_mask );
-    }
-
-    // assignment operators
-    VULKAN_HPP_CONSTEXPR_14 Flags<BitType> & operator=( Flags<BitType> const & rhs ) VULKAN_HPP_NOEXCEPT = default;
-
-    VULKAN_HPP_CONSTEXPR_14 Flags<BitType> & operator|=( Flags<BitType> const & rhs ) VULKAN_HPP_NOEXCEPT
-    {
-      m_mask |= rhs.m_mask;
-      return *this;
-    }
-
-    VULKAN_HPP_CONSTEXPR_14 Flags<BitType> & operator&=( Flags<BitType> const & rhs ) VULKAN_HPP_NOEXCEPT
-    {
-      m_mask &= rhs.m_mask;
-      return *this;
-    }
-
-    VULKAN_HPP_CONSTEXPR_14 Flags<BitType> & operator^=( Flags<BitType> const & rhs ) VULKAN_HPP_NOEXCEPT
-    {
-      m_mask ^= rhs.m_mask;
-      return *this;
-    }
-
-    // cast operators
-    explicit VULKAN_HPP_CONSTEXPR operator bool() const VULKAN_HPP_NOEXCEPT
-    {
-      return !!m_mask;
-    }
-
-    explicit VULKAN_HPP_CONSTEXPR operator MaskType() const VULKAN_HPP_NOEXCEPT
-    {
-      return m_mask;
-    }
-
-#if defined( VULKAN_HPP_FLAGS_MASK_TYPE_AS_PUBLIC )
-  public:
-#else
-  private:
-#endif
-    MaskType m_mask;
-  };
-
-#if !defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
-  // relational operators only needed for pre C++20
-  template <typename BitType>
-  VULKAN_HPP_CONSTEXPR bool operator<( BitType bit, Flags<BitType> const & flags ) VULKAN_HPP_NOEXCEPT
+  VULKAN_HPP_CONSTEXPR bool operator<( Flags<BitType> const & rhs ) const VULKAN_HPP_NOEXCEPT
   {
-    return flags.operator>( bit );
+    return m_mask < rhs.m_mask;
   }
 
-  template <typename BitType>
-  VULKAN_HPP_CONSTEXPR bool operator<=( BitType bit, Flags<BitType> const & flags ) VULKAN_HPP_NOEXCEPT
+  VULKAN_HPP_CONSTEXPR bool operator<=( Flags<BitType> const & rhs ) const VULKAN_HPP_NOEXCEPT
   {
-    return flags.operator>=( bit );
+    return m_mask <= rhs.m_mask;
   }
 
-  template <typename BitType>
-  VULKAN_HPP_CONSTEXPR bool operator>( BitType bit, Flags<BitType> const & flags ) VULKAN_HPP_NOEXCEPT
+  VULKAN_HPP_CONSTEXPR bool operator>( Flags<BitType> const & rhs ) const VULKAN_HPP_NOEXCEPT
   {
-    return flags.operator<( bit );
+    return m_mask > rhs.m_mask;
   }
 
-  template <typename BitType>
-  VULKAN_HPP_CONSTEXPR bool operator>=( BitType bit, Flags<BitType> const & flags ) VULKAN_HPP_NOEXCEPT
+  VULKAN_HPP_CONSTEXPR bool operator>=( Flags<BitType> const & rhs ) const VULKAN_HPP_NOEXCEPT
   {
-    return flags.operator<=( bit );
+    return m_mask >= rhs.m_mask;
   }
 
-  template <typename BitType>
-  VULKAN_HPP_CONSTEXPR bool operator==( BitType bit, Flags<BitType> const & flags ) VULKAN_HPP_NOEXCEPT
+  VULKAN_HPP_CONSTEXPR bool operator==( Flags<BitType> const & rhs ) const VULKAN_HPP_NOEXCEPT
   {
-    return flags.operator==( bit );
+    return m_mask == rhs.m_mask;
   }
 
-  template <typename BitType>
-  VULKAN_HPP_CONSTEXPR bool operator!=( BitType bit, Flags<BitType> const & flags ) VULKAN_HPP_NOEXCEPT
+  VULKAN_HPP_CONSTEXPR bool operator!=( Flags<BitType> const & rhs ) const VULKAN_HPP_NOEXCEPT
   {
-    return flags.operator!=( bit );
+    return m_mask != rhs.m_mask;
   }
 #endif
+
+  // logical operator
+  VULKAN_HPP_CONSTEXPR bool operator!() const VULKAN_HPP_NOEXCEPT
+  {
+    return !m_mask;
+  }
 
   // bitwise operators
-  template <typename BitType>
-  VULKAN_HPP_CONSTEXPR Flags<BitType> operator&( BitType bit, Flags<BitType> const & flags ) VULKAN_HPP_NOEXCEPT
+  VULKAN_HPP_CONSTEXPR Flags<BitType> operator&( Flags<BitType> const & rhs ) const VULKAN_HPP_NOEXCEPT
   {
-    return flags.operator&( bit );
+    return Flags<BitType>( m_mask & rhs.m_mask );
   }
 
-  template <typename BitType>
-  VULKAN_HPP_CONSTEXPR Flags<BitType> operator|( BitType bit, Flags<BitType> const & flags ) VULKAN_HPP_NOEXCEPT
+  VULKAN_HPP_CONSTEXPR Flags<BitType> operator|( Flags<BitType> const & rhs ) const VULKAN_HPP_NOEXCEPT
   {
-    return flags.operator|( bit );
+    return Flags<BitType>( m_mask | rhs.m_mask );
   }
 
-  template <typename BitType>
-  VULKAN_HPP_CONSTEXPR Flags<BitType> operator^( BitType bit, Flags<BitType> const & flags ) VULKAN_HPP_NOEXCEPT
+  VULKAN_HPP_CONSTEXPR Flags<BitType> operator^( Flags<BitType> const & rhs ) const VULKAN_HPP_NOEXCEPT
   {
-    return flags.operator^( bit );
+    return Flags<BitType>( m_mask ^ rhs.m_mask );
   }
 
-  // bitwise operators on BitType
-  template <typename BitType, typename std::enable_if<FlagTraits<BitType>::isBitmask, bool>::type = true>
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR Flags<BitType> operator&(BitType lhs, BitType rhs) VULKAN_HPP_NOEXCEPT
+  VULKAN_HPP_CONSTEXPR Flags<BitType> operator~() const VULKAN_HPP_NOEXCEPT
   {
-    return Flags<BitType>( lhs ) & rhs;
+    return Flags<BitType>( m_mask ^ FlagTraits<BitType>::allFlags.m_mask );
   }
 
-  template <typename BitType, typename std::enable_if<FlagTraits<BitType>::isBitmask, bool>::type = true>
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR Flags<BitType> operator|(BitType lhs, BitType rhs) VULKAN_HPP_NOEXCEPT
+  // assignment operators
+  VULKAN_HPP_CONSTEXPR_14 Flags<BitType> & operator=( Flags<BitType> const & rhs ) VULKAN_HPP_NOEXCEPT = default;
+
+  VULKAN_HPP_CONSTEXPR_14 Flags<BitType> & operator|=( Flags<BitType> const & rhs ) VULKAN_HPP_NOEXCEPT
   {
-    return Flags<BitType>( lhs ) | rhs;
+    m_mask |= rhs.m_mask;
+    return *this;
   }
 
-  template <typename BitType, typename std::enable_if<FlagTraits<BitType>::isBitmask, bool>::type = true>
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR Flags<BitType> operator^(BitType lhs, BitType rhs) VULKAN_HPP_NOEXCEPT
+  VULKAN_HPP_CONSTEXPR_14 Flags<BitType> & operator&=( Flags<BitType> const & rhs ) VULKAN_HPP_NOEXCEPT
   {
-    return Flags<BitType>( lhs ) ^ rhs;
+    m_mask &= rhs.m_mask;
+    return *this;
   }
 
-  template <typename BitType, typename std::enable_if<FlagTraits<BitType>::isBitmask, bool>::type = true>
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR Flags<BitType> operator~( BitType bit ) VULKAN_HPP_NOEXCEPT
+  VULKAN_HPP_CONSTEXPR_14 Flags<BitType> & operator^=( Flags<BitType> const & rhs ) VULKAN_HPP_NOEXCEPT
   {
-    return ~( Flags<BitType>( bit ) );
+    m_mask ^= rhs.m_mask;
+    return *this;
   }
+
+  // cast operators
+  explicit VULKAN_HPP_CONSTEXPR operator bool() const VULKAN_HPP_NOEXCEPT
+  {
+    return !!m_mask;
+  }
+
+  explicit VULKAN_HPP_CONSTEXPR operator MaskType() const VULKAN_HPP_NOEXCEPT
+  {
+    return m_mask;
+  }
+
+#if defined( VULKAN_HPP_FLAGS_MASK_TYPE_AS_PUBLIC )
+public:
+#else
+private:
+#endif
+  MaskType m_mask;
+};
+
+#if !defined( VULKAN_HPP_HAS_SPACESHIP_OPERATOR )
+// relational operators only needed for pre C++20
+template <typename BitType>
+VULKAN_HPP_CONSTEXPR bool operator<( BitType bit, Flags<BitType> const & flags ) VULKAN_HPP_NOEXCEPT
+{
+  return flags.operator>( bit );
+}
+
+template <typename BitType>
+VULKAN_HPP_CONSTEXPR bool operator<=( BitType bit, Flags<BitType> const & flags ) VULKAN_HPP_NOEXCEPT
+{
+  return flags.operator>=( bit );
+}
+
+template <typename BitType>
+VULKAN_HPP_CONSTEXPR bool operator>( BitType bit, Flags<BitType> const & flags ) VULKAN_HPP_NOEXCEPT
+{
+  return flags.operator<( bit );
+}
+
+template <typename BitType>
+VULKAN_HPP_CONSTEXPR bool operator>=( BitType bit, Flags<BitType> const & flags ) VULKAN_HPP_NOEXCEPT
+{
+  return flags.operator<=( bit );
+}
+
+template <typename BitType>
+VULKAN_HPP_CONSTEXPR bool operator==( BitType bit, Flags<BitType> const & flags ) VULKAN_HPP_NOEXCEPT
+{
+  return flags.operator==( bit );
+}
+
+template <typename BitType>
+VULKAN_HPP_CONSTEXPR bool operator!=( BitType bit, Flags<BitType> const & flags ) VULKAN_HPP_NOEXCEPT
+{
+  return flags.operator!=( bit );
+}
+#endif
+
+// bitwise operators
+template <typename BitType>
+VULKAN_HPP_CONSTEXPR Flags<BitType> operator&( BitType bit, Flags<BitType> const & flags ) VULKAN_HPP_NOEXCEPT
+{
+  return flags.operator&( bit );
+}
+
+template <typename BitType>
+VULKAN_HPP_CONSTEXPR Flags<BitType> operator|( BitType bit, Flags<BitType> const & flags ) VULKAN_HPP_NOEXCEPT
+{
+  return flags.operator|( bit );
+}
+
+template <typename BitType>
+VULKAN_HPP_CONSTEXPR Flags<BitType> operator^( BitType bit, Flags<BitType> const & flags ) VULKAN_HPP_NOEXCEPT
+{
+  return flags.operator^( bit );
+}
+
+// bitwise operators on BitType
+template <typename BitType, typename std::enable_if<FlagTraits<BitType>::isBitmask, bool>::type = true>
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR Flags<BitType> operator&(BitType lhs, BitType rhs) VULKAN_HPP_NOEXCEPT
+{
+  return Flags<BitType>( lhs ) & rhs;
+}
+
+template <typename BitType, typename std::enable_if<FlagTraits<BitType>::isBitmask, bool>::type = true>
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR Flags<BitType> operator|(BitType lhs, BitType rhs) VULKAN_HPP_NOEXCEPT
+{
+  return Flags<BitType>( lhs ) | rhs;
+}
+
+template <typename BitType, typename std::enable_if<FlagTraits<BitType>::isBitmask, bool>::type = true>
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR Flags<BitType> operator^(BitType lhs, BitType rhs) VULKAN_HPP_NOEXCEPT
+{
+  return Flags<BitType>( lhs ) ^ rhs;
+}
+
+template <typename BitType, typename std::enable_if<FlagTraits<BitType>::isBitmask, bool>::type = true>
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR Flags<BitType> operator~( BitType bit ) VULKAN_HPP_NOEXCEPT
+{
+  return ~( Flags<BitType>( bit ) );
+}
 

--- a/generator/snippets/FormatTraits.hpp
+++ b/generator/snippets/FormatTraits.hpp
@@ -1,370 +1,373 @@
-  //=====================
-  //=== Format Traits ===
-  //=====================
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
 
-  //=== Function Declarations ===
+//=====================
+//=== Format Traits ===
+//=====================
 
-  // The three-dimensional extent of a texel block.
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 std::array<uint8_t, 3> blockExtent( Format format );
+//=== Function Declarations ===
 
-  // The texel block size in bytes.
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 uint8_t blockSize( Format format );
+// The three-dimensional extent of a texel block.
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 std::array<uint8_t, 3> blockExtent( Format format );
 
-  // The class of the format (can't be just named "class"!)
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 char const * compatibilityClass( Format format );
+// The texel block size in bytes.
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 uint8_t blockSize( Format format );
 
-  // The number of bits in this component, if not compressed, otherwise 0.
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 uint8_t componentBits( Format format, uint8_t component );
+// The class of the format (can't be just named "class"!)
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 char const * compatibilityClass( Format format );
 
-  // The number of components of this format.
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 uint8_t componentCount( Format format );
+// The number of bits in this component, if not compressed, otherwise 0.
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 uint8_t componentBits( Format format, uint8_t component );
 
-  // The name of the component
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 char const * componentName( Format format, uint8_t component );
+// The number of components of this format.
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 uint8_t componentCount( Format format );
 
-  // The numeric format of the component
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 char const * componentNumericFormat( Format format, uint8_t component );
+// The name of the component
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 char const * componentName( Format format, uint8_t component );
 
-  // The plane this component lies in.
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 uint8_t componentPlaneIndex( Format format, uint8_t component );
+// The numeric format of the component
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 char const * componentNumericFormat( Format format, uint8_t component );
 
-  // True, if the components of this format are compressed, otherwise false.
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 bool componentsAreCompressed( Format format );
+// The plane this component lies in.
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 uint8_t componentPlaneIndex( Format format, uint8_t component );
 
-  // A textual description of the compression scheme, or an empty string if it is not compressed
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 char const * compressionScheme( Format format );
+// True, if the components of this format are compressed, otherwise false.
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 bool componentsAreCompressed( Format format );
 
-  // Get all formats
-  VULKAN_HPP_EXPORT std::vector<Format> const & getAllFormats();
+// A textual description of the compression scheme, or an empty string if it is not compressed
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 char const * compressionScheme( Format format );
 
-  // Get all color with a color component
-  VULKAN_HPP_EXPORT std::vector<Format> const & getColorFormats();
+// Get all formats
+VULKAN_HPP_EXPORT std::vector<Format> const & getAllFormats();
 
-  // Get all formats with a depth component
-  VULKAN_HPP_EXPORT std::vector<Format> const & getDepthFormats();
+// Get all color with a color component
+VULKAN_HPP_EXPORT std::vector<Format> const & getColorFormats();
 
-  // Get all formats with a depth and a stencil component
-  VULKAN_HPP_EXPORT std::vector<Format> const & getDepthStencilFormats();
+// Get all formats with a depth component
+VULKAN_HPP_EXPORT std::vector<Format> const & getDepthFormats();
 
-  // Get all formats with a stencil component
-  VULKAN_HPP_EXPORT std::vector<Format> const & getStencilFormats();
+// Get all formats with a depth and a stencil component
+VULKAN_HPP_EXPORT std::vector<Format> const & getDepthStencilFormats();
 
-  // True, if this format has an alpha component
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 bool hasAlphaComponent( Format format );
+// Get all formats with a stencil component
+VULKAN_HPP_EXPORT std::vector<Format> const & getStencilFormats();
 
-  // True, if this format has a blue component
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 bool hasBlueComponent( Format format );
+// True, if this format has an alpha component
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 bool hasAlphaComponent( Format format );
 
-  // True, if this format has a depth component
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 bool hasDepthComponent( Format format );
+// True, if this format has a blue component
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 bool hasBlueComponent( Format format );
 
-  // True, if this format has a green component
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 bool hasGreenComponent( Format format );
+// True, if this format has a depth component
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 bool hasDepthComponent( Format format );
 
-  // True, if this format has a red component
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 bool hasRedComponent( Format format );
+// True, if this format has a green component
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 bool hasGreenComponent( Format format );
 
-  // True, if this format has a stencil component
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 bool hasStencilComponent( Format format );
+// True, if this format has a red component
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 bool hasRedComponent( Format format );
 
-  // True, if the format is a color
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 bool isColor( Format format );
+// True, if this format has a stencil component
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 bool hasStencilComponent( Format format );
 
-  // True, if this format is a compressed one.
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 bool isCompressed( Format format );
+// True, if the format is a color
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 bool isColor( Format format );
 
-  // The number of bits into which the format is packed. A single image element in this format can be stored in the same space as a scalar type of this bit
-  // width.
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 uint8_t packed( Format format );
+// True, if this format is a compressed one.
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 bool isCompressed( Format format );
 
-  // The single-plane format that this plane is compatible with.
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 Format planeCompatibleFormat( Format format, uint8_t plane );
+// The number of bits into which the format is packed. A single image element in this format can be stored in the same space as a scalar type of this bit
+// width.
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 uint8_t packed( Format format );
 
-  // The number of image planes of this format.
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 uint8_t planeCount( Format format );
+// The single-plane format that this plane is compatible with.
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 Format planeCompatibleFormat( Format format, uint8_t plane );
 
-  // The relative height of this plane. A value of k means that this plane is 1/k the height of the overall format.
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 uint8_t planeHeightDivisor( Format format, uint8_t plane );
+// The number of image planes of this format.
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 uint8_t planeCount( Format format );
 
-  // The relative width of this plane. A value of k means that this plane is 1/k the width of the overall format.
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 uint8_t planeWidthDivisor( Format format, uint8_t plane );
+// The relative height of this plane. A value of k means that this plane is 1/k the height of the overall format.
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 uint8_t planeHeightDivisor( Format format, uint8_t plane );
 
-  // The number of texels in a texel block.
-  VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 uint8_t texelsPerBlock( Format format );
+// The relative width of this plane. A value of k means that this plane is 1/k the width of the overall format.
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 uint8_t planeWidthDivisor( Format format, uint8_t plane );
 
-  //=== Function Definitions ===
+// The number of texels in a texel block.
+VULKAN_HPP_EXPORT VULKAN_HPP_CONSTEXPR_14 uint8_t texelsPerBlock( Format format );
 
-  // The three-dimensional extent of a texel block.
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 std::array<uint8_t, 3> blockExtent( Format format )
+//=== Function Definitions ===
+
+// The three-dimensional extent of a texel block.
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 std::array<uint8_t, 3> blockExtent( Format format )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${blockExtentCases}
-      default: return {{1, 1, 1 }};
-    }
+    default: return {{1, 1, 1 }};
   }
+}
 
-  // The texel block size in bytes.
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 uint8_t blockSize( Format format )
+// The texel block size in bytes.
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 uint8_t blockSize( Format format )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${blockSizeCases}
-      default : VULKAN_HPP_ASSERT( false ); return 0;
-    }
+    default : VULKAN_HPP_ASSERT( false ); return 0;
   }
+}
 
-  // The class of the format (can't be just named "class"!)
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 char const * compatibilityClass( Format format )
+// The class of the format (can't be just named "class"!)
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 char const * compatibilityClass( Format format )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${classCases}
-      default : VULKAN_HPP_ASSERT( false ); return "";
-    }
+    default : VULKAN_HPP_ASSERT( false ); return "";
   }
+}
 
-  // The number of bits in this component, if not compressed, otherwise 0.
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 uint8_t componentBits( Format format, uint8_t component )
+// The number of bits in this component, if not compressed, otherwise 0.
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 uint8_t componentBits( Format format, uint8_t component )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${componentBitsCases}
-      default: return 0;
-    }
+    default: return 0;
   }
+}
 
-  // The number of components of this format.
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 uint8_t componentCount( Format format )
+// The number of components of this format.
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 uint8_t componentCount( Format format )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${componentCountCases}
-      default: return 0;
-    }
+    default: return 0;
   }
+}
 
-  // The name of the component
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 char const * componentName( Format format, uint8_t component )
+// The name of the component
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 char const * componentName( Format format, uint8_t component )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${componentNameCases}
-      default: return "";
-    }
+    default: return "";
   }
+}
 
-  // The numeric format of the component
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 char const * componentNumericFormat( Format format, uint8_t component )
+// The numeric format of the component
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 char const * componentNumericFormat( Format format, uint8_t component )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${componentNumericFormatCases}
-      default: return "";
-    }
+    default: return "";
   }
+}
 
-  // The plane this component lies in.
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 uint8_t componentPlaneIndex( Format format, uint8_t component )
+// The plane this component lies in.
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 uint8_t componentPlaneIndex( Format format, uint8_t component )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${componentPlaneIndexCases}
-      default: return 0;
-    }
+    default: return 0;
   }
+}
 
-  // True, if the components of this format are compressed, otherwise false.
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 bool componentsAreCompressed( Format format )
+// True, if the components of this format are compressed, otherwise false.
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 bool componentsAreCompressed( Format format )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${componentsAreCompressedCases}
-        return true;
-      default: return false;
-    }
+      return true;
+    default: return false;
   }
+}
 
-  // A textual description of the compression scheme, or an empty string if it is not compressed
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 char const * compressionScheme( Format format )
+// A textual description of the compression scheme, or an empty string if it is not compressed
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 char const * compressionScheme( Format format )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${compressionSchemeCases}
-      default: return "";
-    }
+    default: return "";
   }
+}
 
-  // Get all formats
-  VULKAN_HPP_INLINE std::vector<Format> const & getAllFormats()
-  {
-    static std::vector<Format> allFormats = { ${allFormats} };
-	return allFormats;
-  }
+// Get all formats
+VULKAN_HPP_INLINE std::vector<Format> const & getAllFormats()
+{
+  static std::vector<Format> allFormats = { ${allFormats} };
+return allFormats;
+}
 
-  // Get all formats with a color component
-  VULKAN_HPP_INLINE std::vector<Format> const & getColorFormats()
-  {
-    static std::vector<Format> colorFormats = { ${colorFormats} };
-	return colorFormats;
-  }
+// Get all formats with a color component
+VULKAN_HPP_INLINE std::vector<Format> const & getColorFormats()
+{
+  static std::vector<Format> colorFormats = { ${colorFormats} };
+return colorFormats;
+}
 
-  // Get all formats with a depth component
-  VULKAN_HPP_INLINE std::vector<Format> const & getDepthFormats()
-  {
-    static std::vector<Format> depthFormats = { ${depthFormats} };
-    return depthFormats;
-  }
+// Get all formats with a depth component
+VULKAN_HPP_INLINE std::vector<Format> const & getDepthFormats()
+{
+  static std::vector<Format> depthFormats = { ${depthFormats} };
+  return depthFormats;
+}
 
-  // Get all formats with a depth and a stencil component
-  VULKAN_HPP_INLINE std::vector<Format> const & getDepthStencilFormats()
-  {
-    static std::vector<Format> depthStencilFormats = { ${depthStencilFormats} };
-    return depthStencilFormats;
-  }
+// Get all formats with a depth and a stencil component
+VULKAN_HPP_INLINE std::vector<Format> const & getDepthStencilFormats()
+{
+  static std::vector<Format> depthStencilFormats = { ${depthStencilFormats} };
+  return depthStencilFormats;
+}
 
-  // Get all formats with a stencil component
-  VULKAN_HPP_INLINE std::vector<Format> const & getStencilFormats()
-  {
-    static std::vector<Format> stencilFormats = { ${stencilFormats} };
-    return stencilFormats;
-  }
+// Get all formats with a stencil component
+VULKAN_HPP_INLINE std::vector<Format> const & getStencilFormats()
+{
+  static std::vector<Format> stencilFormats = { ${stencilFormats} };
+  return stencilFormats;
+}
 
-  // True, if this format has an alpha component
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 bool hasAlphaComponent( Format format )
+// True, if this format has an alpha component
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 bool hasAlphaComponent( Format format )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${alphaCases}
-        return true;
-      default: return false;
-    }
+      return true;
+    default: return false;
   }
+}
 
-  // True, if this format has a blue component
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 bool hasBlueComponent( Format format )
+// True, if this format has a blue component
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 bool hasBlueComponent( Format format )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${blueCases}
-        return true;
-      default: return false;
-    }
+      return true;
+    default: return false;
   }
+}
 
-  // True, if this format has a depth component
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 bool hasDepthComponent( Format format )
+// True, if this format has a depth component
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 bool hasDepthComponent( Format format )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${depthCases}
-        return true;
-      default: return false;
-    }
+      return true;
+    default: return false;
   }
+}
 
-  // True, if this format has a green component
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 bool hasGreenComponent( Format format )
+// True, if this format has a green component
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 bool hasGreenComponent( Format format )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${greenCases}
-        return true;
-      default: return false;
-    }
+      return true;
+    default: return false;
   }
+}
 
-  // True, if this format has a red component
-  VULKAN_HPP_CONSTEXPR_14 bool hasRedComponent( Format format )
+// True, if this format has a red component
+VULKAN_HPP_CONSTEXPR_14 bool hasRedComponent( Format format )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${redCases}
-        return true;
-      default: return false;
-    }
+      return true;
+    default: return false;
   }
+}
 
-  // True, if this format has a stencil component
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 bool hasStencilComponent( Format format )
+// True, if this format has a stencil component
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 bool hasStencilComponent( Format format )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${stencilCases}
-        return true;
-      default: return false;
-    }
+      return true;
+    default: return false;
   }
+}
 
-  // True, if this format is a color.
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 bool isColor( Format format )
-  {
-    return hasRedComponent( format ) || hasGreenComponent( format ) || hasBlueComponent( format ) || hasAlphaComponent( format );
-  }
+// True, if this format is a color.
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 bool isColor( Format format )
+{
+  return hasRedComponent( format ) || hasGreenComponent( format ) || hasBlueComponent( format ) || hasAlphaComponent( format );
+}
 
-  // True, if this format is a compressed one.
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 bool isCompressed( Format format )
-  {
-    return ( *compressionScheme( format ) != 0 );
-  }
+// True, if this format is a compressed one.
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 bool isCompressed( Format format )
+{
+  return ( *compressionScheme( format ) != 0 );
+}
 
-  // The number of bits into which the format is packed. A single image element in this format
-  // can be stored in the same space as a scalar type of this bit width.
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 uint8_t packed( Format format )
+// The number of bits into which the format is packed. A single image element in this format
+// can be stored in the same space as a scalar type of this bit width.
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 uint8_t packed( Format format )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${packedCases}
-      default: return 0;
-    }
+    default: return 0;
   }
+}
 
-  // The single-plane format that this plane is compatible with.
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 Format planeCompatibleFormat( Format format, uint8_t plane )
+// The single-plane format that this plane is compatible with.
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 Format planeCompatibleFormat( Format format, uint8_t plane )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${planeCompatibleCases}
-      default: VULKAN_HPP_ASSERT( plane == 0 ); return format;
-    }
+    default: VULKAN_HPP_ASSERT( plane == 0 ); return format;
   }
+}
 
-  // The number of image planes of this format.
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 uint8_t planeCount( Format format )
+// The number of image planes of this format.
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 uint8_t planeCount( Format format )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${planeCountCases}
-      default: return 1;
-    }
+    default: return 1;
   }
+}
 
-  // The relative height of this plane. A value of k means that this plane is 1/k the height of the overall format.
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 uint8_t planeHeightDivisor( Format format, uint8_t plane )
+// The relative height of this plane. A value of k means that this plane is 1/k the height of the overall format.
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 uint8_t planeHeightDivisor( Format format, uint8_t plane )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${planeHeightDivisorCases}
-      default: VULKAN_HPP_ASSERT( plane == 0 ); return 1;
-    }
+    default: VULKAN_HPP_ASSERT( plane == 0 ); return 1;
   }
+}
 
-  // The relative width of this plane. A value of k means that this plane is 1/k the width of the overall format.
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 uint8_t planeWidthDivisor( Format format, uint8_t plane )
+// The relative width of this plane. A value of k means that this plane is 1/k the width of the overall format.
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 uint8_t planeWidthDivisor( Format format, uint8_t plane )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${planeWidthDivisorCases}
-      default: VULKAN_HPP_ASSERT( plane == 0 ); return 1;
-    }
+    default: VULKAN_HPP_ASSERT( plane == 0 ); return 1;
   }
+}
 
-  // The number of texels in a texel block.
-  VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 uint8_t texelsPerBlock( Format format )
+// The number of texels in a texel block.
+VULKAN_HPP_INLINE VULKAN_HPP_CONSTEXPR_14 uint8_t texelsPerBlock( Format format )
+{
+  switch( format )
   {
-    switch( format )
-    {
 ${texelsPerBlockCases}
-      default: VULKAN_HPP_ASSERT( false ); return 0;
-    }
+    default: VULKAN_HPP_ASSERT( false ); return 0;
   }
+}

--- a/generator/snippets/FormatTraitsHppTemplate.hpp
+++ b/generator/snippets/FormatTraitsHppTemplate.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 ${copyrightMessage}
 
 #ifndef VULKAN_FORMAT_TRAITS_HPP

--- a/generator/snippets/FuncsHppTemplate.hpp
+++ b/generator/snippets/FuncsHppTemplate.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 ${copyrightMessage}
 
 #ifndef VULKAN_FUNCS_HPP

--- a/generator/snippets/HandlesHppTemplate.hpp
+++ b/generator/snippets/HandlesHppTemplate.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 ${copyrightMessage}
 
 #ifndef VULKAN_HANDLES_HPP

--- a/generator/snippets/HashHppTemplate.hpp
+++ b/generator/snippets/HashHppTemplate.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 ${copyrightMessage}
 
 #ifndef VULKAN_HASH_HPP

--- a/generator/snippets/HppTemplate.hpp
+++ b/generator/snippets/HppTemplate.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 ${copyrightMessage}
 #ifndef VULKAN_HPP
 #  define VULKAN_HPP

--- a/generator/snippets/MacrosHppTemplate.hpp
+++ b/generator/snippets/MacrosHppTemplate.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 ${copyrightMessage}
 
 #ifndef VULKAN_HPP_MACROS_HPP

--- a/generator/snippets/ObjectDestroy.hpp
+++ b/generator/snippets/ObjectDestroy.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 template <typename OwnerType, typename Dispatch>
 class ObjectDestroy
 {

--- a/generator/snippets/ObjectFree.hpp
+++ b/generator/snippets/ObjectFree.hpp
@@ -1,42 +1,45 @@
-  template <typename OwnerType, typename Dispatch>
-  class ObjectFree
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+template <typename OwnerType, typename Dispatch>
+class ObjectFree
+{
+public:
+  ObjectFree() = default;
+
+  ObjectFree( OwnerType                           owner,
+              Optional<AllocationCallbacks const> allocationCallbacks VULKAN_HPP_DEFAULT_ASSIGNMENT( nullptr ),
+              Dispatch const & dispatch VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) VULKAN_HPP_NOEXCEPT
+    : m_owner( owner )
+    , m_allocationCallbacks( allocationCallbacks )
+    , m_dispatch( &dispatch )
+  {}
+
+  OwnerType getOwner() const VULKAN_HPP_NOEXCEPT
   {
-  public:
-    ObjectFree() = default;
+    return m_owner;
+  }
 
-    ObjectFree( OwnerType                           owner,
-                Optional<AllocationCallbacks const> allocationCallbacks VULKAN_HPP_DEFAULT_ASSIGNMENT( nullptr ),
-                Dispatch const & dispatch VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) VULKAN_HPP_NOEXCEPT
-      : m_owner( owner )
-      , m_allocationCallbacks( allocationCallbacks )
-      , m_dispatch( &dispatch )
-    {}
+  Optional<AllocationCallbacks const> getAllocator() const VULKAN_HPP_NOEXCEPT
+  {
+    return m_allocationCallbacks;
+  }
 
-    OwnerType getOwner() const VULKAN_HPP_NOEXCEPT
-    {
-      return m_owner;
-    }
+  Dispatch const & getDispatch() const VULKAN_HPP_NOEXCEPT
+  {
+    return *m_dispatch;
+  }
 
-    Optional<AllocationCallbacks const> getAllocator() const VULKAN_HPP_NOEXCEPT
-    {
-      return m_allocationCallbacks;
-    }
+protected:
+  template <typename T>
+  void destroy( T t ) VULKAN_HPP_NOEXCEPT
+  {
+    VULKAN_HPP_ASSERT( m_owner && m_dispatch );
+    ( m_owner.free )( t, m_allocationCallbacks, *m_dispatch );
+  }
 
-    Dispatch const & getDispatch() const VULKAN_HPP_NOEXCEPT
-    {
-      return *m_dispatch;
-    }
-
-  protected:
-    template <typename T>
-    void destroy( T t ) VULKAN_HPP_NOEXCEPT
-    {
-      VULKAN_HPP_ASSERT( m_owner && m_dispatch );
-      ( m_owner.free )( t, m_allocationCallbacks, *m_dispatch );
-    }
-
-  private:
-    OwnerType                           m_owner               = {};
-    Optional<AllocationCallbacks const> m_allocationCallbacks = nullptr;
-    Dispatch const *                    m_dispatch            = nullptr;
-  };
+private:
+  OwnerType                           m_owner               = {};
+  Optional<AllocationCallbacks const> m_allocationCallbacks = nullptr;
+  Dispatch const *                    m_dispatch            = nullptr;
+};

--- a/generator/snippets/ObjectRelease.hpp
+++ b/generator/snippets/ObjectRelease.hpp
@@ -1,34 +1,37 @@
-  template <typename OwnerType, typename Dispatch>
-  class ObjectRelease
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+template <typename OwnerType, typename Dispatch>
+class ObjectRelease
+{
+public:
+  ObjectRelease() = default;
+
+  ObjectRelease( OwnerType                 owner,
+                  Dispatch const & dispatch VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) VULKAN_HPP_NOEXCEPT
+    : m_owner( owner )
+    , m_dispatch( &dispatch )
+  {}
+
+  OwnerType getOwner() const VULKAN_HPP_NOEXCEPT
   {
-  public:
-    ObjectRelease() = default;
+    return m_owner;
+  }
 
-    ObjectRelease( OwnerType                 owner,
-                   Dispatch const & dispatch VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) VULKAN_HPP_NOEXCEPT
-      : m_owner( owner )
-      , m_dispatch( &dispatch )
-    {}
+  Dispatch const & getDispatch() const VULKAN_HPP_NOEXCEPT
+  {
+    return *m_dispatch;
+  }
 
-    OwnerType getOwner() const VULKAN_HPP_NOEXCEPT
-    {
-      return m_owner;
-    }
+protected:
+  template <typename T>
+  void destroy( T t ) VULKAN_HPP_NOEXCEPT
+  {
+    VULKAN_HPP_ASSERT( m_owner && m_dispatch );
+    m_owner.release( t, *m_dispatch );
+  }
 
-    Dispatch const & getDispatch() const VULKAN_HPP_NOEXCEPT
-    {
-      return *m_dispatch;
-    }
-
-  protected:
-    template <typename T>
-    void destroy( T t ) VULKAN_HPP_NOEXCEPT
-    {
-      VULKAN_HPP_ASSERT( m_owner && m_dispatch );
-      m_owner.release( t, *m_dispatch );
-    }
-
-  private:
-    OwnerType        m_owner    = {};
-    Dispatch const * m_dispatch = nullptr;
-  };
+private:
+  OwnerType        m_owner    = {};
+  Dispatch const * m_dispatch = nullptr;
+};

--- a/generator/snippets/Optional.hpp
+++ b/generator/snippets/Optional.hpp
@@ -1,40 +1,43 @@
-  template <typename RefType>
-  class Optional
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+template <typename RefType>
+class Optional
+{
+public:
+  Optional( RefType & reference ) VULKAN_HPP_NOEXCEPT
   {
-  public:
-    Optional( RefType & reference ) VULKAN_HPP_NOEXCEPT
-    {
-      m_ptr = &reference;
-    }
-    Optional( RefType * ptr ) VULKAN_HPP_NOEXCEPT
-    {
-      m_ptr = ptr;
-    }
-    Optional( std::nullptr_t ) VULKAN_HPP_NOEXCEPT
-    {
-      m_ptr = nullptr;
-    }
+    m_ptr = &reference;
+  }
+  Optional( RefType * ptr ) VULKAN_HPP_NOEXCEPT
+  {
+    m_ptr = ptr;
+  }
+  Optional( std::nullptr_t ) VULKAN_HPP_NOEXCEPT
+  {
+    m_ptr = nullptr;
+  }
 
-    operator RefType *() const VULKAN_HPP_NOEXCEPT
-    {
-      return m_ptr;
-    }
-	
-    RefType const * operator->() const VULKAN_HPP_NOEXCEPT
-    {
-      return m_ptr;
-    }
-	
-    RefType const* get() const VULKAN_HPP_NOEXCEPT
-    {
-      return m_ptr;
-    }
-	
-    explicit operator bool() const VULKAN_HPP_NOEXCEPT
-    {
-      return !!m_ptr;
-    }
+  operator RefType *() const VULKAN_HPP_NOEXCEPT
+  {
+    return m_ptr;
+  }
 
-  private:
-    RefType * m_ptr;
-  };
+  RefType const * operator->() const VULKAN_HPP_NOEXCEPT
+  {
+    return m_ptr;
+  }
+
+  RefType const* get() const VULKAN_HPP_NOEXCEPT
+  {
+    return m_ptr;
+  }
+
+  explicit operator bool() const VULKAN_HPP_NOEXCEPT
+  {
+    return !!m_ptr;
+  }
+
+private:
+  RefType * m_ptr;
+};

--- a/generator/snippets/PoolFree.hpp
+++ b/generator/snippets/PoolFree.hpp
@@ -1,30 +1,33 @@
-  template <typename OwnerType, typename PoolType, typename Dispatch>
-  class PoolFree
-  {
-    public:
-      PoolFree() = default;
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
 
-    PoolFree( OwnerType                 owner,
-              PoolType                  pool,
-              Dispatch const & dispatch VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) VULKAN_HPP_NOEXCEPT
-        : m_owner( owner )
-        , m_pool( pool )
-        , m_dispatch( &dispatch )
-      {}
+template <typename OwnerType, typename PoolType, typename Dispatch>
+class PoolFree
+{
+  public:
+    PoolFree() = default;
 
-      OwnerType getOwner() const VULKAN_HPP_NOEXCEPT { return m_owner; }
-      PoolType getPool() const VULKAN_HPP_NOEXCEPT { return m_pool; }
-      Dispatch const & getDispatch() const VULKAN_HPP_NOEXCEPT { return *m_dispatch; }
+  PoolFree( OwnerType                 owner,
+            PoolType                  pool,
+            Dispatch const & dispatch VULKAN_HPP_DEFAULT_DISPATCHER_ASSIGNMENT ) VULKAN_HPP_NOEXCEPT
+      : m_owner( owner )
+      , m_pool( pool )
+      , m_dispatch( &dispatch )
+    {}
 
-    protected:
-      template <typename T>
-      void destroy(T t) VULKAN_HPP_NOEXCEPT
-      {
-        ( m_owner.free )( m_pool, t, *m_dispatch );
-      }
+    OwnerType getOwner() const VULKAN_HPP_NOEXCEPT { return m_owner; }
+    PoolType getPool() const VULKAN_HPP_NOEXCEPT { return m_pool; }
+    Dispatch const & getDispatch() const VULKAN_HPP_NOEXCEPT { return *m_dispatch; }
 
-    private:
-      OwnerType        m_owner    = OwnerType();
-      PoolType         m_pool     = PoolType();
-      Dispatch const * m_dispatch = nullptr;
-  };
+  protected:
+    template <typename T>
+    void destroy(T t) VULKAN_HPP_NOEXCEPT
+    {
+      ( m_owner.free )( m_pool, t, *m_dispatch );
+    }
+
+  private:
+    OwnerType        m_owner    = OwnerType();
+    PoolType         m_pool     = PoolType();
+    Dispatch const * m_dispatch = nullptr;
+};

--- a/generator/snippets/RAIIHppTemplate.hpp
+++ b/generator/snippets/RAIIHppTemplate.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 ${copyrightMessage}
 
 #ifndef VULKAN_RAII_HPP

--- a/generator/snippets/ResultValue.hpp
+++ b/generator/snippets/ResultValue.hpp
@@ -1,156 +1,159 @@
-  template <typename T>
-  struct ResultValue
-  {
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+template <typename T>
+struct ResultValue
+{
 #ifdef VULKAN_HPP_HAS_NOEXCEPT
-    ResultValue( Result r, T & v ) VULKAN_HPP_NOEXCEPT(VULKAN_HPP_NOEXCEPT(T(v)))
+  ResultValue( Result r, T & v ) VULKAN_HPP_NOEXCEPT(VULKAN_HPP_NOEXCEPT(T(v)))
 #else
-    ResultValue( Result r, T & v )
+  ResultValue( Result r, T & v )
 #endif
-      : result( r )
-      , value( v )
-    {}
+    : result( r )
+    , value( v )
+  {}
 
 #ifdef VULKAN_HPP_HAS_NOEXCEPT
-    ResultValue( Result r, T && v ) VULKAN_HPP_NOEXCEPT(VULKAN_HPP_NOEXCEPT(T(std::move(v))))
+  ResultValue( Result r, T && v ) VULKAN_HPP_NOEXCEPT(VULKAN_HPP_NOEXCEPT(T(std::move(v))))
 #else
-    ResultValue( Result r, T && v )
+  ResultValue( Result r, T && v )
 #endif
-      : result( r )
-      , value( std::move( v ) )
-    {}
+    : result( r )
+    , value( std::move( v ) )
+  {}
 
-    Result  result;
-    T       value;
+  Result  result;
+  T       value;
 
-    operator std::tuple<Result &, T &>() VULKAN_HPP_NOEXCEPT
-    {
-      return std::tuple<Result &, T &>( result, value );
-    }
-
-    std::tuple<Result, T> asTuple() &&
-    {
-      return std::make_tuple( result, std::move( value ) );
-    }
-
-	// std::expected-look alike
-    bool has_value() const VULKAN_HPP_NOEXCEPT
-    {
-      return result == vk::Result::eSuccess;
-    }
-
-    T const * operator->() const VULKAN_HPP_NOEXCEPT
-    {
-      VULKAN_HPP_ASSERT( has_value() );
-      return &value;
-    }
-
-    T * operator->() VULKAN_HPP_NOEXCEPT
-    {
-      VULKAN_HPP_ASSERT( has_value() );
-      return &value;
-    }
-
-    T const & operator*() const VULKAN_HPP_NOEXCEPT
-    {
-      VULKAN_HPP_ASSERT(has_value ());
-      return value;
-    }
-
-    T & operator*() VULKAN_HPP_NOEXCEPT
-    {
-      VULKAN_HPP_ASSERT(has_value ());
-      return value;
-    }
-  };
-
-  template <typename T>
-  struct ResultValueType
+  operator std::tuple<Result &, T &>() VULKAN_HPP_NOEXCEPT
   {
+    return std::tuple<Result &, T &>( result, value );
+  }
+
+  std::tuple<Result, T> asTuple() &&
+  {
+    return std::make_tuple( result, std::move( value ) );
+  }
+
+// std::expected-look alike
+  bool has_value() const VULKAN_HPP_NOEXCEPT
+  {
+    return result == vk::Result::eSuccess;
+  }
+
+  T const * operator->() const VULKAN_HPP_NOEXCEPT
+  {
+    VULKAN_HPP_ASSERT( has_value() );
+    return &value;
+  }
+
+  T * operator->() VULKAN_HPP_NOEXCEPT
+  {
+    VULKAN_HPP_ASSERT( has_value() );
+    return &value;
+  }
+
+  T const & operator*() const VULKAN_HPP_NOEXCEPT
+  {
+    VULKAN_HPP_ASSERT(has_value ());
+    return value;
+  }
+
+  T & operator*() VULKAN_HPP_NOEXCEPT
+  {
+    VULKAN_HPP_ASSERT(has_value ());
+    return value;
+  }
+};
+
+template <typename T>
+struct ResultValueType
+{
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 #ifdef VULKAN_HPP_EXPECTED
-  using type = VULKAN_HPP_EXPECTED<T, Result>;
+using type = VULKAN_HPP_EXPECTED<T, Result>;
 #else
-	using type = ResultValue<T>;
+using type = ResultValue<T>;
 #endif
 #else
-	using type = T;
+using type = T;
 #endif
-  };
+};
 
-  template <>
-  struct ResultValueType<void>
-  {
+template <>
+struct ResultValueType<void>
+{
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 #ifdef VULKAN_HPP_EXPECTED
-    using type = VULKAN_HPP_EXPECTED<void, Result>;
+  using type = VULKAN_HPP_EXPECTED<void, Result>;
 #else
-    using type = Result;
+  using type = Result;
 #endif
 #else
-    using type = void;
+  using type = void;
 #endif
-  };
+};
 
-  namespace detail
+namespace detail
+{
+  template <typename T>
+  VULKAN_HPP_CONSTEXPR bool ignore( T const & ) VULKAN_HPP_NOEXCEPT
   {
-    template <typename T>
-    VULKAN_HPP_CONSTEXPR bool ignore( T const & ) VULKAN_HPP_NOEXCEPT
-    {
-      return true;
-    }
+    return true;
+  }
 
-    VULKAN_HPP_INLINE typename ResultValueType<void>::type createResultValueType( Result result )
-    {
+  VULKAN_HPP_INLINE typename ResultValueType<void>::type createResultValueType( Result result )
+  {
 #if defined( VULKAN_HPP_NO_EXCEPTIONS )
 #ifdef VULKAN_HPP_UNEXPECTED
-      if (result == Result::eSuccess)
-      {
-          return {};
-      }
-      return VULKAN_HPP_UNEXPECTED( result );
-#else
-      return result;
-#endif
-#else
-      ignore( result );
-#endif
-    }
-
-    template <typename T>
-    VULKAN_HPP_INLINE typename ResultValueType<T>::type createResultValueType( Result result, T & data )
+    if (result == Result::eSuccess)
     {
+        return {};
+    }
+    return VULKAN_HPP_UNEXPECTED( result );
+#else
+    return result;
+#endif
+#else
+    ignore( result );
+#endif
+  }
+
+  template <typename T>
+  VULKAN_HPP_INLINE typename ResultValueType<T>::type createResultValueType( Result result, T & data )
+  {
 #if defined( VULKAN_HPP_NO_EXCEPTIONS )
 #ifdef VULKAN_HPP_EXPECTED
-      if (result == Result::eSuccess)
-      {
-          return data;
-      }
-      return VULKAN_HPP_UNEXPECTED( result );
-#else
-      return ResultValue<T>( result, data );
-#endif
-#else
-      ignore( result );
-      return data;
-#endif
-    }
-
-    template <typename T>
-    VULKAN_HPP_INLINE typename ResultValueType<T>::type createResultValueType( Result result, T && data )
+    if (result == Result::eSuccess)
     {
+        return data;
+    }
+    return VULKAN_HPP_UNEXPECTED( result );
+#else
+    return ResultValue<T>( result, data );
+#endif
+#else
+    ignore( result );
+    return data;
+#endif
+  }
+
+  template <typename T>
+  VULKAN_HPP_INLINE typename ResultValueType<T>::type createResultValueType( Result result, T && data )
+  {
 #if defined( VULKAN_HPP_NO_EXCEPTIONS )
 #ifdef VULKAN_HPP_EXPECTED
-      if (result == Result::eSuccess)
-      {
-          return std::move(data);
-      }
-      return VULKAN_HPP_UNEXPECTED(result);
-#else
-      return ResultValue<T>( result, std::move( data ) );
-#endif
-#else
-      ignore( result );
-      return std::move( data );
-#endif
+    if (result == Result::eSuccess)
+    {
+        return std::move(data);
     }
-  }  // namespace detail
+    return VULKAN_HPP_UNEXPECTED(result);
+#else
+    return ResultValue<T>( result, std::move( data ) );
+#endif
+#else
+    ignore( result );
+    return std::move( data );
+#endif
+  }
+}  // namespace detail

--- a/generator/snippets/SharedHppTemplate.hpp
+++ b/generator/snippets/SharedHppTemplate.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 ${copyrightMessage}
 
 #ifndef VULKAN_SHARED_HPP

--- a/generator/snippets/StaticAssertionsHppTemplate.hpp
+++ b/generator/snippets/StaticAssertionsHppTemplate.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 ${copyrightMessage}
 
 #ifndef VULKAN_STATIC_ASSERTIONS_HPP

--- a/generator/snippets/StridedArrayProxy.hpp
+++ b/generator/snippets/StridedArrayProxy.hpp
@@ -1,40 +1,43 @@
-  template <typename T>
-  class StridedArrayProxy : protected ArrayProxy<T>
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+template <typename T>
+class StridedArrayProxy : protected ArrayProxy<T>
+{
+public:
+  using ArrayProxy<T>::ArrayProxy;
+
+  StridedArrayProxy( uint32_t count, T const * ptr, uint32_t stride ) VULKAN_HPP_NOEXCEPT
+    : ArrayProxy<T>( count, ptr )
+    , m_stride( stride )
   {
-  public:
-    using ArrayProxy<T>::ArrayProxy;
+    VULKAN_HPP_ASSERT( sizeof( T ) <= stride );
+  }
 
-    StridedArrayProxy( uint32_t count, T const * ptr, uint32_t stride ) VULKAN_HPP_NOEXCEPT
-      : ArrayProxy<T>( count, ptr )
-      , m_stride( stride )
-    {
-      VULKAN_HPP_ASSERT( sizeof( T ) <= stride );
-    }
+  using ArrayProxy<T>::begin;
 
-    using ArrayProxy<T>::begin;
+  T const * end() const VULKAN_HPP_NOEXCEPT
+  {
+    return reinterpret_cast<T const *>( static_cast<uint8_t const *>( begin() ) + size() * m_stride );
+  }
 
-    T const * end() const VULKAN_HPP_NOEXCEPT
-    {
-      return reinterpret_cast<T const *>( static_cast<uint8_t const *>( begin() ) + size() * m_stride );
-    }
+  using ArrayProxy<T>::front;
 
-    using ArrayProxy<T>::front;
+  T const & back() const VULKAN_HPP_NOEXCEPT
+  {
+    VULKAN_HPP_ASSERT( begin() && size() );
+    return *reinterpret_cast<T const *>( static_cast<uint8_t const *>( begin() ) + ( size() - 1 ) * m_stride );
+  }
 
-    T const & back() const VULKAN_HPP_NOEXCEPT
-    {
-      VULKAN_HPP_ASSERT( begin() && size() );
-      return *reinterpret_cast<T const *>( static_cast<uint8_t const *>( begin() ) + ( size() - 1 ) * m_stride );
-    }
+  using ArrayProxy<T>::empty;
+  using ArrayProxy<T>::size;
+  using ArrayProxy<T>::data;
 
-    using ArrayProxy<T>::empty;
-    using ArrayProxy<T>::size;
-    using ArrayProxy<T>::data;
+  uint32_t stride() const
+  {
+    return m_stride;
+  }
 
-    uint32_t stride() const
-    {
-      return m_stride;
-    }
-
-  private:
-    uint32_t m_stride = sizeof( T );
-  };
+private:
+  uint32_t m_stride = sizeof( T );
+};

--- a/generator/snippets/StructsHppTemplate.hpp
+++ b/generator/snippets/StructsHppTemplate.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 ${copyrightMessage}
 
 #ifndef VULKAN_STRUCTS_HPP

--- a/generator/snippets/StructureChain.hpp
+++ b/generator/snippets/StructureChain.hpp
@@ -1,313 +1,316 @@
-  template <typename X, typename Y>
-  struct StructExtends
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
+template <typename X, typename Y>
+struct StructExtends
+{
+  enum
   {
-    enum
-    {
-      value = false
-    };
+    value = false
   };
+};
 
-  template <typename Type, class...>
-  struct IsPartOfStructureChain
+template <typename Type, class...>
+struct IsPartOfStructureChain
+{
+  static bool const valid = false;
+};
+
+template <typename Type, typename Head, typename... Tail>
+struct IsPartOfStructureChain<Type, Head, Tail...>
+{
+  static bool const valid = std::is_same<Type, Head>::value || IsPartOfStructureChain<Type, Tail...>::valid;
+};
+
+template <size_t Index, typename T, typename... ChainElements>
+struct StructureChainContains
+{
+  static bool const value = std::is_same<T, typename std::tuple_element<Index, std::tuple<ChainElements...>>::type>::value ||
+                            StructureChainContains<Index - 1, T, ChainElements...>::value;
+};
+
+template <typename T, typename... ChainElements>
+struct StructureChainContains<0, T, ChainElements...>
+{
+  static bool const value = std::is_same<T, typename std::tuple_element<0, std::tuple<ChainElements...>>::type>::value;
+};
+
+template <size_t Index, typename... ChainElements>
+struct StructureChainValidation
+{
+  using TestType          = typename std::tuple_element<Index, std::tuple<ChainElements...>>::type;
+  static bool const valid = StructExtends<TestType, typename std::tuple_element<0, std::tuple<ChainElements...>>::type>::value &&
+                            ( TestType::allowDuplicate || !StructureChainContains<Index - 1, TestType, ChainElements...>::value ) &&
+                            StructureChainValidation<Index - 1, ChainElements...>::valid;
+};
+
+template <typename... ChainElements>
+struct StructureChainValidation<0, ChainElements...>
+{
+  static bool const valid = true;
+};
+
+template <typename... ChainElements>
+class StructureChain : public std::tuple<ChainElements...>
+{
+  // Note: StructureChain has no move constructor or move assignment operator, as it is not supposed to contain movable containers.
+  //       In order to get a copy-operation on a move-operations, those functions are neither deleted nor defaulted.
+public:
+  StructureChain() VULKAN_HPP_NOEXCEPT
   {
-    static bool const valid = false;
-  };
+    VULKAN_HPP_STATIC_ASSERT( StructureChainValidation<sizeof...( ChainElements ) - 1, ChainElements...>::valid, "The structure chain is not valid!" );
+    link<sizeof...( ChainElements ) - 1>();
+  }
 
-  template <typename Type, typename Head, typename... Tail>
-  struct IsPartOfStructureChain<Type, Head, Tail...>
+  StructureChain( StructureChain const & rhs ) VULKAN_HPP_NOEXCEPT : std::tuple<ChainElements...>( rhs )
   {
-    static bool const valid = std::is_same<Type, Head>::value || IsPartOfStructureChain<Type, Tail...>::valid;
-  };
+    VULKAN_HPP_STATIC_ASSERT( StructureChainValidation<sizeof...( ChainElements ) - 1, ChainElements...>::valid, "The structure chain is not valid!" );
+    link( &std::get<0>( *this ),
+          &std::get<0>( rhs ),
+          reinterpret_cast<VkBaseOutStructure *>( &std::get<0>( *this ) ),
+          reinterpret_cast<VkBaseInStructure const *>( &std::get<0>( rhs ) ) );
+  }
 
-  template <size_t Index, typename T, typename... ChainElements>
-  struct StructureChainContains
+  StructureChain( ChainElements const &... elems ) VULKAN_HPP_NOEXCEPT : std::tuple<ChainElements...>( elems... )
   {
-    static bool const value = std::is_same<T, typename std::tuple_element<Index, std::tuple<ChainElements...>>::type>::value ||
-                              StructureChainContains<Index - 1, T, ChainElements...>::value;
-  };
+    VULKAN_HPP_STATIC_ASSERT( StructureChainValidation<sizeof...( ChainElements ) - 1, ChainElements...>::valid, "The structure chain is not valid!" );
+    link<sizeof...( ChainElements ) - 1>();
+  }
 
-  template <typename T, typename... ChainElements>
-  struct StructureChainContains<0, T, ChainElements...>
+  StructureChain & operator=( StructureChain const & rhs ) VULKAN_HPP_NOEXCEPT
   {
-    static bool const value = std::is_same<T, typename std::tuple_element<0, std::tuple<ChainElements...>>::type>::value;
-  };
-
-  template <size_t Index, typename... ChainElements>
-  struct StructureChainValidation
-  {
-    using TestType          = typename std::tuple_element<Index, std::tuple<ChainElements...>>::type;
-    static bool const valid = StructExtends<TestType, typename std::tuple_element<0, std::tuple<ChainElements...>>::type>::value &&
-                              ( TestType::allowDuplicate || !StructureChainContains<Index - 1, TestType, ChainElements...>::value ) &&
-                              StructureChainValidation<Index - 1, ChainElements...>::valid;
-  };
-
-  template <typename... ChainElements>
-  struct StructureChainValidation<0, ChainElements...>
-  {
-    static bool const valid = true;
-  };
-
-  template <typename... ChainElements>
-  class StructureChain : public std::tuple<ChainElements...>
-  {
-    // Note: StructureChain has no move constructor or move assignment operator, as it is not supposed to contain movable containers.
-    //       In order to get a copy-operation on a move-operations, those functions are neither deleted nor defaulted.
-  public:
-    StructureChain() VULKAN_HPP_NOEXCEPT
-    {
-      VULKAN_HPP_STATIC_ASSERT( StructureChainValidation<sizeof...( ChainElements ) - 1, ChainElements...>::valid, "The structure chain is not valid!" );
-      link<sizeof...( ChainElements ) - 1>();
-    }
-
-    StructureChain( StructureChain const & rhs ) VULKAN_HPP_NOEXCEPT : std::tuple<ChainElements...>( rhs )
-    {
-      VULKAN_HPP_STATIC_ASSERT( StructureChainValidation<sizeof...( ChainElements ) - 1, ChainElements...>::valid, "The structure chain is not valid!" );
-      link( &std::get<0>( *this ),
-            &std::get<0>( rhs ),
-            reinterpret_cast<VkBaseOutStructure *>( &std::get<0>( *this ) ),
-            reinterpret_cast<VkBaseInStructure const *>( &std::get<0>( rhs ) ) );
-    }
-
-    StructureChain( ChainElements const &... elems ) VULKAN_HPP_NOEXCEPT : std::tuple<ChainElements...>( elems... )
-    {
-      VULKAN_HPP_STATIC_ASSERT( StructureChainValidation<sizeof...( ChainElements ) - 1, ChainElements...>::valid, "The structure chain is not valid!" );
-      link<sizeof...( ChainElements ) - 1>();
-    }
-
-    StructureChain & operator=( StructureChain const & rhs ) VULKAN_HPP_NOEXCEPT
-    {
-      std::tuple<ChainElements...>::operator=( rhs );
-      link( &std::get<0>( *this ),
-            &std::get<0>( rhs ),
-            reinterpret_cast<VkBaseOutStructure *>( &std::get<0>( *this ) ),
-            reinterpret_cast<VkBaseInStructure const *>( &std::get<0>( rhs ) ) );
-      return *this;
-    }
+    std::tuple<ChainElements...>::operator=( rhs );
+    link( &std::get<0>( *this ),
+          &std::get<0>( rhs ),
+          reinterpret_cast<VkBaseOutStructure *>( &std::get<0>( *this ) ),
+          reinterpret_cast<VkBaseInStructure const *>( &std::get<0>( rhs ) ) );
+    return *this;
+  }
 
 #if defined(VULKAN_HPP_USE_REFLECT) && ( 14 <= VULKAN_HPP_CPP_VERSION )
-  private:
-    // some helper structs to strip away the first two elements from a tuple
-    template <std::size_t I, std::size_t N, std::size_t... integers>
-    struct makeIndexSequenceHelper
-    {
-      using type = typename makeIndexSequenceHelper<I + 1, N, integers..., I>::type;
-    };
+private:
+  // some helper structs to strip away the first two elements from a tuple
+  template <std::size_t I, std::size_t N, std::size_t... integers>
+  struct makeIndexSequenceHelper
+  {
+    using type = typename makeIndexSequenceHelper<I + 1, N, integers..., I>::type;
+  };
 
-    template <std::size_t N, std::size_t... integers>
-    struct makeIndexSequenceHelper<N, N, integers...>
-    {
-      using type = std::index_sequence<integers...>;
-    };
+  template <std::size_t N, std::size_t... integers>
+  struct makeIndexSequenceHelper<N, N, integers...>
+  {
+    using type = std::index_sequence<integers...>;
+  };
 
-    template <std::size_t I, std::size_t N>
-    using makeIndexSequence = typename makeIndexSequenceHelper<I, N>::type;
+  template <std::size_t I, std::size_t N>
+  using makeIndexSequence = typename makeIndexSequenceHelper<I, N>::type;
 
-    template <typename Tuple, std::size_t... Is>
-    auto subTuple( Tuple & t, std::index_sequence<Is...> )
-    {
-      return std::make_tuple( std::get<Is>( t )... );
-    }
+  template <typename Tuple, std::size_t... Is>
+  auto subTuple( Tuple & t, std::index_sequence<Is...> )
+  {
+    return std::make_tuple( std::get<Is>( t )... );
+  }
 
-  public:
-    // compare a complete structure in the StructureChain, ignoring the chaining
-    template <typename T = typename std::tuple_element<0, std::tuple<ChainElements...>>::type, size_t Which = 0>
-    VULKAN_HPP_NODISCARD bool elementEquals( T rhs ) VULKAN_HPP_NOEXCEPT
-    {
-      auto lhsTuple       = get<T, Which>().reflect();
-      auto rhsTuple       = rhs.reflect();
-      // skip the first two members: sType and pNext
-      auto indexSequence = makeIndexSequence<2, std::tuple_size<decltype( lhsTuple )>{}>{};
-      return subTuple( lhsTuple, indexSequence ) == subTuple( rhsTuple, indexSequence );
-    }
+public:
+  // compare a complete structure in the StructureChain, ignoring the chaining
+  template <typename T = typename std::tuple_element<0, std::tuple<ChainElements...>>::type, size_t Which = 0>
+  VULKAN_HPP_NODISCARD bool elementEquals( T rhs ) VULKAN_HPP_NOEXCEPT
+  {
+    auto lhsTuple       = get<T, Which>().reflect();
+    auto rhsTuple       = rhs.reflect();
+    // skip the first two members: sType and pNext
+    auto indexSequence = makeIndexSequence<2, std::tuple_size<decltype( lhsTuple )>{}>{};
+    return subTuple( lhsTuple, indexSequence ) == subTuple( rhsTuple, indexSequence );
+  }
 #endif
 
-    template <typename T = typename std::tuple_element<0, std::tuple<ChainElements...>>::type, size_t Which = 0>
-      VULKAN_HPP_NODISCARD T & get() & VULKAN_HPP_NOEXCEPT
-    {
-      return std::get<ChainElementIndex<0, T, Which, void, ChainElements...>::value>( static_cast<std::tuple<ChainElements...> &>( *this ) );
-    }
+  template <typename T = typename std::tuple_element<0, std::tuple<ChainElements...>>::type, size_t Which = 0>
+    VULKAN_HPP_NODISCARD T & get() & VULKAN_HPP_NOEXCEPT
+  {
+    return std::get<ChainElementIndex<0, T, Which, void, ChainElements...>::value>( static_cast<std::tuple<ChainElements...> &>( *this ) );
+  }
 
-    template <typename T = typename std::tuple_element<0, std::tuple<ChainElements...>>::type, size_t Which = 0>
-    VULKAN_HPP_NODISCARD T const & get() const & VULKAN_HPP_NOEXCEPT
-    {
-      return std::get<ChainElementIndex<0, T, Which, void, ChainElements...>::value>( static_cast<std::tuple<ChainElements...> const &>( *this ) );
-    }
+  template <typename T = typename std::tuple_element<0, std::tuple<ChainElements...>>::type, size_t Which = 0>
+  VULKAN_HPP_NODISCARD T const & get() const & VULKAN_HPP_NOEXCEPT
+  {
+    return std::get<ChainElementIndex<0, T, Which, void, ChainElements...>::value>( static_cast<std::tuple<ChainElements...> const &>( *this ) );
+  }
 
-    template <typename T = typename std::tuple_element<0, std::tuple<ChainElements...>>::type, size_t Which = 0>
-      VULKAN_HPP_NODISCARD T && get() && VULKAN_HPP_NOEXCEPT
-    {
-      return std::move( std::get<ChainElementIndex<0, T, Which, void, ChainElements...>::value>( static_cast<std::tuple<ChainElements...> &>( *this ) ) );
-    }
+  template <typename T = typename std::tuple_element<0, std::tuple<ChainElements...>>::type, size_t Which = 0>
+    VULKAN_HPP_NODISCARD T && get() && VULKAN_HPP_NOEXCEPT
+  {
+    return std::move( std::get<ChainElementIndex<0, T, Which, void, ChainElements...>::value>( static_cast<std::tuple<ChainElements...> &>( *this ) ) );
+  }
 
-    template <typename T0, typename T1, typename... Ts>
-      VULKAN_HPP_NODISCARD std::tuple<T0 &, T1 &, Ts &...> get() & VULKAN_HPP_NOEXCEPT
-    {
-      return std::tie( get<T0>(), get<T1>(), get<Ts>()... );
-    }
+  template <typename T0, typename T1, typename... Ts>
+    VULKAN_HPP_NODISCARD std::tuple<T0 &, T1 &, Ts &...> get() & VULKAN_HPP_NOEXCEPT
+  {
+    return std::tie( get<T0>(), get<T1>(), get<Ts>()... );
+  }
 
-    template <typename T0, typename T1, typename... Ts>
-    VULKAN_HPP_NODISCARD std::tuple<T0 const &, T1 const &, Ts const &...> get() const & VULKAN_HPP_NOEXCEPT
-    {
-      return std::tie( get<T0>(), get<T1>(), get<Ts>()... );
-    }
+  template <typename T0, typename T1, typename... Ts>
+  VULKAN_HPP_NODISCARD std::tuple<T0 const &, T1 const &, Ts const &...> get() const & VULKAN_HPP_NOEXCEPT
+  {
+    return std::tie( get<T0>(), get<T1>(), get<Ts>()... );
+  }
 
-    template <typename T0, typename T1, typename... Ts>
-      VULKAN_HPP_NODISCARD std::tuple<T0 &&, T1 &&, Ts &&...> get() && VULKAN_HPP_NOEXCEPT
-    {
-      return std::forward_as_tuple( std::move( get<T0>() ), std::move( get<T1>() ), std::move( get<Ts>() )... );
-    }
+  template <typename T0, typename T1, typename... Ts>
+    VULKAN_HPP_NODISCARD std::tuple<T0 &&, T1 &&, Ts &&...> get() && VULKAN_HPP_NOEXCEPT
+  {
+    return std::forward_as_tuple( std::move( get<T0>() ), std::move( get<T1>() ), std::move( get<Ts>() )... );
+  }
 
-    template <typename T0, typename T1, typename... Ts>
-    VULKAN_HPP_NODISCARD std::tuple<T0 const &&, T1 const &&, Ts const &&...> get() const && VULKAN_HPP_NOEXCEPT
-    {
-      return std::forward_as_tuple( std::move( get<T0>() ), std::move( get<T1>() ), std::move( get<Ts>() )... );
-    }
+  template <typename T0, typename T1, typename... Ts>
+  VULKAN_HPP_NODISCARD std::tuple<T0 const &&, T1 const &&, Ts const &&...> get() const && VULKAN_HPP_NOEXCEPT
+  {
+    return std::forward_as_tuple( std::move( get<T0>() ), std::move( get<T1>() ), std::move( get<Ts>() )... );
+  }
 
-    // assign a complete structure to the StructureChain without modifying the chaining
-    template <typename T = typename std::tuple_element<0, std::tuple<ChainElements...>>::type, size_t Which = 0>
-    StructureChain & assign( T const & rhs ) VULKAN_HPP_NOEXCEPT
-    {
-      T &  lhs   	= get<T, Which>();
-      auto pNext = lhs.pNext;
-      lhs        = rhs;
-      lhs.pNext  = pNext;
-      return *this;
-    }
+  // assign a complete structure to the StructureChain without modifying the chaining
+  template <typename T = typename std::tuple_element<0, std::tuple<ChainElements...>>::type, size_t Which = 0>
+  StructureChain & assign( T const & rhs ) VULKAN_HPP_NOEXCEPT
+  {
+    T &  lhs   	= get<T, Which>();
+    auto pNext = lhs.pNext;
+    lhs        = rhs;
+    lhs.pNext  = pNext;
+    return *this;
+  }
 
-    template <typename ClassType, size_t Which = 0>
-    VULKAN_HPP_NODISCARD
-      typename std::enable_if<std::is_same<ClassType, typename std::tuple_element<0, std::tuple<ChainElements...>>::type>::value && ( Which == 0 ), bool>::type
-      isLinked() const VULKAN_HPP_NOEXCEPT
-    {
-      return true;
-    }
+  template <typename ClassType, size_t Which = 0>
+  VULKAN_HPP_NODISCARD
+    typename std::enable_if<std::is_same<ClassType, typename std::tuple_element<0, std::tuple<ChainElements...>>::type>::value && ( Which == 0 ), bool>::type
+    isLinked() const VULKAN_HPP_NOEXCEPT
+  {
+    return true;
+  }
 
-    template <typename ClassType, size_t Which = 0>
-    VULKAN_HPP_NODISCARD
-      typename std::enable_if<!std::is_same<ClassType, typename std::tuple_element<0, std::tuple<ChainElements...>>::type>::value || ( Which != 0 ), bool>::type
-      isLinked() const VULKAN_HPP_NOEXCEPT
-    {
-      VULKAN_HPP_STATIC_ASSERT( IsPartOfStructureChain<ClassType, ChainElements...>::valid, "Can't unlink Structure that's not part of this StructureChain!" );
-      return isLinked( reinterpret_cast<VkBaseInStructure const *>( &get<ClassType, Which>() ) );
-    }
+  template <typename ClassType, size_t Which = 0>
+  VULKAN_HPP_NODISCARD
+    typename std::enable_if<!std::is_same<ClassType, typename std::tuple_element<0, std::tuple<ChainElements...>>::type>::value || ( Which != 0 ), bool>::type
+    isLinked() const VULKAN_HPP_NOEXCEPT
+  {
+    VULKAN_HPP_STATIC_ASSERT( IsPartOfStructureChain<ClassType, ChainElements...>::valid, "Can't unlink Structure that's not part of this StructureChain!" );
+    return isLinked( reinterpret_cast<VkBaseInStructure const *>( &get<ClassType, Which>() ) );
+  }
 
-    template <typename ClassType, size_t Which = 0>
-    typename std::enable_if<!std::is_same<ClassType, typename std::tuple_element<0, std::tuple<ChainElements...>>::type>::value || ( Which != 0 ), void>::type
-      relink() VULKAN_HPP_NOEXCEPT
-    {
-      VULKAN_HPP_STATIC_ASSERT( IsPartOfStructureChain<ClassType, ChainElements...>::valid, "Can't relink Structure that's not part of this StructureChain!" );
-      auto pNext = reinterpret_cast<VkBaseInStructure *>( &get<ClassType, Which>() );
-      VULKAN_HPP_ASSERT( !isLinked( pNext ) );
-      auto & headElement = std::get<0>( static_cast<std::tuple<ChainElements...> &>( *this ) );
-      pNext->pNext       = reinterpret_cast<VkBaseInStructure const *>( headElement.pNext );
-      headElement.pNext  = pNext;
-    }
+  template <typename ClassType, size_t Which = 0>
+  typename std::enable_if<!std::is_same<ClassType, typename std::tuple_element<0, std::tuple<ChainElements...>>::type>::value || ( Which != 0 ), void>::type
+    relink() VULKAN_HPP_NOEXCEPT
+  {
+    VULKAN_HPP_STATIC_ASSERT( IsPartOfStructureChain<ClassType, ChainElements...>::valid, "Can't relink Structure that's not part of this StructureChain!" );
+    auto pNext = reinterpret_cast<VkBaseInStructure *>( &get<ClassType, Which>() );
+    VULKAN_HPP_ASSERT( !isLinked( pNext ) );
+    auto & headElement = std::get<0>( static_cast<std::tuple<ChainElements...> &>( *this ) );
+    pNext->pNext       = reinterpret_cast<VkBaseInStructure const *>( headElement.pNext );
+    headElement.pNext  = pNext;
+  }
 
-    template <typename ClassType, size_t Which = 0>
-    typename std::enable_if<!std::is_same<ClassType, typename std::tuple_element<0, std::tuple<ChainElements...>>::type>::value || ( Which != 0 ), void>::type
-      unlink() VULKAN_HPP_NOEXCEPT
-    {
-      VULKAN_HPP_STATIC_ASSERT( IsPartOfStructureChain<ClassType, ChainElements...>::valid, "Can't unlink Structure that's not part of this StructureChain!" );
-      unlink( reinterpret_cast<VkBaseOutStructure const *>( &get<ClassType, Which>() ) );
-    }
+  template <typename ClassType, size_t Which = 0>
+  typename std::enable_if<!std::is_same<ClassType, typename std::tuple_element<0, std::tuple<ChainElements...>>::type>::value || ( Which != 0 ), void>::type
+    unlink() VULKAN_HPP_NOEXCEPT
+  {
+    VULKAN_HPP_STATIC_ASSERT( IsPartOfStructureChain<ClassType, ChainElements...>::valid, "Can't unlink Structure that's not part of this StructureChain!" );
+    unlink( reinterpret_cast<VkBaseOutStructure const *>( &get<ClassType, Which>() ) );
+  }
 
-  private:
-    template <int Index, typename T, int Which, typename, class First, class... Types>
-    struct ChainElementIndex : ChainElementIndex<Index + 1, T, Which, void, Types...>
-    {
-    };
-
-    template <int Index, typename T, int Which, class First, class... Types>
-    struct ChainElementIndex<Index, T, Which, typename std::enable_if<!std::is_same<T, First>::value, void>::type, First, Types...>
-      : ChainElementIndex<Index + 1, T, Which, void, Types...>
-    {
-    };
-
-    template <int Index, typename T, int Which, class First, class... Types>
-    struct ChainElementIndex<Index, T, Which, typename std::enable_if<std::is_same<T, First>::value, void>::type, First, Types...>
-      : ChainElementIndex<Index + 1, T, Which - 1, void, Types...>
-    {
-    };
-
-    template <int Index, typename T, class First, class... Types>
-    struct ChainElementIndex<Index, T, 0, typename std::enable_if<std::is_same<T, First>::value, void>::type, First, Types...>
-      : std::integral_constant<int, Index>
-    {
-    };
-
-    VULKAN_HPP_NODISCARD bool isLinked( VkBaseInStructure const * pNext ) const VULKAN_HPP_NOEXCEPT
-    {
-      VkBaseInStructure const * elementPtr =
-        reinterpret_cast<VkBaseInStructure const *>( &std::get<0>( static_cast<std::tuple<ChainElements...> const &>( *this ) ) );
-      while ( elementPtr )
-      {
-        if ( elementPtr->pNext == pNext )
-        {
-          return true;
-        }
-        elementPtr = elementPtr->pNext;
-      }
-      return false;
-    }
-
-    template <size_t Index>
-    typename std::enable_if<Index != 0, void>::type link() VULKAN_HPP_NOEXCEPT
-    {
-      auto & x = std::get<Index - 1>( static_cast<std::tuple<ChainElements...> &>( *this ) );
-      x.pNext  = &std::get<Index>( static_cast<std::tuple<ChainElements...> &>( *this ) );
-      link<Index - 1>();
-    }
-
-    template <size_t Index>
-    typename std::enable_if<Index == 0, void>::type link() VULKAN_HPP_NOEXCEPT
-    {
-    }
-
-    void link( void * dstBase, void const * srcBase, VkBaseOutStructure * dst, VkBaseInStructure const * src )
-    {
-      while ( src->pNext )
-      {
-        std::ptrdiff_t offset = reinterpret_cast<char const *>( src->pNext ) - reinterpret_cast<char const *>( srcBase );
-        dst->pNext            = reinterpret_cast<VkBaseOutStructure *>( reinterpret_cast<char *>( dstBase ) + offset );
-        dst                   = dst->pNext;
-        src                   = src->pNext;
-      }
-      dst->pNext = nullptr;
-    }
-
-    void unlink( VkBaseOutStructure const * pNext ) VULKAN_HPP_NOEXCEPT
-    {
-      VkBaseOutStructure * elementPtr = reinterpret_cast<VkBaseOutStructure *>( &std::get<0>( static_cast<std::tuple<ChainElements...> &>( *this ) ) );
-      while ( elementPtr && ( elementPtr->pNext != pNext ) )
-      {
-        elementPtr = elementPtr->pNext;
-      }
-      if ( elementPtr )
-      {
-        elementPtr->pNext = pNext->pNext;
-      }
-      else
-      {
-        VULKAN_HPP_ASSERT( false );  // fires, if the ClassType member has already been unlinked !
-      }
-    }
+private:
+  template <int Index, typename T, int Which, typename, class First, class... Types>
+  struct ChainElementIndex : ChainElementIndex<Index + 1, T, Which, void, Types...>
+  {
   };
-  // interupt the VULKAN_HPP_NAMESPACE for a moment to add specializations of std::tuple_size and std::tuple_element for the StructureChain!
+
+  template <int Index, typename T, int Which, class First, class... Types>
+  struct ChainElementIndex<Index, T, Which, typename std::enable_if<!std::is_same<T, First>::value, void>::type, First, Types...>
+    : ChainElementIndex<Index + 1, T, Which, void, Types...>
+  {
+  };
+
+  template <int Index, typename T, int Which, class First, class... Types>
+  struct ChainElementIndex<Index, T, Which, typename std::enable_if<std::is_same<T, First>::value, void>::type, First, Types...>
+    : ChainElementIndex<Index + 1, T, Which - 1, void, Types...>
+  {
+  };
+
+  template <int Index, typename T, class First, class... Types>
+  struct ChainElementIndex<Index, T, 0, typename std::enable_if<std::is_same<T, First>::value, void>::type, First, Types...>
+    : std::integral_constant<int, Index>
+  {
+  };
+
+  VULKAN_HPP_NODISCARD bool isLinked( VkBaseInStructure const * pNext ) const VULKAN_HPP_NOEXCEPT
+  {
+    VkBaseInStructure const * elementPtr =
+      reinterpret_cast<VkBaseInStructure const *>( &std::get<0>( static_cast<std::tuple<ChainElements...> const &>( *this ) ) );
+    while ( elementPtr )
+    {
+      if ( elementPtr->pNext == pNext )
+      {
+        return true;
+      }
+      elementPtr = elementPtr->pNext;
+    }
+    return false;
+  }
+
+  template <size_t Index>
+  typename std::enable_if<Index != 0, void>::type link() VULKAN_HPP_NOEXCEPT
+  {
+    auto & x = std::get<Index - 1>( static_cast<std::tuple<ChainElements...> &>( *this ) );
+    x.pNext  = &std::get<Index>( static_cast<std::tuple<ChainElements...> &>( *this ) );
+    link<Index - 1>();
+  }
+
+  template <size_t Index>
+  typename std::enable_if<Index == 0, void>::type link() VULKAN_HPP_NOEXCEPT
+  {
+  }
+
+  void link( void * dstBase, void const * srcBase, VkBaseOutStructure * dst, VkBaseInStructure const * src )
+  {
+    while ( src->pNext )
+    {
+      std::ptrdiff_t offset = reinterpret_cast<char const *>( src->pNext ) - reinterpret_cast<char const *>( srcBase );
+      dst->pNext            = reinterpret_cast<VkBaseOutStructure *>( reinterpret_cast<char *>( dstBase ) + offset );
+      dst                   = dst->pNext;
+      src                   = src->pNext;
+    }
+    dst->pNext = nullptr;
+  }
+
+  void unlink( VkBaseOutStructure const * pNext ) VULKAN_HPP_NOEXCEPT
+  {
+    VkBaseOutStructure * elementPtr = reinterpret_cast<VkBaseOutStructure *>( &std::get<0>( static_cast<std::tuple<ChainElements...> &>( *this ) ) );
+    while ( elementPtr && ( elementPtr->pNext != pNext ) )
+    {
+      elementPtr = elementPtr->pNext;
+    }
+    if ( elementPtr )
+    {
+      elementPtr->pNext = pNext->pNext;
+    }
+    else
+    {
+      VULKAN_HPP_ASSERT( false );  // fires, if the ClassType member has already been unlinked !
+    }
+  }
+};
+// interupt the VULKAN_HPP_NAMESPACE for a moment to add specializations of std::tuple_size and std::tuple_element for the StructureChain!
 }
 
 VULKAN_HPP_EXPORT namespace std
 {
-  template <typename... Elements>
-  struct tuple_size<VULKAN_HPP_NAMESPACE::StructureChain<Elements...>>
-  {
-    static constexpr size_t value = std::tuple_size<std::tuple<Elements...>>::value;
-  };
+template <typename... Elements>
+struct tuple_size<VULKAN_HPP_NAMESPACE::StructureChain<Elements...>>
+{
+  static constexpr size_t value = std::tuple_size<std::tuple<Elements...>>::value;
+};
 
-  template <std::size_t Index, typename... Elements>
-  struct tuple_element<Index, VULKAN_HPP_NAMESPACE::StructureChain<Elements...>>
-  {
-    using type = typename std::tuple_element<Index, std::tuple<Elements...>>::type;
-  };
+template <std::size_t Index, typename... Elements>
+struct tuple_element<Index, VULKAN_HPP_NAMESPACE::StructureChain<Elements...>>
+{
+  using type = typename std::tuple_element<Index, std::tuple<Elements...>>::type;
+};
 }  // namespace std
 
 VULKAN_HPP_EXPORT namespace VULKAN_HPP_NAMESPACE

--- a/generator/snippets/ToStringHppTemplate.hpp
+++ b/generator/snippets/ToStringHppTemplate.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 ${copyrightMessage}
 
 #ifndef VULKAN_TO_STRING_HPP

--- a/generator/snippets/UniqueHandle.hpp
+++ b/generator/snippets/UniqueHandle.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 #if !defined( VULKAN_HPP_NO_SMART_HANDLE )
 template <typename Type, typename Dispatch>
 class UniqueHandleTraits;

--- a/generator/snippets/VideoCppmTemplate.hpp
+++ b/generator/snippets/VideoCppmTemplate.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 ${copyrightMessage}
 
 module;

--- a/generator/snippets/VideoHppTemplate.hpp
+++ b/generator/snippets/VideoHppTemplate.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 ${copyrightMessage}
 
 #ifndef VULKAN_VIDEO_HPP

--- a/generator/snippets/defines.hpp
+++ b/generator/snippets/defines.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 // <tuple> includes <sys/sysmacros.h> through some other header
 // this results in major(x) being resolved to gnu_dev_major(x)
 // which is an expression in a constructor initializer list.

--- a/generator/snippets/includes.hpp
+++ b/generator/snippets/includes.hpp
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
+
 #if !defined( VULKAN_HPP_CXX_MODULE )
 #  include <vulkan/${vulkan_h}>
 // clang-format off

--- a/generator/snippets/resultChecks.hpp
+++ b/generator/snippets/resultChecks.hpp
@@ -1,62 +1,64 @@
+// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+// SPDX-License-Identifier: Apache-2.0
 
-  namespace detail
+namespace detail
+{
+  VULKAN_HPP_INLINE void resultCheck( Result result, char const * message )
   {
-    VULKAN_HPP_INLINE void resultCheck( Result result, char const * message )
-    {
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
-      ignore( result );		// just in case VULKAN_HPP_ASSERT_ON_RESULT is empty
-      ignore( message );
-      VULKAN_HPP_ASSERT_ON_RESULT( result == Result::eSuccess );
+    ignore( result );		// just in case VULKAN_HPP_ASSERT_ON_RESULT is empty
+    ignore( message );
+    VULKAN_HPP_ASSERT_ON_RESULT( result == Result::eSuccess );
 #else
-      if ( result != Result::eSuccess )
-      {
-        throwResultException( result, message );
-      }
-#endif
+    if ( result != Result::eSuccess )
+    {
+      throwResultException( result, message );
     }
+#endif
+  }
 
-    VULKAN_HPP_INLINE void resultCheck( Result result, char const * message, std::initializer_list<Result> successCodes )
-    {
+  VULKAN_HPP_INLINE void resultCheck( Result result, char const * message, std::initializer_list<Result> successCodes )
+  {
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
-      ignore( result );  		// just in case VULKAN_HPP_ASSERT_ON_RESULT is empty
-      ignore( message );
-      ignore( successCodes );	// just in case VULKAN_HPP_ASSERT_ON_RESULT is empty
-      VULKAN_HPP_ASSERT_ON_RESULT( std::find( successCodes.begin(), successCodes.end(), result ) != successCodes.end() );
+    ignore( result );  		// just in case VULKAN_HPP_ASSERT_ON_RESULT is empty
+    ignore( message );
+    ignore( successCodes );	// just in case VULKAN_HPP_ASSERT_ON_RESULT is empty
+    VULKAN_HPP_ASSERT_ON_RESULT( std::find( successCodes.begin(), successCodes.end(), result ) != successCodes.end() );
 #else
-      if ( std::find( successCodes.begin(), successCodes.end(), result ) == successCodes.end() )
-      {
-        throwResultException( result, message );
-      }
-#endif
+    if ( std::find( successCodes.begin(), successCodes.end(), result ) == successCodes.end() )
+    {
+      throwResultException( result, message );
     }
+#endif
+  }
 
-    template <typename HandleType, typename AllocatorType, typename Dispatch>
-    VULKAN_HPP_INLINE void resultCheck( Result                                         result,
-                                        char const *                                   message,
-                                        std::initializer_list<Result>                  successCodes,
-                                        VkDevice                                       device,
-                                        std::vector<HandleType, AllocatorType> const & pipelines,
-                                        AllocationCallbacks const *                    pAllocator,
-                                        Dispatch const &                               d )
-    {
+  template <typename HandleType, typename AllocatorType, typename Dispatch>
+  VULKAN_HPP_INLINE void resultCheck( Result                                         result,
+                                      char const *                                   message,
+                                      std::initializer_list<Result>                  successCodes,
+                                      VkDevice                                       device,
+                                      std::vector<HandleType, AllocatorType> const & pipelines,
+                                      AllocationCallbacks const *                    pAllocator,
+                                      Dispatch const &                               d )
+  {
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
-      ignore( result );  		// just in case VULKAN_HPP_ASSERT_ON_RESULT is empty
-      ignore( message );
-      ignore( successCodes );	// just in case VULKAN_HPP_ASSERT_ON_RESULT is empty
-      ignore( device );
-      ignore( pipelines );
-      ignore( pAllocator );
-      ignore( d );
-      VULKAN_HPP_ASSERT_ON_RESULT( std::find( successCodes.begin(), successCodes.end(), result ) != successCodes.end() );
+    ignore( result );  		// just in case VULKAN_HPP_ASSERT_ON_RESULT is empty
+    ignore( message );
+    ignore( successCodes );	// just in case VULKAN_HPP_ASSERT_ON_RESULT is empty
+    ignore( device );
+    ignore( pipelines );
+    ignore( pAllocator );
+    ignore( d );
+    VULKAN_HPP_ASSERT_ON_RESULT( std::find( successCodes.begin(), successCodes.end(), result ) != successCodes.end() );
 #else
-      if ( std::find( successCodes.begin(), successCodes.end(), result ) == successCodes.end() )
+    if ( std::find( successCodes.begin(), successCodes.end(), result ) == successCodes.end() )
+    {
+      for ( HandleType pipeline : pipelines )
       {
-        for ( HandleType pipeline : pipelines )
-        {
-          d.vkDestroyPipeline( device, static_cast<VkPipeline>( pipeline ), reinterpret_cast<VkAllocationCallbacks const*>( pAllocator ) );
-        }
-        throwResultException( result, message );
+        d.vkDestroyPipeline( device, static_cast<VkPipeline>( pipeline ), reinterpret_cast<VkAllocationCallbacks const*>( pAllocator ) );
       }
-#endif
+      throwResultException( result, message );
     }
-  }  // namespace detail
+#endif
+  }
+}  // namespace detail


### PR DESCRIPTION
As per #2569, all `generator/snippets/*` now have the following license header:

```cpp
// SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
// SPDX-License-Identifier: Apache-2.0
```

This is stripped out when reading the snippet during header generation.
`REUSE.toml` was updated to the minimum of what is now needed.

Auto formatting removed the spurious indents for some snippets. Makes them a bit more readable and does not affect output, so I reckon I should leave it as is.