### PR TITLE
Add 32-bit Linux CI coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
       if: contains(matrix.env.os, 'ubuntu')
       run: |
         sudo apt update
-        sudo apt install -y libgl-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev ${{ matrix.env.ubuntu_packages || '' }}
+        sudo apt install -y libgl-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev ${{ contains(matrix.env.arch, 'x86') && format('{0}-multilib {1}-multilib', matrix.env.c, matrix.env.cxx) || '' }}
     - name: Setup MacOS
       if: contains(matrix.env.os, 'macos')
       run: brew install molten-vk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
       VAR_CMAKE_FLAGS: |
         ${{ matrix.env.c && format('-D CMAKE_C_COMPILER={0}', matrix.env.c) }} \
         ${{ matrix.env.cxx && format('-D CMAKE_CXX_COMPILER={0}', matrix.env.cxx) }} \
-        ${{ matrix.env.c_flags && format('-D CMAKE_C_FLAGS''={0}''', matrix.env.c_flags) }} \
+        ${{ matrix.env.c_flags && format('-D CMAKE_C_FLAGS={0}', matrix.env.c_flags) }} \
         ${{ matrix.env.cxx_flags && format('-D CMAKE_CXX_FLAGS''={0}''', matrix.env.cxx_flags) }} \
         ${{ matrix.env.linker_flags && format('-D CMAKE_EXE_LINKER_FLAGS=''{0}''', matrix.env.linker_flags) }} \
 
@@ -116,7 +116,7 @@ jobs:
 
     # Build samples using highest available C++ standard.
     - name: Build Samples with C++${{matrix.env.cxx_max}}
-      if: (!matrix.env.modules) && (!matrix.env.skip_samples) # Exclude module and cross-compilation runners.
+      if: (!matrix.env.modules) && (!contains(matrix.env.arch, 'x86')) # Exclude module and cross-compilation runners.
       run: |
         for BUILD_TYPE in Debug Release; do
           cmake -B build -G '${{matrix.env.gen}}' --fresh --preset samples \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           { os: ubuntu-24.04,        cxx: g++-12,           c: gcc-12,         arch: x64, gen: Ninja,                 cxx_max: 23 },
           { os: ubuntu-24.04,        cxx: g++-13,           c: gcc-13,         arch: x64, gen: Ninja,                 cxx_max: 23 },
           { os: ubuntu-24.04,        cxx: g++-14,           c: gcc-14,         arch: x64, gen: Ninja,                 cxx_max: 23 },
-          { os: ubuntu-24.04,        cxx: g++-14,           c: gcc-14,         arch: x86, gen: Ninja,                 cxx_max: 23, c_flags: '-m32', cxx_flags: '-m32', linker_flags: '-m32', ubuntu_packages: 'gcc-14-multilib g++-14-multilib', skip_samples: true },
+          { os: ubuntu-24.04,        cxx: g++-14,           c: gcc-14,         arch: x86, gen: Ninja,                 cxx_max: 23, c_flags: '-m32', cxx_flags: '-m32', linker_flags: '-m32' },
           { os: ubuntu-24.04,        cxx: clang++-16,       c: clang-16,       arch: x64, gen: Ninja,                 cxx_max: 20 },
           { os: ubuntu-24.04,        cxx: clang++-17,       c: clang-17,       arch: x64, gen: Ninja,                 cxx_max: 20 },
           { os: ubuntu-24.04,        cxx: clang++-18,       c: clang-18,       arch: x64, gen: Ninja,                 cxx_max: 23 },

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
           { os: ubuntu-24.04,        cxx: g++-12,           c: gcc-12,         arch: x64, gen: Ninja,                 cxx_max: 23 },
           { os: ubuntu-24.04,        cxx: g++-13,           c: gcc-13,         arch: x64, gen: Ninja,                 cxx_max: 23 },
           { os: ubuntu-24.04,        cxx: g++-14,           c: gcc-14,         arch: x64, gen: Ninja,                 cxx_max: 23 },
+          { os: ubuntu-24.04,        cxx: g++-14,           c: gcc-14,         arch: x86, gen: Ninja,                 cxx_max: 23, c_flags: '-m32', cxx_flags: '-m32', linker_flags: '-m32', ubuntu_packages: 'gcc-14-multilib g++-14-multilib', skip_samples: true },
           { os: ubuntu-24.04,        cxx: clang++-16,       c: clang-16,       arch: x64, gen: Ninja,                 cxx_max: 20 },
           { os: ubuntu-24.04,        cxx: clang++-17,       c: clang-17,       arch: x64, gen: Ninja,                 cxx_max: 20 },
           { os: ubuntu-24.04,        cxx: clang++-18,       c: clang-18,       arch: x64, gen: Ninja,                 cxx_max: 23 },
@@ -54,6 +55,7 @@ jobs:
       VAR_CMAKE_FLAGS: |
         ${{ matrix.env.c && format('-D CMAKE_C_COMPILER={0}', matrix.env.c) }} \
         ${{ matrix.env.cxx && format('-D CMAKE_CXX_COMPILER={0}', matrix.env.cxx) }} \
+        ${{ matrix.env.c_flags && format('-D CMAKE_C_FLAGS''={0}''', matrix.env.c_flags) }} \
         ${{ matrix.env.cxx_flags && format('-D CMAKE_CXX_FLAGS''={0}''', matrix.env.cxx_flags) }} \
         ${{ matrix.env.linker_flags && format('-D CMAKE_EXE_LINKER_FLAGS=''{0}''', matrix.env.linker_flags) }} \
 
@@ -71,7 +73,9 @@ jobs:
         arch: ${{matrix.env.arch}}
     - name: Setup Ubuntu
       if: contains(matrix.env.os, 'ubuntu')
-      run: sudo apt update && sudo apt install libgl-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev
+      run: |
+        sudo apt update
+        sudo apt install -y libgl-dev libxcursor-dev libxi-dev libxinerama-dev libxrandr-dev ${{ matrix.env.ubuntu_packages || '' }}
     - name: Setup MacOS
       if: contains(matrix.env.os, 'macos')
       run: brew install molten-vk
@@ -112,7 +116,7 @@ jobs:
 
     # Build samples using highest available C++ standard.
     - name: Build Samples with C++${{matrix.env.cxx_max}}
-      if: (!matrix.env.modules) # Exclude module runners.
+      if: (!matrix.env.modules) && (!matrix.env.skip_samples) # Exclude module and cross-compilation runners.
       run: |
         for BUILD_TYPE in Debug Release; do
           cmake -B build -G '${{matrix.env.gen}}' --fresh --preset samples \


### PR DESCRIPTION
Adds a 32-bit Ubuntu CI matrix entry using gcc/g++ multilib and -m32 flags.

The sample build is skipped for this cross-compilation entry to avoid requiring 32-bit graphics/system libraries, while header generation and the unit test builds still run across the supported C++ standards.

This covers the Linux 32-bit CI case discussed in #2584 and helps exercise the kind of build configuration involved in #2583.

Tested on my fork:
- CI Build / ubuntu-24.04 x86, Ninja, g++-14 passed
- Full fork PR checks passed

Refs #2584.