### PR TITLE
Add MinGW GCC CI coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
         shell: bash
 
     # Keep the full compiler matrix visible so CI consumers can inspect every job.
+    # Matrix smoke-test push marker: behavior and coverage remain unchanged.
     strategy:
       matrix:
         env: [

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,3 +188,61 @@ jobs:
             ctest -j --output-on-failure --test-dir build -C $BUILD_TYPE
           done
         done
+  # MinGW requires a dedicated MSYS2 toolchain and shell.
+  mingw:
+    name: Windows x64, MinGW GCC, Ninja
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6.0.0
+      with:
+        submodules: recursive
+
+    - name: Setup CMake and Ninja
+      uses: lukka/get-cmake@latest
+      with:
+        cmakeVersion: 4.3.4
+        ninjaVersion: latest
+
+    - name: Setup MinGW
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: UCRT64
+        update: true
+        path-type: inherit
+        install: >-
+          mingw-w64-ucrt-x86_64-gcc
+
+    - name: Verify MinGW toolchain
+      run: |
+        which gcc
+        which g++
+        gcc --version
+        g++ --version
+        gcc -dumpmachine
+        cmake --version
+        ninja --version
+
+    - name: Generate headers
+      run: |
+        cmake -B build-mingw -G Ninja --fresh --preset generator-run \
+          -D CMAKE_C_COMPILER=gcc \
+          -D CMAKE_CXX_COMPILER=g++ \
+          -D CMAKE_BUILD_TYPE=Release
+        cmake --build build-mingw --parallel --clean-first
+
+    - name: Build and test with C++23 modules
+      run: |
+        cmake -B build-mingw -G Ninja --fresh --preset samples-tests \
+          -D CMAKE_C_COMPILER=gcc \
+          -D CMAKE_CXX_COMPILER=g++ \
+          -D CMAKE_CXX_STANDARD=23 \
+          -D CMAKE_EXPERIMENTAL_CXX_IMPORT_STD=451f2fe2-a8a2-47c3-bc32-94786d8fc91b \
+          -D VULKAN_HPP_BUILD_CXX_MODULE=ON \
+          -D CMAKE_BUILD_TYPE=Release
+        cmake --build build-mingw --parallel --clean-first
+        ctest -j --output-on-failure --test-dir build-mingw

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
       run:
         shell: bash
 
+    # Keep the full compiler matrix visible so CI consumers can inspect every job.
     strategy:
       matrix:
         env: [


### PR DESCRIPTION
Closes #2584.

Adds a dedicated Windows x64 MinGW GCC CI job using MSYS2 UCRT64.

The job:

* installs the MinGW GCC toolchain through MSYS2
* verifies the selected compiler and target
* generates the Vulkan-Hpp headers
* builds the samples and tests with C++23 module support enabled
* runs the test suite

### Fork validation

The validation run completed with 27 passing checks and two failures:

* `Windows x64, MinGW GCC, Ninja`

  * reproduces the known MinGW GCC module linker failure tracked in #2468
  * fails with duplicate definitions of the function-local `errorCategory` instance
* `ubuntu-24.04 x64, Ninja, clang++-18`

  * this is an existing matrix job and is separate from the newly added MinGW job

The MinGW failure is intentionally left visible as a toolchain signal. As discussed in #2596, the existing Vulkan-Hpp implementation is valid and links successfully with MSVC and Clang, so this PR does not add a project-side workaround for the MinGW GCC bug.

Refs #2468.
