### PR TITLE
cmake: reduce duplication in samples build setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,30 +260,58 @@ function( vulkan_hpp__setup_vulkan_module )
 	target_link_libraries( ${TARGET_NAME} PUBLIC Vulkan::Hpp )
 endfunction()
 
+# shared local-vs-system Vulkan include directory setup
+function( vulkan_hpp__setup_vulkan_include_dirs )
+	set( options )
+	set( oneValueArgs NAME SCOPE )
+	set( multiValueArgs )
+	cmake_parse_arguments( TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+	if( VULKAN_HPP_BUILD_WITH_LOCAL_VULKAN_HPP )
+		# Vulkan C++ headers
+		target_include_directories( ${TARGET_NAME} ${TARGET_SCOPE} "${CMAKE_CURRENT_FUNCTION_LIST_DIR}" )
+		# Vulkan C headers
+		target_include_directories( ${TARGET_NAME} ${TARGET_SCOPE} "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/Vulkan-Headers/include" )
+	else()
+		find_package( Vulkan REQUIRED )
+		target_include_directories( ${TARGET_NAME} ${TARGET_SCOPE} "${Vulkan_INCLUDE_DIRS}" )
+	endif()
+endfunction()
+
 function( vulkan_hpp__setup_vulkan_targets )
 	# Create Vulkan-Hpp interface target
 	add_library( VulkanHpp INTERFACE )
 	add_library( Vulkan::Hpp ALIAS VulkanHpp )
-	if( VULKAN_HPP_BUILD_WITH_LOCAL_VULKAN_HPP )
-		# Vulkan C++ headers
-		target_include_directories( VulkanHpp INTERFACE "${CMAKE_CURRENT_FUNCTION_LIST_DIR}" )
-		# Vulkan C headers
-		target_include_directories( VulkanHpp INTERFACE "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/Vulkan-Headers/include" )
-	else()
-		find_package( Vulkan REQUIRED )
-		target_include_directories( VulkanHpp INTERFACE "${Vulkan_INCLUDE_DIRS}" )
-	endif()
+	vulkan_hpp__setup_vulkan_include_dirs( NAME VulkanHpp SCOPE INTERFACE )
 	if( VULKAN_HPP_RUN_GENERATOR )
 		add_dependencies( VulkanHpp build_vulkan_hpp build_video_hpp )
 	endif()
 
 	# set up compile definitions
-	if( VULKAN_HPP_DISABLE_ENHANCED_MODE )
-		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_DISABLE_ENHANCED_MODE" )
-	endif()
-	if( VK_NO_PROTOTYPES )
-		target_compile_definitions(VulkanHpp INTERFACE "VK_NO_PROTOTYPES" )
-	endif()
+	# most options map 1:1 to an identically named compile definition
+	foreach( VULKAN_HPP_OPTION
+		VK_NO_PROTOTYPES
+		VULKAN_HPP_DISABLE_ENHANCED_MODE
+		VULKAN_HPP_FLAGS_MASK_TYPE_AS_PUBLIC
+		VULKAN_HPP_HANDLE_ERROR_OUT_OF_DATE_AS_SUCCESS
+		VULKAN_HPP_HANDLES_MOVE_EXCHANGE
+		VULKAN_HPP_NO_CONSTRUCTORS
+		VULKAN_HPP_NO_DEFAULT_DISPATCHER
+		VULKAN_HPP_NO_EXCEPTIONS
+		VULKAN_HPP_NO_NODISCARD_WARNINGS
+		VULKAN_HPP_NO_SETTERS
+		VULKAN_HPP_NO_SMART_HANDLE
+		VULKAN_HPP_NO_SPACESHIP_OPERATOR
+		VULKAN_HPP_NO_TO_STRING
+		VULKAN_HPP_NO_WIN32_PROTOTYPES
+		VULKAN_HPP_RAII_NO_EXCEPTIONS
+		VULKAN_HPP_SMART_HANDLE_IMPLICIT_CAST
+		VULKAN_HPP_USE_REFLECT
+		VULKAN_HPP_USE_STD_EXPECTED )
+		if( ${VULKAN_HPP_OPTION} )
+			target_compile_definitions( VulkanHpp INTERFACE "${VULKAN_HPP_OPTION}" )
+		endif()
+	endforeach()
 	if( VULKAN_HPP_DISPATCH_LOADER_DYNAMIC )
 		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_DISPATCH_LOADER_DYNAMIC" )
 		if( UNIX )
@@ -297,56 +325,9 @@ function( vulkan_hpp__setup_vulkan_targets )
 			message(WARNING "Could not link to system Vulkan libraries, consider using VULKAN_HPP_DISPATCH_LOADER_DYNAMIC")
 		endif()
 	endif()
-	if( VULKAN_HPP_USE_REFLECT )
-		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_USE_REFLECT" )
-	endif()
-	if( VULKAN_HPP_USE_STD_EXPECTED )
-		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_USE_STD_EXPECTED" )
-	endif()
+	# VULKAN_HPP_TYPESAFE_CONVERSION is inverted and carries an explicit value when disabled
 	if( NOT VULKAN_HPP_TYPESAFE_CONVERSION )
 		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_TYPESAFE_CONVERSION=0" )
-	endif()
-	if( VULKAN_HPP_HANDLES_MOVE_EXCHANGE )
-		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_HANDLES_MOVE_EXCHANGE" )
-	endif()
-	if( VULKAN_HPP_FLAGS_MASK_TYPE_AS_PUBLIC )
-		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_FLAGS_MASK_TYPE_AS_PUBLIC" )
-	endif()
-	if( VULKAN_HPP_HANDLE_ERROR_OUT_OF_DATE_AS_SUCCESS )
-		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_HANDLE_ERROR_OUT_OF_DATE_AS_SUCCESS" )
-	endif()
-	if( VULKAN_HPP_SMART_HANDLE_IMPLICIT_CAST )
-		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_SMART_HANDLE_IMPLICIT_CAST" )
-	endif()
-	if( VULKAN_HPP_NO_SETTERS )
-		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_NO_SETTERS" )
-	endif()
-	if( VULKAN_HPP_NO_TO_STRING )
-		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_NO_TO_STRING" )
-	endif()
-	if( VULKAN_HPP_NO_EXCEPTIONS )
-		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_NO_EXCEPTIONS" )
-	endif()
-	if( VULKAN_HPP_NO_CONSTRUCTORS )
-		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_NO_CONSTRUCTORS" )
-	endif()
-	if( VULKAN_HPP_NO_DEFAULT_DISPATCHER )
-		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_NO_DEFAULT_DISPATCHER" )
-	endif()
-	if( VULKAN_HPP_NO_SMART_HANDLE )
-		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_NO_SMART_HANDLE" )
-	endif()
-	if( VULKAN_HPP_RAII_NO_EXCEPTIONS )
-		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_RAII_NO_EXCEPTIONS" )
-	endif()
-	if( VULKAN_HPP_NO_WIN32_PROTOTYPES )
-		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_NO_WIN32_PROTOTYPES" )
-	endif()
-	if( VULKAN_HPP_NO_NODISCARD_WARNINGS )
-		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_NO_NODISCARD_WARNINGS" )
-	endif()
-	if( VULKAN_HPP_NO_SPACESHIP_OPERATOR )
-		target_compile_definitions(VulkanHpp INTERFACE "VULKAN_HPP_NO_SPACESHIP_OPERATOR" )
 	endif()
 
 	# Build Vulkan-Hpp as a module
@@ -381,6 +362,18 @@ function( vulkan_hpp__setup_platform )
 	endif()
 endfunction()
 
+# common per-target setup shared by libraries and samples
+function( vulkan_hpp__setup_target_defaults )
+	set( options )
+	set( oneValueArgs NAME )
+	set( multiValueArgs )
+	cmake_parse_arguments( TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+	vulkan_hpp__setup_platform( NAME ${TARGET_NAME} )
+	vulkan_hpp__setup_warning_level( NAME ${TARGET_NAME} )
+	set_target_properties( ${TARGET_NAME} PROPERTIES CXX_STANDARD_REQUIRED ON )
+endfunction()
+
 function( vulkan_hpp__setup_project )
 	set( options )
 	set( oneValueArgs NAME )
@@ -406,18 +399,8 @@ function( vulkan_hpp__setup_library )
 		else()
 			add_library( ${TARGET_NAME} ${TARGET_SOURCES} ${TARGET_HEADERS} )
 		endif()
-		vulkan_hpp__setup_platform( NAME ${TARGET_NAME} )
-		vulkan_hpp__setup_warning_level( NAME ${TARGET_NAME} )
-		set_target_properties( ${TARGET_NAME} PROPERTIES CXX_STANDARD_REQUIRED ON )
-		if( VULKAN_HPP_BUILD_WITH_LOCAL_VULKAN_HPP )
-			# Vulkan C++ headers
-			target_include_directories( ${TARGET_NAME} PUBLIC "${CMAKE_CURRENT_FUNCTION_LIST_DIR}" )
-			# Vulkan C headers
-			target_include_directories( ${TARGET_NAME} PUBLIC "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/Vulkan-Headers/include" )
-		else()
-			find_package( Vulkan REQUIRED )
-			target_include_directories( ${TARGET_NAME} PUBLIC "${Vulkan_INCLUDE_DIRS}" )
-		endif()
+		vulkan_hpp__setup_target_defaults( NAME ${TARGET_NAME} )
+		vulkan_hpp__setup_vulkan_include_dirs( NAME ${TARGET_NAME} SCOPE PUBLIC )
 	endif()
 	set_target_properties( ${TARGET_NAME} PROPERTIES FOLDER ${TARGET_FOLDER} )
 endfunction()
@@ -430,9 +413,7 @@ function( vulkan_hpp__setup_sample )
 
 	vulkan_hpp__setup_project( NAME ${TARGET_NAME} )
 	add_executable( ${TARGET_NAME} ${TARGET_HEADERS} ${TARGET_SOURCES} )
-	vulkan_hpp__setup_platform( NAME ${TARGET_NAME} )
-	vulkan_hpp__setup_warning_level( NAME ${TARGET_NAME} )
-	set_target_properties( ${TARGET_NAME} PROPERTIES CXX_STANDARD_REQUIRED ON )
+	vulkan_hpp__setup_target_defaults( NAME ${TARGET_NAME} )
 
 	if( TARGET_FOLDER )
 		set_target_properties( ${TARGET_NAME} PROPERTIES FOLDER "${TARGET_FOLDER}" )
@@ -451,68 +432,58 @@ function( vulkan_hpp__setup_sample )
 	endif()
 endfunction()
 
-function( vulkan_hpp__setup_sample_static )
-	set( options )
-	set( oneValueArgs NAME )
-	set( multiValueArgs )
+# common implementation behind the static/dynamic/raii sample setup functions below.
+# LINKAGE selects the utils_<LINKAGE> library to reuse (static or dynamic); RAII additionally
+# prefixes the target name with RAII_ and places it in the RAII_Samples folder.
+function( vulkan_hpp__setup_sample_variant )
+	set( options RAII )
+	set( oneValueArgs NAME LINKAGE )
+	set( multiValueArgs HEADERS SOURCES )
 	cmake_parse_arguments( TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
 	if( NOT TARGET_NAME )
-		message( FATAL_ERROR "NAME must be defined in vulkan_hpp__setup_sample_static" )
+		message( FATAL_ERROR "NAME must be defined in vulkan_hpp__setup_sample_variant" )
+	endif()
+	if( NOT TARGET_LINKAGE )
+		message( FATAL_ERROR "LINKAGE must be defined in vulkan_hpp__setup_sample_variant" )
+	endif()
+	if( NOT TARGET_SOURCES )
+		set( TARGET_SOURCES ${TARGET_NAME}.cpp )
 	endif()
 
-	find_package( Vulkan REQUIRED )
+	set( SAMPLE_LIBS utils_${TARGET_LINKAGE} )
+	if( TARGET_LINKAGE STREQUAL "static" )
+		find_package( Vulkan REQUIRED )
+		list( APPEND SAMPLE_LIBS ${Vulkan_LIBRARIES} )
+	endif()
+
+	if( TARGET_RAII )
+		set( SAMPLE_NAME RAII_${TARGET_NAME} )
+		set( SAMPLE_FOLDER RAII_Samples )
+	else()
+		set( SAMPLE_NAME ${TARGET_NAME} )
+		set( SAMPLE_FOLDER Samples )
+	endif()
 
 	vulkan_hpp__setup_sample(
-		NAME         ${TARGET_NAME}
-		FOLDER       Samples
-		PCH_REUSE    utils_static
-		SOURCES      ${TARGET_NAME}.cpp
-		LIBS         utils_static ${Vulkan_LIBRARIES} )
+		NAME         ${SAMPLE_NAME}
+		FOLDER       ${SAMPLE_FOLDER}
+		PCH_REUSE    utils_${TARGET_LINKAGE}
+		HEADERS      ${TARGET_HEADERS}
+		SOURCES      ${TARGET_SOURCES}
+		LIBS         ${SAMPLE_LIBS} )
+endfunction()
+
+function( vulkan_hpp__setup_sample_static )
+	vulkan_hpp__setup_sample_variant( LINKAGE static ${ARGN} )
 endfunction()
 
 function( vulkan_hpp__setup_sample_dynamic )
-	set( options )
-	set( oneValueArgs NAME )
-	set( multiValueArgs HEADERS SOURCES )
-	cmake_parse_arguments( TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
-
-	if( NOT TARGET_NAME )
-		message( FATAL_ERROR "NAME must be defined in vulkan_hpp__setup_sample_dynamic" )
-	endif()
-	if( NOT TARGET_SOURCES )
-		set( TARGET_SOURCES ${TARGET_NAME}.cpp )
-	endif()
-
-	vulkan_hpp__setup_sample(
-		NAME         ${TARGET_NAME}
-		FOLDER       Samples
-		PCH_REUSE    utils_dynamic
-		HEADERS      ${TARGET_HEADERS}
-		SOURCES      ${TARGET_SOURCES}
-		LIBS         utils_dynamic )
+	vulkan_hpp__setup_sample_variant( LINKAGE dynamic ${ARGN} )
 endfunction()
 
 function( vulkan_hpp__setup_sample_raii )
-	set( options )
-	set( oneValueArgs NAME )
-	set( multiValueArgs HEADERS SOURCES )
-	cmake_parse_arguments( TARGET "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
-
-	if( NOT TARGET_NAME )
-		message( FATAL_ERROR "NAME must be defined in vulkan_hpp__setup_sample_raii" )
-	endif()
-	if( NOT TARGET_SOURCES )
-		set( TARGET_SOURCES ${TARGET_NAME}.cpp )
-	endif()
-
-	vulkan_hpp__setup_sample(
-		NAME         RAII_${TARGET_NAME}
-		FOLDER       RAII_Samples
-		PCH_REUSE    utils_dynamic
-		HEADERS      ${TARGET_HEADERS}
-		SOURCES      ${TARGET_SOURCES}
-		LIBS         utils_dynamic )
+	vulkan_hpp__setup_sample_variant( LINKAGE dynamic RAII ${ARGN} )
 endfunction()
 
 # set up CTest or add_subdirectory test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,9 +432,8 @@ function( vulkan_hpp__setup_sample )
 	endif()
 endfunction()
 
-# common implementation behind the static/dynamic/raii sample setup functions below.
-# LINKAGE selects the utils_<LINKAGE> library to reuse (static or dynamic); RAII additionally
-# prefixes the target name with RAII_ and places it in the RAII_Samples folder.
+# sets up a sample executable, reusing the utils_<LINKAGE> library (static or dynamic).
+# RAII additionally prefixes the target name with RAII_ and places it in the RAII_Samples folder.
 function( vulkan_hpp__setup_sample_variant )
 	set( options RAII )
 	set( oneValueArgs NAME LINKAGE )
@@ -472,14 +471,6 @@ function( vulkan_hpp__setup_sample_variant )
 		HEADERS      ${TARGET_HEADERS}
 		SOURCES      ${TARGET_SOURCES}
 		LIBS         ${SAMPLE_LIBS} )
-endfunction()
-
-function( vulkan_hpp__setup_sample_static )
-	vulkan_hpp__setup_sample_variant( LINKAGE static ${ARGN} )
-endfunction()
-
-function( vulkan_hpp__setup_sample_dynamic )
-	vulkan_hpp__setup_sample_variant( LINKAGE dynamic ${ARGN} )
 endfunction()
 
 function( vulkan_hpp__setup_sample_raii )

--- a/samples/01_InitInstance/CMakeLists.txt
+++ b/samples/01_InitInstance/CMakeLists.txt
@@ -3,5 +3,5 @@
 
 find_package( Vulkan QUIET )
 if ( Vulkan_FOUND )
-	vulkan_hpp__setup_sample_static( NAME 01_InitInstance )
+	vulkan_hpp__setup_sample_variant( LINKAGE static NAME 01_InitInstance )
 endif()

--- a/samples/02_EnumerateDevices/CMakeLists.txt
+++ b/samples/02_EnumerateDevices/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2018-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME 02_EnumerateDevices )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME 02_EnumerateDevices )

--- a/samples/03_InitDevice/CMakeLists.txt
+++ b/samples/03_InitDevice/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2018-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME 03_InitDevice )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME 03_InitDevice )

--- a/samples/04_InitCommandBuffer/CMakeLists.txt
+++ b/samples/04_InitCommandBuffer/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2018-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME 04_InitCommandBuffer )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME 04_InitCommandBuffer )

--- a/samples/05_InitSwapchain/CMakeLists.txt
+++ b/samples/05_InitSwapchain/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2018-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME 05_InitSwapchain )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME 05_InitSwapchain )

--- a/samples/06_InitDepthBuffer/CMakeLists.txt
+++ b/samples/06_InitDepthBuffer/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2018-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME 06_InitDepthBuffer )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME 06_InitDepthBuffer )

--- a/samples/07_InitUniformBuffer/CMakeLists.txt
+++ b/samples/07_InitUniformBuffer/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2018-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME 07_InitUniformBuffer )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME 07_InitUniformBuffer )

--- a/samples/08_InitPipelineLayout/CMakeLists.txt
+++ b/samples/08_InitPipelineLayout/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2018-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME 08_InitPipelineLayout )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME 08_InitPipelineLayout )

--- a/samples/09_InitDescriptorSet/CMakeLists.txt
+++ b/samples/09_InitDescriptorSet/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2018-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME 09_InitDescriptorSet )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME 09_InitDescriptorSet )

--- a/samples/10_InitRenderPass/CMakeLists.txt
+++ b/samples/10_InitRenderPass/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2018-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME 10_InitRenderPass )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME 10_InitRenderPass )

--- a/samples/11_InitShaders/CMakeLists.txt
+++ b/samples/11_InitShaders/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME 11_InitShaders )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME 11_InitShaders )

--- a/samples/12_InitFrameBuffers/CMakeLists.txt
+++ b/samples/12_InitFrameBuffers/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME 12_InitFrameBuffers )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME 12_InitFrameBuffers )

--- a/samples/13_InitVertexBuffer/CMakeLists.txt
+++ b/samples/13_InitVertexBuffer/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME 13_InitVertexBuffer )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME 13_InitVertexBuffer )

--- a/samples/14_InitPipeline/CMakeLists.txt
+++ b/samples/14_InitPipeline/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME 14_InitPipeline )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME 14_InitPipeline )

--- a/samples/15_DrawCube/CMakeLists.txt
+++ b/samples/15_DrawCube/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME 15_DrawCube )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME 15_DrawCube )

--- a/samples/16_Vulkan_1_1/CMakeLists.txt
+++ b/samples/16_Vulkan_1_1/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME 16_Vulkan_1_1 )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME 16_Vulkan_1_1 )

--- a/samples/CopyBlitImage/CMakeLists.txt
+++ b/samples/CopyBlitImage/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME CopyBlitImage )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME CopyBlitImage )

--- a/samples/CreateDebugUtilsMessenger/CMakeLists.txt
+++ b/samples/CreateDebugUtilsMessenger/CMakeLists.txt
@@ -3,5 +3,5 @@
 
 find_package( Vulkan QUIET )
 if ( Vulkan_FOUND )
-	vulkan_hpp__setup_sample_static( NAME CreateDebugUtilsMessenger )
+	vulkan_hpp__setup_sample_variant( LINKAGE static NAME CreateDebugUtilsMessenger )
 endif()

--- a/samples/DebugUtilsObjectName/CMakeLists.txt
+++ b/samples/DebugUtilsObjectName/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2020-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME DebugUtilsObjectName )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME DebugUtilsObjectName )

--- a/samples/DrawTexturedCube/CMakeLists.txt
+++ b/samples/DrawTexturedCube/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME DrawTexturedCube )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME DrawTexturedCube )

--- a/samples/DynamicUniform/CMakeLists.txt
+++ b/samples/DynamicUniform/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME DynamicUniform )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME DynamicUniform )

--- a/samples/EnableValidationWithCallback/CMakeLists.txt
+++ b/samples/EnableValidationWithCallback/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME EnableValidationWithCallback )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME EnableValidationWithCallback )

--- a/samples/EnumerateDevicesAdvanced/CMakeLists.txt
+++ b/samples/EnumerateDevicesAdvanced/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2018-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME EnumerateDevicesAdvanced )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME EnumerateDevicesAdvanced )

--- a/samples/Events/CMakeLists.txt
+++ b/samples/Events/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME Events )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME Events )

--- a/samples/ImmutableSampler/CMakeLists.txt
+++ b/samples/ImmutableSampler/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME ImmutableSampler )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME ImmutableSampler )

--- a/samples/InitTexture/CMakeLists.txt
+++ b/samples/InitTexture/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME InitTexture )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME InitTexture )

--- a/samples/InputAttachment/CMakeLists.txt
+++ b/samples/InputAttachment/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME InputAttachment )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME InputAttachment )

--- a/samples/InstanceExtensionProperties/CMakeLists.txt
+++ b/samples/InstanceExtensionProperties/CMakeLists.txt
@@ -3,5 +3,5 @@
 
 find_package( Vulkan QUIET )
 if ( Vulkan_FOUND )
-	vulkan_hpp__setup_sample_static( NAME InstanceExtensionProperties )
+	vulkan_hpp__setup_sample_variant( LINKAGE static NAME InstanceExtensionProperties )
 endif()

--- a/samples/InstanceLayerExtensionProperties/CMakeLists.txt
+++ b/samples/InstanceLayerExtensionProperties/CMakeLists.txt
@@ -3,5 +3,5 @@
 
 find_package( Vulkan QUIET )
 if ( Vulkan_FOUND )
-	vulkan_hpp__setup_sample_static( NAME InstanceLayerExtensionProperties )
+	vulkan_hpp__setup_sample_variant( LINKAGE static NAME InstanceLayerExtensionProperties )
 endif()

--- a/samples/InstanceLayerProperties/CMakeLists.txt
+++ b/samples/InstanceLayerProperties/CMakeLists.txt
@@ -3,5 +3,5 @@
 
 find_package( Vulkan QUIET )
 if ( Vulkan_FOUND )
-	vulkan_hpp__setup_sample_static( NAME InstanceLayerProperties )
+	vulkan_hpp__setup_sample_variant( LINKAGE static NAME InstanceLayerProperties )
 endif()

--- a/samples/InstanceVersion/CMakeLists.txt
+++ b/samples/InstanceVersion/CMakeLists.txt
@@ -3,5 +3,5 @@
 
 find_package( Vulkan QUIET )
 if ( Vulkan_FOUND )
-	vulkan_hpp__setup_sample_static( NAME InstanceVersion )
+	vulkan_hpp__setup_sample_variant( LINKAGE static NAME InstanceVersion )
 endif()

--- a/samples/MultipleSets/CMakeLists.txt
+++ b/samples/MultipleSets/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME MultipleSets )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME MultipleSets )

--- a/samples/OcclusionQuery/CMakeLists.txt
+++ b/samples/OcclusionQuery/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME OcclusionQuery )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME OcclusionQuery )

--- a/samples/PhysicalDeviceExtensions/CMakeLists.txt
+++ b/samples/PhysicalDeviceExtensions/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME PhysicalDeviceExtensions )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME PhysicalDeviceExtensions )

--- a/samples/PhysicalDeviceFeatures/CMakeLists.txt
+++ b/samples/PhysicalDeviceFeatures/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME PhysicalDeviceFeatures )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME PhysicalDeviceFeatures )

--- a/samples/PhysicalDeviceGroups/CMakeLists.txt
+++ b/samples/PhysicalDeviceGroups/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME PhysicalDeviceGroups )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME PhysicalDeviceGroups )

--- a/samples/PhysicalDeviceMemoryProperties/CMakeLists.txt
+++ b/samples/PhysicalDeviceMemoryProperties/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME PhysicalDeviceMemoryProperties )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME PhysicalDeviceMemoryProperties )

--- a/samples/PhysicalDeviceProperties/CMakeLists.txt
+++ b/samples/PhysicalDeviceProperties/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME PhysicalDeviceProperties )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME PhysicalDeviceProperties )

--- a/samples/PhysicalDeviceQueueFamilyProperties/CMakeLists.txt
+++ b/samples/PhysicalDeviceQueueFamilyProperties/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME PhysicalDeviceQueueFamilyProperties )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME PhysicalDeviceQueueFamilyProperties )

--- a/samples/PipelineCache/CMakeLists.txt
+++ b/samples/PipelineCache/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME PipelineCache )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME PipelineCache )

--- a/samples/PipelineDerivative/CMakeLists.txt
+++ b/samples/PipelineDerivative/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME PipelineDerivative )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME PipelineDerivative )

--- a/samples/PushConstants/CMakeLists.txt
+++ b/samples/PushConstants/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME PushConstants )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME PushConstants )

--- a/samples/PushDescriptors/CMakeLists.txt
+++ b/samples/PushDescriptors/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME PushDescriptors )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME PushDescriptors )

--- a/samples/RayTracing/CMakeLists.txt
+++ b/samples/RayTracing/CMakeLists.txt
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic(
+vulkan_hpp__setup_sample_variant(
+    LINKAGE dynamic
     NAME RayTracing
     HEADERS
         CameraManipulator.hpp

--- a/samples/SecondaryCommandBuffer/CMakeLists.txt
+++ b/samples/SecondaryCommandBuffer/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME SecondaryCommandBuffer )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME SecondaryCommandBuffer )

--- a/samples/SeparateImageSampler/CMakeLists.txt
+++ b/samples/SeparateImageSampler/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME SeparateImageSampler )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME SeparateImageSampler )

--- a/samples/SharedHandles/CMakeLists.txt
+++ b/samples/SharedHandles/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME SharedHandles )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME SharedHandles )

--- a/samples/SurfaceCapabilities/CMakeLists.txt
+++ b/samples/SurfaceCapabilities/CMakeLists.txt
@@ -3,5 +3,5 @@
 
 # Win32 exclusive vk::SurfaceCapabilitiesFullScreenExclusiveEXT is used
 if(WIN32)
-  vulkan_hpp__setup_sample_dynamic( NAME SurfaceCapabilities )
+  vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME SurfaceCapabilities )
 endif()

--- a/samples/SurfaceFormats/CMakeLists.txt
+++ b/samples/SurfaceFormats/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME SurfaceFormats )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME SurfaceFormats )

--- a/samples/Template/CMakeLists.txt
+++ b/samples/Template/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME Template )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME Template )

--- a/samples/TexelBuffer/CMakeLists.txt
+++ b/samples/TexelBuffer/CMakeLists.txt
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2019-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_sample_dynamic( NAME TexelBuffer )
+vulkan_hpp__setup_sample_variant( LINKAGE dynamic NAME TexelBuffer )

--- a/samples/utils/CMakeLists.txt
+++ b/samples/utils/CMakeLists.txt
@@ -1,36 +1,30 @@
 # SPDX-FileCopyrightText: 2020-2026 NVIDIA CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 
-vulkan_hpp__setup_library(
-	NAME utils_static
-	HEADERS math.hpp shaders.hpp utils.hpp
-	SOURCES math.cpp shaders.cpp utils.cpp
-	FOLDER "Samples" )
+# common third-party dependencies shared by both utils_static and utils_dynamic
+add_library( utils_deps INTERFACE )
+target_link_libraries( utils_deps INTERFACE
+	glfw
+	glm::glm
+	glslang::glslang
+	glslang::glslang-default-resource-limits
+	glslang::SPIRV )
 
-vulkan_hpp__setup_library(
-	NAME utils_dynamic
-	HEADERS math.hpp shaders.hpp utils.hpp
-	SOURCES math.cpp shaders.cpp utils.cpp
-	FOLDER "Samples" )
+foreach( LINKAGE static dynamic )
+	vulkan_hpp__setup_library(
+		NAME utils_${LINKAGE}
+		HEADERS math.hpp shaders.hpp utils.hpp
+		SOURCES math.cpp shaders.cpp utils.cpp
+		FOLDER "Samples" )
 
-if( VULKAN_HPP_RUN_GENERATOR )
-	add_dependencies( utils_static build_vulkan_hpp )
-	add_dependencies( utils_dynamic build_vulkan_hpp )
-endif()
+	if( VULKAN_HPP_RUN_GENERATOR )
+		add_dependencies( utils_${LINKAGE} build_vulkan_hpp )
+	endif()
 
-target_link_libraries( utils_static PUBLIC glfw )
-target_link_libraries( utils_static PUBLIC glm::glm )
-target_link_libraries( utils_static PUBLIC glslang::glslang )
-target_link_libraries( utils_static PUBLIC glslang::glslang-default-resource-limits )
-target_link_libraries( utils_static PUBLIC glslang::SPIRV )
-target_compile_definitions( utils_static PUBLIC VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=0 )
-target_precompile_headers( utils_static PRIVATE "pch.hpp" )
+	target_link_libraries( utils_${LINKAGE} PUBLIC utils_deps )
+	target_precompile_headers( utils_${LINKAGE} PRIVATE "pch.hpp" )
+endforeach()
 
-target_link_libraries( utils_dynamic PUBLIC glfw )
-target_link_libraries( utils_dynamic PUBLIC glm::glm )
-target_link_libraries( utils_dynamic PUBLIC glslang::glslang )
-target_link_libraries( utils_dynamic PUBLIC glslang::glslang-default-resource-limits )
-target_link_libraries( utils_dynamic PUBLIC glslang::SPIRV )
+target_compile_definitions( utils_static  PUBLIC VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=0 )
 target_compile_definitions( utils_dynamic PUBLIC VULKAN_HPP_DISPATCH_LOADER_DYNAMIC=1 )
-target_precompile_headers( utils_dynamic PRIVATE "pch.hpp" )
 


### PR DESCRIPTION
Some cleanup for the samples build logic, in preparation for `module`ifying all the samples.