### PR TITLE
Parse required properties

### DIFF
--- a/generator/VkXMLParser.cpp
+++ b/generator/VkXMLParser.cpp
@@ -49,6 +49,7 @@ ExtensionRequireEnumConstant parseExtensionRequireEnumConstant( tinyxml2::XMLEle
 Extensions                   parseExtensions( tinyxml2::XMLElement const * element );
 Feature                      parseFeature( tinyxml2::XMLElement const * element );
 FeatureElement               parseFeatureElement( tinyxml2::XMLElement const * element );
+PropertyElement              parsePropertyElement( tinyxml2::XMLElement const * element );
 Require                      parseFeatureRequire( tinyxml2::XMLElement const * element );
 RequireEnumVariant           parseFeatureRequireEnum( tinyxml2::XMLElement const * element );
 ExtendEnumAlias              parseFeatureRequireEnumAlias( tinyxml2::XMLElement const * element, std::map<std::string, std::string> const & attributes );
@@ -1262,6 +1263,7 @@ ExtensionRequire parseExtensionRequire( tinyxml2::XMLElement const * element )
                    { "comment", MultipleAllowed::Yes },
                    { "enum", MultipleAllowed::Yes },
                    { "feature", MultipleAllowed::Yes },
+                   { "property", MultipleAllowed::Yes },
                    { "type", MultipleAllowed::Yes } } );
 
   ExtensionRequire require{ .xmlLine = line };
@@ -1322,6 +1324,10 @@ ExtensionRequire parseExtensionRequire( tinyxml2::XMLElement const * element )
                        "require feature <" + name + "> with struct <" + requireFeature.structure + "> already listed for this require block" );
       }
       require.features.push_back( std::move( requireFeature ) );
+    }
+    else if ( value == "property" )
+    {
+      require.properties.push_back( parsePropertyElement( child ) );
     }
     else if ( value == "type" )
     {
@@ -1919,6 +1925,36 @@ FeatureElement parseFeatureElement( tinyxml2::XMLElement const * element )
   return feature;
 }
 
+PropertyElement parsePropertyElement( tinyxml2::XMLElement const * element )
+{
+  int const                          line       = element->GetLineNum();
+  std::map<std::string, std::string> attributes = getAttributes( element );
+  checkAttributes( "vk.xml", line, attributes, { { "name", {} }, { "struct", {} }, { "value", {} } }, {} );
+  checkElements( "vk.xml", line, getChildElements( element ), {} );
+
+  PropertyElement property{ .xmlLine = line };
+  for ( auto const & attribute : attributes )
+  {
+    if ( attribute.first == "name" )
+    {
+      checkNoList( "vk.xml", attribute.second, line );
+      property.name = attribute.second;
+    }
+    else if ( attribute.first == "struct" )
+    {
+      checkNoList( "vk.xml", attribute.second, line );
+      property.structure = attribute.second;
+    }
+    else if ( attribute.first == "value" )
+    {
+      checkNoList( "vk.xml", attribute.second, line );
+      property.value = attribute.second;
+    }
+  }
+
+  return property;
+}
+
 Require parseFeatureRequire( tinyxml2::XMLElement const * element )
 {
   int const                          line       = element->GetLineNum();
@@ -1933,6 +1969,7 @@ Require parseFeatureRequire( tinyxml2::XMLElement const * element )
                    { "comment", MultipleAllowed::Yes },
                    { "enum", MultipleAllowed::Yes },
                    { "feature", MultipleAllowed::Yes },
+                   { "property", MultipleAllowed::Yes },
                    { "type", MultipleAllowed::Yes } } );
 
   Require require{ .xmlLine = line };
@@ -2002,6 +2039,10 @@ Require parseFeatureRequire( tinyxml2::XMLElement const * element )
                      requireFeature.xmlLine,
                      "require feature <" + requireFeature.name + "> with struct <" + requireFeature.structure + "> already listed for this require block" );
       require.features.push_back( std::move( requireFeature ) );
+    }
+    else if ( value == "property" )
+    {
+      require.properties.push_back( parsePropertyElement( child ) );
     }
     else if ( value == "type" )
     {

--- a/generator/VkXMLParser.hpp
+++ b/generator/VkXMLParser.hpp
@@ -449,6 +449,14 @@ struct MultiFeatureElement
   int                      xmlLine   = {};
 };
 
+struct PropertyElement
+{
+  std::string name      = {};
+  std::string structure = {};
+  std::string value     = {};
+  int         xmlLine   = {};
+};
+
 struct ExtensionRequire
 {
   std::string                              api      = {};
@@ -457,6 +465,7 @@ struct ExtensionRequire
   std::string                              depends  = {};
   std::vector<ExtensionRequireEnumVariant> enums    = {};
   std::vector<MultiFeatureElement>         features = {};
+  std::vector<PropertyElement>             properties = {};
   std::vector<NameElement>                 types    = {};
   int                                      xmlLine  = {};
 };
@@ -548,6 +557,7 @@ struct Require
   std::vector<ExtendEnumConstant> enumConstants = {};
   std::vector<ExtendEnumRegular>  enumRegulars  = {};
   std::vector<FeatureElement>     features      = {};
+  std::vector<PropertyElement>    properties    = {};
   std::vector<RequireType>        types         = {};
   int                             xmlLine       = {};
 };


### PR DESCRIPTION
https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8501 introduced required properties in vk.xml.

This caused warnings in Gitlab tests.

Another thing that might be a problem, the MR improved the completness of the feature requirements for Vulkan core versions and C.I. generate this message:

```
caught exception: vk.xml: Spec error on line 21226: feature <samplerMirrorClampToEdge> with struct <VkPhysicalDeviceVulkan12Features> already listed as required for feature <VK_VERSION_1_2>
```

It looks like the parser code has some handling for the "depends" attributes but it's not clear to me how much.

With Vulkan 1.2, samplerMirrorClampToEdge requires 'VK_KHR_sampler_mirror_clamp_to_edge' support.
With Vulkan 1.4, samplerMirrorClampToEdge must be supported inconditionally.

I would appriciate some helps regarding these issues.