### PR TITLE
CI: Fix automatic header update

### DIFF
--- a/.github/workflows/update-header-pr.yml
+++ b/.github/workflows/update-header-pr.yml
@@ -66,7 +66,7 @@ jobs:
         git clean -xf
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v8
       with:
         commit-message: Update Vulkan-Headers to ${{ env.VK_HEADER_GIT_TAG }}
         title: Update Vulkan-Headers to ${{ env.VK_HEADER_GIT_TAG }}


### PR DESCRIPTION
Resolves #2598.

As per peter-evans/create-pull-request#4272 and peter-evans/create-pull-request#4228, the v5 version of `create-pull-request` is incompatible with `actions/checkout@v6`. This is fixed in [v7.0.9](https://github.com/peter-evans/create-pull-request/releases/tag/v7.0.9), so using v8 should fix the issue.