### PR TITLE
Docs: Updated module example

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -865,8 +865,6 @@ find_package( Vulkan 1.4.350 QUIET )
 if( NOT Vulkan_FOUND )
     # when you do not have the right version installed, just fetch the headers directly
     include(FetchContent)
-    # disable the automatic module target since may result in cmake ICE (last tested with 4.3.20260521-gd36a884)
-    set(VULKAN_HEADERS_ENABLE_MODULE OFF)
     FetchContent_Declare(vulkan-headers
         URL https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.4.350.zip
         URL_HASH SHA256=92b80c2d746297e1856e2864e1e244ca116de20d72c728f33596aaa79120d565

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -864,27 +864,15 @@ find_package( Vulkan 1.4.350 QUIET )
 if( NOT Vulkan_FOUND )
     # when you do not have the right version installed, just fetch the headers directly
     include(FetchContent)
-    # disable the automatic module target since it results in cmake ICE (last tested with 4.3.20260521-gd36a884)
+    # disable the automatic module target since may result in cmake ICE (last tested with 4.3.20260521-gd36a884)
     set(VULKAN_HEADERS_ENABLE_MODULE OFF)
-    if( TRUE ) # Option 1: Fetch only the released .zip or .tar.gz
-        FetchContent_Declare(vulkan-headers
-            URL https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.4.350.zip
-            URL_HASH SHA256=92b80c2d746297e1856e2864e1e244ca116de20d72c728f33596aaa79120d565
-            # URL https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.4.350.tar.gz
-            # URL_HASH SHA256=6dd105e5cc7ddab6e7b611ae2c1872740d1727557cc8bf9daf13d6de1e4b3999
-            USES_TERMINAL_DOWNLOAD TRUE
-            OVERRIDE_FIND_PACKAGE
-            EXCLUDE_FROM_ALL
-            SYSTEM)
-    else() # Option 2: Fetch the full repository
-        FetchContent_Declare(vulkan-headers
-            GIT_REPOSITORY "https://github.com/KhronosGroup/Vulkan-Headers.git"
-            GIT_TAG "v1.4.350"
-            GIT_SHALLOW ON
-            OVERRIDE_FIND_PACKAGE
-            EXCLUDE_FROM_ALL
-            SYSTEM)
-    endif()
+    FetchContent_Declare(vulkan-headers
+        URL https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.4.350.zip
+        URL_HASH SHA256=92b80c2d746297e1856e2864e1e244ca116de20d72c728f33596aaa79120d565
+        USES_TERMINAL_DOWNLOAD TRUE
+        OVERRIDE_FIND_PACKAGE
+        EXCLUDE_FROM_ALL
+        SYSTEM)
     FetchContent_MakeAvailable(vulkan-headers)
     # make sure to set up the include path as if found by find_package
     set(Vulkan_INCLUDE_DIR "${vulkan-headers_SOURCE_DIR}/include")

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -842,13 +842,19 @@ This UUID variable may also be set before the `project()` call, or in a [CMake p
 A complete example `CMakeLists.txt` file for a project using the Vulkan-Hpp named module is provided below.
 
 ```cmake
-# CMake 3.30 has experimental support for `import std;`
-# But we recommend using CMake 4.3 or later, which has more stable support for this feature
 cmake_minimum_required( VERSION 4.3 )
 
-# either set this here or on the CLI (example UUID for 4.3)
+# either set the experimental gate here or via CLI
 if( NOT CMAKE_EXPERIMENTAL_CXX_IMPORT_STD )
-    set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD 451f2fe2-a8a2-47c3-bc32-94786d8fc91b)
+    if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL 4.3 )
+        set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD 451f2fe2-a8a2-47c3-bc32-94786d8fc91b)
+    elseif( ${CMAKE_VERSION} VERSION_GREATER_EQUAL 4.2 )
+        set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD d0edc3af-4c50-42ea-a356-e2862fe7a444)
+    elseif( ${CMAKE_VERSION} VERSION_GREATER_EQUAL 4.0 )
+        set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD 1942b4fa-b2c5-4546-9385-83f254070067)
+	elseif( ${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.30 )
+        set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD 0e5b6991-d74f-4b3d-a41c-cf096e0b2508)
+    endif()
 endif()
 project( vulkan_hpp_modules_example LANGUAGES CXX )
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -832,6 +832,7 @@ If you have CMake versions between 3.30 and 4.3, where the [`CXX_MODULE_STD`](ht
 To find the precise value for your specific version, check out the correct release tag and look for `CMAKE_EXPERIMENTAL_CXX_IMPORT_STD` in [Help/dev/experimental.rst](https://gitlab.kitware.com/cmake/cmake/-/blob/master/Help/dev/experimental.rst).
 
 ```bash
+# example UUID for CMake 4.3
 cmake -DCMAKE_EXPERIMENTAL_CXX_IMPORT_STD=451f2fe2-a8a2-47c3-bc32-94786d8fc91b ...
 ```
 
@@ -842,7 +843,7 @@ This UUID variable may also be set before the `project()` call, or in a [CMake p
 A complete example `CMakeLists.txt` file for a project using the Vulkan-Hpp named module is provided below.
 
 ```cmake
-cmake_minimum_required( VERSION 4.3 )
+cmake_minimum_required( VERSION 3.30...4.3 )
 
 # either set the experimental gate here or via CLI
 if( NOT CMAKE_EXPERIMENTAL_CXX_IMPORT_STD )

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -828,11 +828,11 @@ CMake provides the [FindVulkan module](https://cmake.org/cmake/help/latest/modul
 <details>
 <summary>For CMake versions earlier than 4.3.0</summary>
 
-If you have CMake versions between 3.30 and 4.2, where the [`CXX_MODULE_STD`](https://cmake.org/cmake/help/v4.2/prop_tgt/CXX_MODULE_STD.html) variable is still experimental, then make sure to provide the following UUID to enable CMake's experimental support for the C++ standard library module.
+If you have CMake versions between 3.30 and 4.3, where the [`CXX_MODULE_STD`](https://cmake.org/cmake/help/v4.3/prop_tgt/CXX_MODULE_STD.html) variable is still experimental, then make sure to provide the following UUID to enable CMake's experimental support for the C++ standard library module.
 To find the precise value for your specific version, check out the correct release tag and look for `CMAKE_EXPERIMENTAL_CXX_IMPORT_STD` in [Help/dev/experimental.rst](https://gitlab.kitware.com/cmake/cmake/-/blob/master/Help/dev/experimental.rst).
 
 ```bash
-cmake -DCMAKE_EXPERIMENTAL_CXX_IMPORT_STD=d0edc3af-4c50-42ea-a356-e2862fe7a444 ...
+cmake -DCMAKE_EXPERIMENTAL_CXX_IMPORT_STD=451f2fe2-a8a2-47c3-bc32-94786d8fc91b ...
 ```
 
 This UUID variable may also be set before the `project()` call, or in a [CMake preset file](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#configure-preset) in the `cacheVariables` key for a configure preset.
@@ -843,17 +843,50 @@ A complete example `CMakeLists.txt` file for a project using the Vulkan-Hpp name
 
 ```cmake
 # CMake 3.30 has experimental support for `import std;`
-# But we recommend using CMake 4.3 or later, which has stable support for this feature
-cmake_minimum_required( VERSION 4.3.0 )
+# But we recommend using CMake 4.3 or later, which has more stable support for this feature
+cmake_minimum_required( VERSION 4.3 )
 
+# either set this here or on the CLI (example UUID for 4.3)
+if( NOT CMAKE_EXPERIMENTAL_CXX_IMPORT_STD )
+    set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD 451f2fe2-a8a2-47c3-bc32-94786d8fc91b)
+endif()
 project( vulkan_hpp_modules_example LANGUAGES CXX )
 
 # Although modules were first made available in Vulkan-Headers v1.3.256,
-# they have changed drastically since then and this example assumes version 1.4.344
-find_package( Vulkan 1.4.344 QUIET )
-if ( Vulkan_FOUND )
-    # set up Vulkan C++ module as a static library
-    add_library( Vulkan-HppModule STATIC )
+# they have changed drastically since then and this example assumes version 1.4.350
+find_package( Vulkan 1.4.350 QUIET )
+if( NOT Vulkan_FOUND )
+    # when you do not have the right version installed, just fetch the headers directly
+    include(FetchContent)
+    # disable the automatic module target since it results in cmake ICE (last tested with 4.3.20260521-gd36a884)
+    set(VULKAN_HEADERS_ENABLE_MODULE OFF)
+    if( TRUE ) # Option 1: Fetch only the released .zip or .tar.gz
+        FetchContent_Declare(vulkan-headers
+            URL https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.4.350.zip
+            URL_HASH SHA256=92b80c2d746297e1856e2864e1e244ca116de20d72c728f33596aaa79120d565
+            # URL https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.4.350.tar.gz
+            # URL_HASH SHA256=6dd105e5cc7ddab6e7b611ae2c1872740d1727557cc8bf9daf13d6de1e4b3999
+            USES_TERMINAL_DOWNLOAD TRUE
+            OVERRIDE_FIND_PACKAGE
+            EXCLUDE_FROM_ALL
+            SYSTEM)
+    else() # Option 2: Fetch the full repository
+        FetchContent_Declare(vulkan-headers
+            GIT_REPOSITORY "https://github.com/KhronosGroup/Vulkan-Headers.git"
+            GIT_TAG "v1.4.350"
+            GIT_SHALLOW ON
+            OVERRIDE_FIND_PACKAGE
+            EXCLUDE_FROM_ALL
+            SYSTEM)
+    endif()
+    FetchContent_MakeAvailable(vulkan-headers)
+    # make sure to set up the include path as if found by find_package
+    set(Vulkan_INCLUDE_DIR "${vulkan-headers_SOURCE_DIR}/include")
+endif()
+
+# manually create module target if it was not previously provided
+if( NOT TARGET Vulkan::HppModule )
+    add_library( Vulkan-HppModule OBJECT )
     add_library( Vulkan::HppModule ALIAS Vulkan-HppModule )
     target_sources( Vulkan-HppModule PUBLIC
         FILE_SET CXX_MODULES
@@ -861,34 +894,20 @@ if ( Vulkan_FOUND )
         FILES
             ${Vulkan_INCLUDE_DIR}/vulkan/vulkan.cppm
             ${Vulkan_INCLUDE_DIR}/vulkan/vulkan_video.cppm)
-else()
-    # when you do not have the right version installed, just fetch the headers directly
-    include(FetchContent)
-    FetchContent_Declare(vulkan-headers
-        GIT_REPOSITORY "https://github.com/KhronosGroup/Vulkan-Headers.git"
-        GIT_TAG "v1.4.344"
-        GIT_SHALLOW ON
-        OVERRIDE_FIND_PACKAGE
-        SYSTEM)
-    FetchContent_MakeAvailable(vulkan-headers)
-    # make sure to set up the include path for CMake
-    set(Vulkan_INCLUDE_DIR "${vulkan-headers_SOURCE_DIR}/include")
+    target_compile_features( Vulkan-HppModule PUBLIC cxx_std_23 )
+    set_target_properties( Vulkan-HppModule PROPERTIES CXX_MODULE_STD ON )
+    target_include_directories( Vulkan-HppModule PUBLIC ${Vulkan_INCLUDE_DIR} )
 endif()
 
-# configure the module target (import std currently requires C++23 with CMake)
-target_compile_features( Vulkan-HppModule PUBLIC cxx_std_23 )
-set_target_properties( Vulkan-HppModule PROPERTIES CXX_MODULE_STD ON )
-
 if( TRUE ) # if you want to use the dynamic dispatcher
-    target_link_libraries( Vulkan-HppModule PUBLIC Vulkan::Headers )
     target_compile_definitions( Vulkan-HppModule PUBLIC VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
-else() # otherwise, use Vulkan::Vulkan to link to vulkan-1
+else() # otherwise, use Vulkan::Vulkan to link to vulkan-1 (requires discovery via find_package)
     target_link_libraries( Vulkan-HppModule PUBLIC Vulkan::Vulkan )
 endif()
 
 # link Vulkan-Hpp C++ module into user project
-add_executable( YourProject main.cpp )
-target_link_libraries( YourProject PRIVATE Vulkan-HppModule )
+add_executable( ${PROJECT_NAME} "main.cpp" )
+target_link_libraries( ${PROJECT_NAME} PRIVATE Vulkan::HppModule )
 ```
 
 Configuring the named module is straightforward; add any required Vulkan-Hpp feature macros listed in [Configuration](./Configuration.md) (or any C macros) to `target_compile_definitions`.


### PR DESCRIPTION
This will resolve #2508.

This PR updates the example to show how to fetch the .zip or .tar.gz version of Vulkan-Headers, which is much more lightweight. It is also updated to use the most recent SDK version (v1.4.350).

There appears to be a CMake bug with this current example when trying to configure this project:

```
cmake/Source/cmTarget.cxx:1741: void cmTarget::CopyPolicyStatuses(const cmTarget *): Assertion `tgt->IsImported() || tgt->IsNormal()' failed.
```

It seems related to the latest SDK version when using the `Vulkan::HppModule` target provided by `Vulkan-Headers`, as it did not error out like this previously. I have therefore disabled the automatic module target creation until we figure out what is wrong:

```cmake
set(VULKAN_HEADERS_ENABLE_MODULE OFF)
```

Tracking CMake issue in https://gitlab.kitware.com/cmake/cmake/-/work_items/27834

<details>

<summary>Try reproducing it yourself with this CMakeLists.txt</summary>

```cmake
# CMake 3.30 has experimental support for `import std;`
# But we recommend using CMake 4.3 or later, which has more stable support for this feature
cmake_minimum_required( VERSION 4.3 )

# either set this here or on the CLI (example UUID for 4.3)
if( NOT CMAKE_EXPERIMENTAL_CXX_IMPORT_STD )
    set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD 451f2fe2-a8a2-47c3-bc32-94786d8fc91b)
endif()
project( vulkan_hpp_modules_example LANGUAGES CXX )

# Although modules were first made available in Vulkan-Headers v1.3.256,
# they have changed drastically since then and this example assumes version 1.4.350
find_package( Vulkan 1.4.350 QUIET )
if( NOT Vulkan_FOUND )
    # when you do not have the right version installed, just fetch the headers directly
    include(FetchContent)
    # disable the automatic module target since it results in cmake ICE (last tested with 4.3.20260521-gd36a884)
    # set(VULKAN_HEADERS_ENABLE_MODULE OFF)
    if( TRUE ) # Option 1: Fetch only the released .zip or .tar.gz
        FetchContent_Declare(vulkan-headers
            URL https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.4.350.zip
            URL_HASH SHA256=92b80c2d746297e1856e2864e1e244ca116de20d72c728f33596aaa79120d565
            # URL https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.4.350.tar.gz
            # URL_HASH SHA256=6dd105e5cc7ddab6e7b611ae2c1872740d1727557cc8bf9daf13d6de1e4b3999
            USES_TERMINAL_DOWNLOAD TRUE
            OVERRIDE_FIND_PACKAGE
            EXCLUDE_FROM_ALL
            SYSTEM)
    else() # Option 2: Fetch the full repository
        FetchContent_Declare(vulkan-headers
            GIT_REPOSITORY "https://github.com/KhronosGroup/Vulkan-Headers.git"
            GIT_TAG "v1.4.350"
            GIT_SHALLOW ON
            OVERRIDE_FIND_PACKAGE
            EXCLUDE_FROM_ALL
            SYSTEM)
    endif()
    FetchContent_MakeAvailable(vulkan-headers)
    # make sure to set up the include path as if found by find_package
    set(Vulkan_INCLUDE_DIR "${vulkan-headers_SOURCE_DIR}/include")
endif()

# manually create module target if it was not previously provided
if( NOT TARGET Vulkan::HppModule )
    add_library( Vulkan-HppModule OBJECT )
    add_library( Vulkan::HppModule ALIAS Vulkan-HppModule )
    target_sources( Vulkan-HppModule PUBLIC
        FILE_SET CXX_MODULES
        BASE_DIRS ${Vulkan_INCLUDE_DIR}
        FILES
            ${Vulkan_INCLUDE_DIR}/vulkan/vulkan.cppm
            ${Vulkan_INCLUDE_DIR}/vulkan/vulkan_video.cppm)
    target_compile_features( Vulkan-HppModule PUBLIC cxx_std_23 )
    set_target_properties( Vulkan-HppModule PROPERTIES CXX_MODULE_STD ON )
    target_include_directories( Vulkan-HppModule PUBLIC ${Vulkan_INCLUDE_DIR} )
endif()

if( TRUE ) # if you want to use the dynamic dispatcher
    target_compile_definitions( Vulkan-HppModule PUBLIC VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
else() # otherwise, use Vulkan::Vulkan to link to vulkan-1 (requires discovery via find_package)
    target_link_libraries( Vulkan-HppModule PUBLIC Vulkan::Vulkan )
endif()

# link Vulkan-Hpp C++ module into user project
add_executable( ${PROJECT_NAME} "main.cpp" )
target_link_libraries( ${PROJECT_NAME} PRIVATE Vulkan::HppModule )

```


</details>