### PR TITLE
Fix MinGW C++ module error category linkage

### DIFF
--- a/generator/snippets/Exceptions.hpp
+++ b/generator/snippets/Exceptions.hpp
@@ -55,10 +55,21 @@ class SystemError : public Error, public std::system_error
   virtual char const * what() const VULKAN_HPP_NOEXCEPT { return std::system_error::what(); }
 };
 
+#if defined( VULKAN_HPP_CXX_MODULE )
+namespace detail
+{
+  inline ErrorCategoryImpl errorCategoryInstance;
+}
+#endif
+
 VULKAN_HPP_INLINE std::error_category const & errorCategory() VULKAN_HPP_NOEXCEPT
 {
+#if defined( VULKAN_HPP_CXX_MODULE )
+  return detail::errorCategoryInstance;
+#else
   static ErrorCategoryImpl instance;
   return instance;
+#endif
 }
 
 VULKAN_HPP_INLINE std::error_code make_error_code(Result e) VULKAN_HPP_NOEXCEPT

--- a/vulkan/vulkan.hpp
+++ b/vulkan/vulkan.hpp
@@ -8558,11 +8558,22 @@ VULKAN_HPP_EXPORT namespace VULKAN_HPP_NAMESPACE
     }
   };
 
-  VULKAN_HPP_INLINE std::error_category const & errorCategory() VULKAN_HPP_NOEXCEPT
-  {
-    static ErrorCategoryImpl instance;
-    return instance;
-  }
+#if defined( VULKAN_HPP_CXX_MODULE )
+namespace detail
+{
+  inline ErrorCategoryImpl errorCategoryInstance;
+}
+#endif
+
+VULKAN_HPP_INLINE std::error_category const & errorCategory() VULKAN_HPP_NOEXCEPT
+{
+#if defined( VULKAN_HPP_CXX_MODULE )
+  return detail::errorCategoryInstance;
+#else
+  static ErrorCategoryImpl instance;
+  return instance;
+#endif
+}
 
   VULKAN_HPP_INLINE std::error_code make_error_code( Result e ) VULKAN_HPP_NOEXCEPT
   {


### PR DESCRIPTION
Fixes #2468.

MinGW GCC fails to link the C++ module tests because the function-local static `ErrorCategoryImpl` instance is emitted both by the module object and by module consumers.

For C++ module builds, this replaces the local static with a namespace-level inline instance. Header-only builds keep the existing implementation unchanged.

The generated `vulkan/vulkan.hpp` is updated to match the source snippet.

Tested with MinGW GCC 16.1.0:

* Before the change: module tests failed with duplicate definitions of `vk::errorCategory@vulkan()::instance`
* After the change: all 29 CI checks passed

The MinGW CI coverage is being kept as a separate change for #2584.
