### PR TITLE
DispatchLoader: Allow passing explicit `vkGetDeviceProcAddr` to dynamic dispatch loader

### DIFF
--- a/generator/VulkanHppGenerator.cpp
+++ b/generator/VulkanHppGenerator.cpp
@@ -5888,7 +5888,7 @@ std::string VulkanHppGenerator::generateDispatchLoaderDynamicDeviceCommandAssign
   forEachRequiredCommand( requireData,
                           [&]( NameLine const & command, auto const & commandData )
                           {
-                            if ( !listedCommands.contains( command.name ) && command.name.compare( "vkGetDeviceProcAddr" ) && !commandData.second.handle.empty() && isDeviceCommand( commandData.second ) )
+                            if ( !listedCommands.contains( command.name ) && ( command.name != "vkGetDeviceProcAddr" ) && !commandData.second.handle.empty() && isDeviceCommand( commandData.second ) )
                             {
                               deviceCommandAssignments += generateDispatchLoaderDynamicCommandAssignment( command.name, commandData.first, "device" );
                             }

--- a/generator/VulkanHppGenerator.cpp
+++ b/generator/VulkanHppGenerator.cpp
@@ -5834,111 +5834,11 @@ std::string VulkanHppGenerator::generateDeprecatedStructSetters( std::string con
 
 std::string VulkanHppGenerator::generateDispatchLoaderDynamic() const
 {
-  std::string const dispatchLoaderDynamicTemplate = R"(
-  using PFN_dummy = void ( * )();
-
-  class DispatchLoaderDynamic : public DispatchLoaderBase
-  {
-  public:
-${commandMembers}
-
-  public:
-    DispatchLoaderDynamic() VULKAN_HPP_NOEXCEPT = default;
-    DispatchLoaderDynamic( DispatchLoaderDynamic const & rhs ) VULKAN_HPP_NOEXCEPT = default;
-
-    DispatchLoaderDynamic(PFN_vkGetInstanceProcAddr getInstanceProcAddr) VULKAN_HPP_NOEXCEPT
-    {
-      init(getInstanceProcAddr);
-    }
-
-    // This interface does not require a linked vulkan library.
-    DispatchLoaderDynamic( VkInstance                instance,
-                           PFN_vkGetInstanceProcAddr getInstanceProcAddr,
-                           VkDevice                  device            = {},
-                           PFN_vkGetDeviceProcAddr   getDeviceProcAddr = nullptr ) VULKAN_HPP_NOEXCEPT
-    {
-      init( instance, getInstanceProcAddr, device, getDeviceProcAddr );
-    }
-
-    template <typename DynamicLoader
-#if VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL
-      = VULKAN_HPP_NAMESPACE::detail::DynamicLoader
-#endif
-    >
-    void init()
-    {
-      static DynamicLoader dl;
-      init( dl );
-    }
-
-    template <typename DynamicLoader>
-    void init( DynamicLoader const & dl ) VULKAN_HPP_NOEXCEPT
-    {
-      PFN_vkGetInstanceProcAddr getInstanceProcAddr = dl.template getProcAddress<PFN_vkGetInstanceProcAddr>( "vkGetInstanceProcAddr" );
-      init( getInstanceProcAddr );
-    }
-
-    void init( PFN_vkGetInstanceProcAddr getInstanceProcAddr ) VULKAN_HPP_NOEXCEPT
-    {
-      VULKAN_HPP_ASSERT(getInstanceProcAddr);
-
-      vkGetInstanceProcAddr = getInstanceProcAddr;
-
-${initialCommandAssignments}
-    }
-
-    // This interface does not require a linked vulkan library.
-    void init( VkInstance                instance,
-               PFN_vkGetInstanceProcAddr getInstanceProcAddr,
-               VkDevice                  device              = {},
-               PFN_vkGetDeviceProcAddr /*getDeviceProcAddr*/ = nullptr ) VULKAN_HPP_NOEXCEPT
-    {
-      VULKAN_HPP_ASSERT(instance && getInstanceProcAddr);
-      vkGetInstanceProcAddr = getInstanceProcAddr;
-      init( Instance(instance) );
-      if (device)
-      {
-        init( Device(device) );
-      }
-    }
-
-    void init( Instance instanceCpp ) VULKAN_HPP_NOEXCEPT
-    {
-      VkInstance instance = static_cast<VkInstance>( instanceCpp );
-
-${instanceCommandAssignments}
-    }
-
-    void init( Device deviceCpp ) VULKAN_HPP_NOEXCEPT
-    {
-      VkDevice device = static_cast<VkDevice>( deviceCpp );
-
-${deviceCommandAssignments}
-    }
-
-    template <typename DynamicLoader>
-    void init( Instance const & instance, Device const & device, DynamicLoader const & dl ) VULKAN_HPP_NOEXCEPT
-    {
-      PFN_vkGetInstanceProcAddr getInstanceProcAddr = dl.template getProcAddress<PFN_vkGetInstanceProcAddr>( "vkGetInstanceProcAddr" );
-      PFN_vkGetDeviceProcAddr getDeviceProcAddr = dl.template getProcAddress<PFN_vkGetDeviceProcAddr>( "vkGetDeviceProcAddr" );
-      init( static_cast<VkInstance>( instance ), getInstanceProcAddr, static_cast<VkDevice>( device ), device ? getDeviceProcAddr : nullptr );
-    }
-
-    template <typename DynamicLoader
-#if VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL
-      = VULKAN_HPP_NAMESPACE::detail::DynamicLoader
-#endif
-    >
-    void init( Instance const & instance, Device const & device ) VULKAN_HPP_NOEXCEPT
-    {
-      static DynamicLoader dl;
-      init(instance, device, dl);
-    }
-  };
-)";
+  std::string const dispatchLoaderDynamicTemplate = readSnippet( "DispatchLoaderDynamic.hpp" );
 
   std::string           commandMembers, deviceCommandAssignments, initialCommandAssignments, instanceCommandAssignments;
   std::set<std::string> listedCommands;  // some commands are listed with more than one extension!
+
   for ( auto const & feature : m_features )
   {
     commandMembers += generateDispatchLoaderDynamicCommandMembers( feature.requireData, listedCommands, feature.name );
@@ -5988,7 +5888,7 @@ std::string VulkanHppGenerator::generateDispatchLoaderDynamicDeviceCommandAssign
   forEachRequiredCommand( requireData,
                           [&]( NameLine const & command, auto const & commandData )
                           {
-                            if ( !listedCommands.contains( command.name ) && !commandData.second.handle.empty() && isDeviceCommand( commandData.second ) )
+                            if ( !listedCommands.contains( command.name ) && command.name.compare( "vkGetDeviceProcAddr" ) && !commandData.second.handle.empty() && isDeviceCommand( commandData.second ) )
                             {
                               deviceCommandAssignments += generateDispatchLoaderDynamicCommandAssignment( command.name, commandData.first, "device" );
                             }

--- a/generator/VulkanHppGenerator.cpp
+++ b/generator/VulkanHppGenerator.cpp
@@ -5888,6 +5888,7 @@ std::string VulkanHppGenerator::generateDispatchLoaderDynamicDeviceCommandAssign
   forEachRequiredCommand( requireData,
                           [&]( NameLine const & command, auto const & commandData )
                           {
+                            // ignore vkGetDeviceProcAddr as it is already part of instance command assignments
                             if ( !listedCommands.contains( command.name ) && ( command.name != "vkGetDeviceProcAddr" ) && !commandData.second.handle.empty() && isDeviceCommand( commandData.second ) )
                             {
                               deviceCommandAssignments += generateDispatchLoaderDynamicCommandAssignment( command.name, commandData.first, "device" );

--- a/generator/snippets/DispatchLoaderDynamic.hpp
+++ b/generator/snippets/DispatchLoaderDynamic.hpp
@@ -55,18 +55,23 @@ public:
 
     // This interface does not require a linked vulkan library.
     void init( VkInstance                instance,
-               PFN_vkGetInstanceProcAddr getInstanceProcAddr,
-               VkDevice                  device              = {},
-               PFN_vkGetDeviceProcAddr   getDeviceProcAddr = nullptr ) VULKAN_HPP_NOEXCEPT
+               PFN_vkGetInstanceProcAddr getInstanceProcAddr) VULKAN_HPP_NOEXCEPT
     {
         VULKAN_HPP_ASSERT(instance && getInstanceProcAddr);
         vkGetInstanceProcAddr = getInstanceProcAddr;
-        vkGetDeviceProcAddr = getDeviceProcAddr;
         init( Instance(instance) );
-        if (device)
-        {
+    }
+
+    // This interface does not require a linked vulkan library.
+    void init( VkInstance                instance,
+               PFN_vkGetInstanceProcAddr getInstanceProcAddr,
+               VkDevice                  device,
+               PFN_vkGetDeviceProcAddr   getDeviceProcAddr ) VULKAN_HPP_NOEXCEPT
+    {
+        init( instance, getInstanceProcAddr );
+        VULKAN_HPP_ASSERT( device && getDeviceProcAddr );
+        vkGetDeviceProcAddr = getDeviceProcAddr;
         init( Device(device) );
-        }
     }
 
     void init( Instance instanceCpp ) VULKAN_HPP_NOEXCEPT

--- a/generator/snippets/DispatchLoaderDynamic.hpp
+++ b/generator/snippets/DispatchLoaderDynamic.hpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 The Khronos Group, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+using PFN_dummy = void ( * )();
+
+class DispatchLoaderDynamic : public DispatchLoaderBase
+{
+public:
+        ${commandMembers}
+
+public:
+    DispatchLoaderDynamic() VULKAN_HPP_NOEXCEPT = default;
+    DispatchLoaderDynamic( DispatchLoaderDynamic const & rhs ) VULKAN_HPP_NOEXCEPT = default;
+
+    DispatchLoaderDynamic(PFN_vkGetInstanceProcAddr getInstanceProcAddr) VULKAN_HPP_NOEXCEPT
+    {
+        init(getInstanceProcAddr);
+    }
+
+    // This interface does not require a linked vulkan library.
+    DispatchLoaderDynamic( VkInstance                instance,
+                            PFN_vkGetInstanceProcAddr getInstanceProcAddr,
+                            VkDevice                  device            = {},
+                            PFN_vkGetDeviceProcAddr   getDeviceProcAddr = nullptr ) VULKAN_HPP_NOEXCEPT
+    {
+        init( instance, getInstanceProcAddr, device, getDeviceProcAddr );
+    }
+
+    template <typename DynamicLoader
+    #if VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL
+        = VULKAN_HPP_NAMESPACE::detail::DynamicLoader
+    #endif
+    >
+    void init()
+    {
+        static DynamicLoader dl;
+        init( dl );
+    }
+
+    template <typename DynamicLoader>
+    void init( DynamicLoader const & dl ) VULKAN_HPP_NOEXCEPT
+    {
+        PFN_vkGetInstanceProcAddr getInstanceProcAddr = dl.template getProcAddress<PFN_vkGetInstanceProcAddr>( "vkGetInstanceProcAddr" );
+        init( getInstanceProcAddr );
+    }
+
+    void init( PFN_vkGetInstanceProcAddr getInstanceProcAddr ) VULKAN_HPP_NOEXCEPT
+    {
+        VULKAN_HPP_ASSERT(getInstanceProcAddr);
+
+        vkGetInstanceProcAddr = getInstanceProcAddr;
+
+    ${initialCommandAssignments}
+    }
+
+    // This interface does not require a linked vulkan library.
+    void init( VkInstance                instance,
+               PFN_vkGetInstanceProcAddr getInstanceProcAddr,
+               VkDevice                  device              = {},
+               PFN_vkGetDeviceProcAddr   getDeviceProcAddr = nullptr ) VULKAN_HPP_NOEXCEPT
+    {
+        VULKAN_HPP_ASSERT(instance && getInstanceProcAddr);
+        vkGetInstanceProcAddr = getInstanceProcAddr;
+        vkGetDeviceProcAddr = getDeviceProcAddr;
+        init( Instance(instance) );
+        if (device)
+        {
+        init( Device(device) );
+        }
+    }
+
+    void init( Instance instanceCpp ) VULKAN_HPP_NOEXCEPT
+    {
+        VkInstance instance = static_cast<VkInstance>( instanceCpp );
+
+    ${instanceCommandAssignments}
+    }
+
+    void init( Device deviceCpp ) VULKAN_HPP_NOEXCEPT
+    {
+        VkDevice device = static_cast<VkDevice>( deviceCpp );
+
+    ${deviceCommandAssignments}
+    }
+
+    template <typename DynamicLoader>
+    void init( Instance const & instance, Device const & device, DynamicLoader const & dl ) VULKAN_HPP_NOEXCEPT
+    {
+        PFN_vkGetInstanceProcAddr getInstanceProcAddr = dl.template getProcAddress<PFN_vkGetInstanceProcAddr>( "vkGetInstanceProcAddr" );
+        PFN_vkGetDeviceProcAddr getDeviceProcAddr = dl.template getProcAddress<PFN_vkGetDeviceProcAddr>( "vkGetDeviceProcAddr" );
+        init( static_cast<VkInstance>( instance ), getInstanceProcAddr, static_cast<VkDevice>( device ), device ? getDeviceProcAddr : nullptr );
+    }
+
+    template <typename DynamicLoader
+    #if VULKAN_HPP_ENABLE_DYNAMIC_LOADER_TOOL
+        = VULKAN_HPP_NAMESPACE::detail::DynamicLoader
+    #endif
+    >
+    void init( Instance const & instance, Device const & device ) VULKAN_HPP_NOEXCEPT
+    {
+        static DynamicLoader dl;
+        init(instance, device, dl);
+    }
+};

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -24162,13 +24162,12 @@ VULKAN_HPP_EXPORT namespace VULKAN_HPP_NAMESPACE
       }
 
       // This interface does not require a linked vulkan library.
-      void init( VkInstance                instance,
-                 PFN_vkGetInstanceProcAddr getInstanceProcAddr,
-                 VkDevice                  device              = {},
-                 PFN_vkGetDeviceProcAddr /*getDeviceProcAddr*/ = nullptr ) VULKAN_HPP_NOEXCEPT
+      void init( VkInstance instance, PFN_vkGetInstanceProcAddr getInstanceProcAddr, VkDevice device = {}, PFN_vkGetDeviceProcAddr getDeviceProcAddr = nullptr )
+        VULKAN_HPP_NOEXCEPT
       {
         VULKAN_HPP_ASSERT( instance && getInstanceProcAddr );
         vkGetInstanceProcAddr = getInstanceProcAddr;
+        vkGetDeviceProcAddr   = getDeviceProcAddr;
         init( Instance( instance ) );
         if ( device )
         {
@@ -25860,7 +25859,6 @@ VULKAN_HPP_EXPORT namespace VULKAN_HPP_NAMESPACE
         VkDevice device = static_cast<VkDevice>( deviceCpp );
 
         //=== VK_VERSION_1_0 ===
-        vkGetDeviceProcAddr                = PFN_vkGetDeviceProcAddr( vkGetDeviceProcAddr( device, "vkGetDeviceProcAddr" ) );
         vkDestroyDevice                    = PFN_vkDestroyDevice( vkGetDeviceProcAddr( device, "vkDestroyDevice" ) );
         vkGetDeviceQueue                   = PFN_vkGetDeviceQueue( vkGetDeviceProcAddr( device, "vkGetDeviceQueue" ) );
         vkQueueSubmit                      = PFN_vkQueueSubmit( vkGetDeviceProcAddr( device, "vkQueueSubmit" ) );
@@ -27205,7 +27203,6 @@ VULKAN_HPP_EXPORT namespace VULKAN_HPP_NAMESPACE
         init( instance, device, dl );
       }
     };
-
 #if defined( VULKAN_HPP_CXX_MODULE ) && !defined( VULKAN_HPP_DEFAULT_DISPATCHER_HANDLED ) && VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
     VULKAN_HPP_STORAGE_API DispatchLoaderDynamic defaultDispatchLoaderDynamic;
 #endif

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -24162,17 +24162,21 @@ VULKAN_HPP_EXPORT namespace VULKAN_HPP_NAMESPACE
       }
 
       // This interface does not require a linked vulkan library.
-      void init( VkInstance instance, PFN_vkGetInstanceProcAddr getInstanceProcAddr, VkDevice device = {}, PFN_vkGetDeviceProcAddr getDeviceProcAddr = nullptr )
-        VULKAN_HPP_NOEXCEPT
+      void init( VkInstance instance, PFN_vkGetInstanceProcAddr getInstanceProcAddr ) VULKAN_HPP_NOEXCEPT
       {
         VULKAN_HPP_ASSERT( instance && getInstanceProcAddr );
         vkGetInstanceProcAddr = getInstanceProcAddr;
-        vkGetDeviceProcAddr   = getDeviceProcAddr;
         init( Instance( instance ) );
-        if ( device )
-        {
-          init( Device( device ) );
-        }
+      }
+
+      // This interface does not require a linked vulkan library.
+      void init( VkInstance instance, PFN_vkGetInstanceProcAddr getInstanceProcAddr, VkDevice device, PFN_vkGetDeviceProcAddr getDeviceProcAddr )
+        VULKAN_HPP_NOEXCEPT
+      {
+        init( instance, getInstanceProcAddr );
+        VULKAN_HPP_ASSERT( device && getDeviceProcAddr );
+        vkGetDeviceProcAddr = getDeviceProcAddr;
+        init( Device( device ) );
       }
 
       void init( Instance instanceCpp ) VULKAN_HPP_NOEXCEPT


### PR DESCRIPTION
This will resolve #2578.

This function signature overload for `DispatchLoaderDynamic::init` previously did not do anything with the `vkGetDeviceProcAddr` param:

```cpp
// This interface does not require a linked vulkan library.
void init( VkInstance                instance,
           PFN_vkGetInstanceProcAddr getInstanceProcAddr,
           VkDevice                  device              = {},
           PFN_vkGetDeviceProcAddr /*getDeviceProcAddr*/ = nullptr ) VULKAN_HPP_NOEXCEPT
{
  VULKAN_HPP_ASSERT( instance && getInstanceProcAddr );
  vkGetInstanceProcAddr = getInstanceProcAddr;
  init( Instance( instance ) );
  if ( device )
  {
    init( Device( device ) );
  }
}
```

This PR does 4 things:
1. Changed aforementioned function to now use the `vkGetDeviceProcAddr` parameter
2. Removed default parameter assignments from aforementioned function
3. Added function overload that _only_ takes instance and `vkInstanceProcAddr`
4. Removed surplus load of `vkGetDeviceProcAddr` in `void init( Device deviceCpp )`

I'm marking this as draft for now, as CI does not run these tests and thus, this change could be dangerous without proper testing. Please give it a try and see if it works for you @PancakeTAS