### PR TITLE
README: Added license to documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2026 The Khronos Group, Inc.
+SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+SPDX-FileCopyrightText: 2026 The Khronos Group, Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+SPDX-FileCopyrightText: 2026 The Khronos Group, Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Building
 
 ## Minimum requirements

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+SPDX-FileCopyrightText: 2026 The Khronos Group, Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Configuration Options
 
 Vulkan-Hpp has several configurable options and features for consumer projects.

--- a/docs/Handles.md
+++ b/docs/Handles.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+SPDX-FileCopyrightText: 2026 The Khronos Group, Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/docs/Handles.md
+++ b/docs/Handles.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Handles in Vulkan-Hpp
 
 The default handle types in Vulkan-Hpp are thin wrappers around the Vulkan C handles.

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+SPDX-FileCopyrightText: 2026 The Khronos Group, Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Usage
 
 This manual assumes familiarity with Vulkan; it details improvements and differences introduced by Vulkan-Hpp.

--- a/docs/VkRaiiProgrammingGuide.md
+++ b/docs/VkRaiiProgrammingGuide.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+SPDX-FileCopyrightText: 2026 The Khronos Group, Inc.
 SPDX-License-Identifier: Apache-2.0
 -->
 

--- a/docs/VkRaiiProgrammingGuide.md
+++ b/docs/VkRaiiProgrammingGuide.md
@@ -1,4 +1,7 @@
-
+<!--
+SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
+SPDX-License-Identifier: Apache-2.0
+-->
 
 # vulkan_raii.hpp: a programming guide
 


### PR DESCRIPTION
More work for #2569, where all documentation files had the following license header added:

```md
<!--
SPDX-FileCopyrightText: 2026 NVIDIA CORPORATION
SPDX-License-Identifier: Apache-2.0
-->
```

#2570 had already added the `2026 The Khronos Group, Inc.` copyright holder to README.md, so I'm not sure what is correct; the repo is managed by Khronos, but @asuessenbach represents NVIDIA, hence the NVIDIA copyright holder in most files?

The newly added [CONTRIBUTING.md](https://github.com/KhronosGroup/Vulkan-Hpp/blob/main/CONTRIBUTING.md) in particular mentions the CLA, which all contributers have signed:

> When you propose a pull request on this repository you must execute a Contributor License Agreement, to confirm you own your work and are granting Khronos the necessary permissions to redistribute it under our licenses.

Does this mean that all public contributions should have Khronos as their copyright holder by default? Would love if you could chime in for this one @KhronosWebservices. The README (updated) and documentation (added) work in question was done in #2358.