### PR TITLE
Support '+' separator in feature depends

### DIFF
--- a/generator/VkXMLParser.cpp
+++ b/generator/VkXMLParser.cpp
@@ -1410,7 +1410,9 @@ Feature parseFeature( tinyxml2::XMLElement const * element )
     }
     else if ( attribute.first == "depends" )
     {
-      feature.depends = tokenize( attribute.second, "," );
+      // Feature depends uses '+' (AND) per the dependency syntax, but ',' was used historically with the same meaning.
+      // Accept both so this works with both old (comma-separated) and new (plus-separated) XML.
+      feature.depends = tokenizeAny( attribute.second, ",+" );
     }
     else if ( attribute.first == "name" )
     {


### PR DESCRIPTION
The Vulkan dependency syntax defines '+' as logical AND and ',' as logical OR.
The `depends` attribute on `<feature>` elements always intends AND semantics,
but historically used ',' as the separator. Future XML corrections will use
the proper '+' separator (see https://gitlab.khronos.org/vulkan/vulkan/-/issues/4912).

Switch from `tokenize(..., ",")` to `tokenizeAny(..., ",+")` so the parser
accepts both forms — backward-compatible with current XML, forward-compatible
with the corrected XML.

▎ GenAI disclosure: Draft assisted by Claude (claude-sonnet-4-6[1m], Anthropic, commercial SaaS — Claude Code CLI).