### PR TITLE
Adjust message to trigger the CI.

### DIFF
--- a/.github/workflows/update-header-pr.yml
+++ b/.github/workflows/update-header-pr.yml
@@ -73,4 +73,4 @@ jobs:
         branch: update-vulkan-headers-pr
         base: ${{ github.head_ref }}
         body: |
-          Please close and reopen this PR to trigger the CI!
+          Please trigger the CI!


### PR DESCRIPTION
It's not needed anymore to close and reopen the update header PR.